### PR TITLE
FEAT: 자유양식 화면구현

### DIFF
--- a/public/icons/close.svg
+++ b/public/icons/close.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6.75 17.25L17.25 6.75M17.25 17.25L6.75 6.75" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/components/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/components/FreeFormWrite/EditorBlockFF.tsx
@@ -1,0 +1,90 @@
+import MDEditor from "@uiw/react-md-editor";
+
+export interface BlockData {
+  id: number;
+  title: string;
+  content: string;
+  isSaved: boolean;
+}
+
+interface Props {
+  block: BlockData;
+  index: number;
+  onChange: (index: number, updated: Partial<BlockData>) => void;
+  onAddBlock?: () => void;
+  onSave?: (index: number) => void;
+  isActive: boolean;
+  isLast: boolean;
+  onEnd?: () => void;
+  isEndDisabled?: boolean;
+}
+
+const EditorBlock = ({
+  block,
+  index,
+  onChange,
+  onAddBlock,
+  onSave,
+  isActive,
+  isLast,
+  onEnd,
+  isEndDisabled = false,
+}: Props) => {
+  return (
+    <div className="flex flex-row gap-[25px] pb-[25px]">
+      <div className="flex flex-col gap-[16px] w-[1200px]">
+        <div className="flex justify-between items-start">
+          <input
+            type="text"
+            value={block.title}
+            onChange={(e) => onChange(index, { title: e.target.value })}
+            placeholder="소제목을 입력해주세요"
+            className="w-full p-2 border-none rounded font-bold text-black text-[24px]"
+          />
+
+          {isActive && (
+            <div className="flex flex-col items-end gap-2 min-w-[160px]">
+              <div className="flex gap-2">
+                <button
+                  onClick={() => onSave?.(index)}
+                  className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-100"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => {
+                    if (isLast) onEnd?.();
+                    else onAddBlock?.();
+                  }}
+                  disabled={isLast && isEndDisabled}
+                  className={`px-4 py-2 rounded-lg text-sm ${
+                    isLast
+                      ? isEndDisabled
+                        ? "bg-gray-300 text-white cursor-not-allowed"
+                        : "bg-purple-500 text-white hover:bg-purple-600"
+                      : "bg-purple-500 text-white hover:bg-purple-600"
+                  }`}
+                >
+                  {isLast ? "End" : "Next"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div data-color-mode="light">
+          <MDEditor
+            value={block.content}
+            onChange={(val) => onChange(index, { content: val || "" })}
+            height={240}
+            preview={isActive ? "edit" : "preview"}
+            style={{ width: "1200px" }}
+            autoFocus={isActive}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditorBlock;

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -69,7 +69,7 @@ export default function FolderModal({
         </span>
         <button onClick={onClose}>
           <img
-            src="/icons/close.svg"
+            src="/icons/exiticon.svg"
             alt="close"
             className="w-[24px] h-[24px] mb-[12px] mt-[3px]"
           />

--- a/src/components/TemplateWrite/CategoryTag.tsx
+++ b/src/components/TemplateWrite/CategoryTag.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import CategoryTagModal from "../../pages/TempWrite/CategoryTagModal";
 import { allTags } from "../../pages/TempWrite/tagData";
-import searchIcon2 from "/public/icons/searchicon2.svg";
+import searchIcon2 from "/icons/searchicon2.svg";
 
 interface CategoryTagProps {
   value: string[];

--- a/src/components/TemplateWrite/CategoryTag.tsx
+++ b/src/components/TemplateWrite/CategoryTag.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import CategoryTagModal from "../../pages/TempWrite/CategoryTagModal";
 import { allTags } from "../../pages/TempWrite/tagData";
-import searchIcon2 from "../../../public/icons/searchicon2.svg";
+import searchIcon2 from "/public/icons/searchicon2.svg";
 
 interface CategoryTagProps {
   value: string[];

--- a/src/components/TemplateWrite/EditorBlock.tsx
+++ b/src/components/TemplateWrite/EditorBlock.tsx
@@ -18,10 +18,11 @@ interface Props {
   onChange: (index: number, updated: Partial<BlockData>) => void;
   onToggleChecklist: (index: number, item: string, checked: boolean) => void;
   onAddBlock?: () => void;
-  onSave?: (index: number) => void;
+
   isActive: boolean;
   isLast: boolean;
   onEnd?: () => void;
+  onShowSaveAlert?: () => void;
 }
 
 const EditorBlock = ({
@@ -30,41 +31,43 @@ const EditorBlock = ({
   onChange,
   onToggleChecklist,
   onAddBlock,
-  onSave,
+
   isActive,
   isLast,
   onEnd,
   title,
   selectedErrorType,
+  onShowSaveAlert,
 }: Props) => {
   return (
     <div className="flex flex-row gap-[25px] pb-[25px]">
       <div className="flex flex-col gap-[16px] w-[1200px]">
+        {/* 상단 제목 + 버튼 영역 */}
         <div className="flex justify-between items-start">
           <span className="font-bold text-black text-[24px]">
             {block.question}
           </span>
+
           {isActive && (
             <div className="flex flex-col items-end gap-2 min-w-[160px]">
-              {block.isSaved && (
-                <div className="inline-flex gap-[5px] px-[16px] justify-center bg-white shadow-2xs  items-center rounded-lg ">
-                  <img src="/src/assets/images/checkicon.svg" />
-                  <p className="text-14-black"> 저장되었습니다.</p>
-                </div>
-              )}
               <div className="flex gap-2">
+                {/* Save 버튼 */}
                 <button
-                  onClick={() => onSave?.(index)}
-                  className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => {
+                    onShowSaveAlert?.();
+                  }}
+                  className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100"
                 >
                   Save
                 </button>
+
+                {/* End / Next 버튼 */}
                 <button
                   onClick={() => {
                     if (isLast) onEnd?.();
                     else onAddBlock?.();
                   }}
-                  className={`px-4 py-2 rounded-lg text-sm ${
+                  className={`px-4 py-2 rounded-xl text-sm ${
                     isLast
                       ? title.trim() && selectedErrorType
                         ? "bg-purple-500 text-white hover:bg-purple-600"
@@ -79,6 +82,7 @@ const EditorBlock = ({
           )}
         </div>
 
+        {/* 에디터 */}
         <div data-color-mode="light">
           <MDEditor
             value={block.content}
@@ -103,6 +107,7 @@ const EditorBlock = ({
             {block.checklistTitle}
           </h3>
         )}
+
         {block.checklistItems.map((item) => (
           <label
             key={item}
@@ -116,10 +121,10 @@ const EditorBlock = ({
             />
             <span
               className={`
-        inline-block w-5 h-5 bg-no-repeat bg-center bg-contain
-        peer-checked:bg-[url('/public/icons/checkedbox.svg')]
-        bg-[url('/public/icons/noncheckedbox.svg')]
-      `}
+                inline-block w-5 h-5 bg-no-repeat bg-center bg-contain
+                peer-checked:bg-[url('/public/icons/checkedbox.svg')]
+                bg-[url('/public/icons/noncheckedbox.svg')]
+              `}
             ></span>
             <span>{item}</span>
           </label>

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -111,7 +111,7 @@ const FreeFormWritePage = () => {
           )}
 
           {showSaveAlert && (
-            <div className="fixed top-[120px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+            <div className="fixed top-[120px] left-1/2 transform -translate-x-1/2 z-50 bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               저장되었습니다.
             </div>
           )}

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1,0 +1,249 @@
+import { useState } from "react";
+import MDEditor from "@uiw/react-md-editor";
+import HeaderWoSearch from "@/components/Header/HeaderWoSearch";
+import DropDownButton from "../../components/Button/DropDownButton";
+import CategoryTag from "../../components/TemplateWrite/CategoryTag";
+import type { BlockData } from "../../components/FreeFormWrite/EditorBlockFF";
+
+import PostSaveModal from "../TempWrite/PostSaveModal";
+import PostLoadingModal from "../TempWrite/PostLoadingModal";
+import TemplateSelectModal from "../TempWrite/TemplateSelectModal";
+
+const FreeFormWritePage = () => {
+  const [title, setTitle] = useState("");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
+  const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
+    useState(false);
+  const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
+  const [selectedErrorType, setSelectedErrorType] = useState<string | null>(
+    null
+  );
+  const [showAlert, setShowAlert] = useState(false);
+  const [showSaveAlert, setShowSaveAlert] = useState(false);
+  const [showBlockAlert, setShowBlockAlert] = useState(false);
+
+  const [blocks, setBlocks] = useState<BlockData[]>([
+    {
+      id: Date.now(),
+      title: "",
+      content: "",
+      isSaved: false,
+    },
+  ]);
+
+  const handleEnd = () => {
+    if (!title.trim() || !selectedErrorType) {
+      setShowAlert(true);
+      setTimeout(() => setShowAlert(false), 3000);
+      return;
+    }
+    if (!blocks[0].content.trim()) {
+      setShowBlockAlert(true);
+      setTimeout(() => setShowBlockAlert(false), 3000);
+      return;
+    }
+
+    setShowAlert(false);
+    setIsPostSaveModalOpen(true);
+  };
+
+  const handleAddBlock = () => {
+    if (blocks.length >= 10) return;
+    const newBlock: BlockData = {
+      id: Date.now(),
+      title: "",
+      content: "",
+      isSaved: false,
+    };
+    setBlocks((prev) => [...prev, newBlock]);
+  };
+
+  const handleChangeBlock = (
+    id: number,
+    key: "title" | "content",
+    value: string
+  ) => {
+    setBlocks((prev) =>
+      prev.map((b) => (b.id === id ? { ...b, [key]: value } : b))
+    );
+  };
+
+  const handleNextInPostSaveModal = () => {
+    setIsPostSaveModalOpen(false);
+    setIsTemplateSelectModalOpen(true);
+  };
+
+  const handleConfirmTemplate = () => {
+    setIsTemplateSelectModalOpen(false);
+    setIsLoadingModalOpen(true);
+    setTimeout(() => setIsLoadingModalOpen(false), 60000);
+  };
+
+  const errorOptions = [
+    "Build / Compile Error",
+    "Runtime Error",
+    "Dependency / Version Error",
+    "Network / API Error",
+    "Authentication / Authorization Error",
+    "Database Error",
+    "UI / Rendering Error",
+    "Configuration Error",
+    "Timeout / Error Handling",
+    "Third-Party Library Error",
+    "Others",
+  ];
+
+  return (
+    <div>
+      <HeaderWoSearch />
+      <div className="flex justify-center px-[360px] pt-[68px] items-start">
+        <div className="flex-1 flex w-[1200px] flex-col gap-3">
+          {showAlert && (
+            <div className="fixed top-[120px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              제목과 에러 종류를 모두 입력해주세요.
+            </div>
+          )}
+          {showBlockAlert && (
+            <div className="fixed top-[120px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              첫 번째 블록의 내용이 비어있습니다.
+            </div>
+          )}
+
+          {showSaveAlert && (
+            <div className="fixed top-[120px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              저장되었습니다.
+            </div>
+          )}
+
+          {/* 제목 + 태그 */}
+          <div className="flex flex-col items-start gap-[40px]">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="제목을 입력하세요."
+              className="text-[36px] md:text-[48px] font-bold text-black outline-none w-full leading-tight"
+            />
+            <div className="flex gap-[36px] items-center">
+              <DropDownButton
+                options={errorOptions}
+                placeholder="에러 종류를 선택하세요"
+                width="w-[340px]"
+                onSelect={(selectedError) =>
+                  setSelectedErrorType(selectedError)
+                }
+              />
+              <CategoryTag value={selectedTags} onChange={setSelectedTags} />
+            </div>
+          </div>
+
+          {blocks.length > 0 && (
+            <div
+              key={blocks[0].id}
+              className="flex justify-between items-start max-w-[1200px] gap-4"
+            >
+              <div className="flex-1">
+                <div className="w-full flex flex-row justify-center items-end h-[60px] mb-3">
+                  <input
+                    type="text"
+                    value={blocks[0].title}
+                    onChange={(e) =>
+                      handleChangeBlock(blocks[0].id, "title", e.target.value)
+                    }
+                    placeholder="소제목을 입력해주세요"
+                    className="w-[1070px] p-2 border-none rounded  font-bold text-black text-[24px]"
+                  />
+                  {/* Save / End 버튼 */}
+                  <div className="flex items-end justify-center gap-2">
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => {
+                          setShowSaveAlert(true);
+                          setTimeout(() => setShowSaveAlert(false), 3000);
+                        }}
+                        className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100"
+                      >
+                        Save
+                      </button>
+
+                      <button
+                        onClick={handleEnd}
+                        className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600"
+                      >
+                        End
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <MDEditor
+                  value={blocks[0].content}
+                  onChange={(val) =>
+                    handleChangeBlock(blocks[0].id, "content", val || "")
+                  }
+                  preview="edit"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* 나머지 블록 */}
+          {blocks.slice(1).map((block) => (
+            <div key={block.id} className="border-none max-w-[1200px]">
+              <input
+                type="text"
+                value={block.title}
+                onChange={(e) =>
+                  handleChangeBlock(block.id, "title", e.target.value)
+                }
+                placeholder="소제목을 입력하세요"
+                className="w-[1200px] p-2 border-none rounded mb-3 font-bold text-black text-[24px]"
+              />
+
+              <MDEditor
+                value={block.content}
+                onChange={(val) =>
+                  handleChangeBlock(block.id, "content", val || "")
+                }
+                preview="edit"
+              />
+            </div>
+          ))}
+
+          {/* 블록 추가 버튼 */}
+          <button
+            onClick={handleAddBlock}
+            disabled={blocks.length >= 10}
+            className="border-2 border-dashed p-4 rounded-xl w-full h-[140px] mt-4 text-gray-500 text-[20px] hover:bg-gray-50 disabled:opacity-50"
+          >
+            + 블록 추가하기 ({blocks.length}/10)
+          </button>
+
+          {isPostSaveModalOpen && (
+            <PostSaveModal
+              onClose={() => setIsPostSaveModalOpen(false)}
+              onNext={handleNextInPostSaveModal}
+            />
+          )}
+
+          {isTemplateSelectModalOpen && (
+            <TemplateSelectModal
+              onConfirm={handleConfirmTemplate}
+              onClose={() => setIsTemplateSelectModalOpen(false)}
+            />
+          )}
+
+          {isLoadingModalOpen && (
+            <PostLoadingModal
+              onClose={() => setIsLoadingModalOpen(false)}
+              progress={100}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FreeFormWritePage;

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -1,4 +1,3 @@
-import KakaoLogo from "/public/icons/kakaologo.svg";
 import { KAKAO_REDIRECT_URI } from "../../config";
 
 const KakaoLoginButton = () => {
@@ -23,7 +22,7 @@ const KakaoLoginButton = () => {
       onClick={KakaoLogin}
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
-      <img src={KakaoLogo} className="w-[18px] h-[18px]" alt="kakao" />
+      <img src="/public/icons/.svg" className="w-[18px] h-[18px]" alt="kakao" />
       <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
         카카오 로그인
       </span>

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -1,4 +1,4 @@
-import KakaoLogo from "../../../public/icons/kakaologo.svg";
+import KakaoLogo from "/public/icons/kakaologo.svg";
 import { KAKAO_REDIRECT_URI } from "../../config";
 
 const KakaoLoginButton = () => {

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -22,7 +22,11 @@ const KakaoLoginButton = () => {
       onClick={KakaoLogin}
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
-      <img src="/public/icons/.svg" className="w-[18px] h-[18px]" alt="kakao" />
+      <img
+        src="/icons/kakaologo.svg"
+        className="w-[18px] h-[18px]"
+        alt="kakao"
+      />
       <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
         카카오 로그인
       </span>

--- a/src/pages/TempWrite/CategoryTagModal.tsx
+++ b/src/pages/TempWrite/CategoryTagModal.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import exitIcon from "/public/icons/exiticon.svg";
 export type TagCategory =
   | "프론트엔드"
   | "백엔드"
@@ -67,7 +66,11 @@ const CategoryTagModal: React.FC<CategoryTagModalProps> = ({
         <div className="flex justify-between items-center p-5 pb-0">
           <h2 className="text-xl font-bold">기술 태그 검색</h2>
           <button onClick={onClose} className="w-6 h-6">
-            <img src={exitIcon} alt="닫기" className="w-full h-full" />
+            <img
+              src="/icons/exiticon.svg"
+              alt="닫기"
+              className="w-full h-full"
+            />
           </button>
         </div>
 

--- a/src/pages/TempWrite/CategoryTagModal.tsx
+++ b/src/pages/TempWrite/CategoryTagModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import exitIcon from "../../../public/icons/exiticon.svg";
+import exitIcon from "/public/icons/exiticon.svg";
 export type TagCategory =
   | "프론트엔드"
   | "백엔드"

--- a/src/pages/TempWrite/PostLoadingModal.tsx
+++ b/src/pages/TempWrite/PostLoadingModal.tsx
@@ -1,5 +1,5 @@
 import BaseModal from "../../components/Modal/BaseModal";
-import exitIcon from "../../../public/icons/exiticon.svg";
+import exitIcon from "/public/icons/exiticon.svg";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import PostSuccessModal from "./PostSuccessModal";

--- a/src/pages/TempWrite/PostLoadingModal.tsx
+++ b/src/pages/TempWrite/PostLoadingModal.tsx
@@ -1,5 +1,5 @@
 import BaseModal from "../../components/Modal/BaseModal";
-import exitIcon from "/public/icons/exiticon.svg";
+
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import PostSuccessModal from "./PostSuccessModal";
@@ -36,7 +36,7 @@ export default function PostLoadingModal({
       <div className="flex flex-col justify-center mt-[39px] ml-[64px] ">
         <div className="flex w-full pl-[452px] ">
           <button onClick={onClose} className="w-6 h-6 pt">
-            <img src={exitIcon} alt="닫기" className="" />
+            <img src="/icons/exiticon.svg" alt="닫기" className="" />
           </button>
         </div>
         <div className="flex flex-col w-[452px] gap-[40px] items-center">

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from "react";
 import BaseModal from "../../components/Modal/BaseModal";
 import SaveButton from "../../components/Button/SaveButton";
 import CancelButton from "../../components/Button/CancelButton";
-import exitIcon from "../../../public/icons/exiticon.svg";
+import exitIcon from "/public/icons/exiticon.svg";
 import DropDownButton from "@/components/Button/DropDownButton";
 export default function PostSaveModal({
   onClose,

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -2,7 +2,6 @@ import { useState, useRef } from "react";
 import BaseModal from "../../components/Modal/BaseModal";
 import SaveButton from "../../components/Button/SaveButton";
 import CancelButton from "../../components/Button/CancelButton";
-import exitIcon from "/public/icons/exiticon.svg";
 import DropDownButton from "@/components/Button/DropDownButton";
 export default function PostSaveModal({
   onClose,
@@ -54,7 +53,7 @@ export default function PostSaveModal({
       <div className="flex w-full justify-between gap-[500px] mt-[36px] mb-[24px]">
         <span className="text-head-24-bold">포스트 미리 보기</span>
         <button onClick={onClose} className="w-6 h-6">
-          <img src={exitIcon} alt="닫기" className="w-full h-full" />
+          <img src="/icons/exiticon.svg" alt="닫기" className="w-full h-full" />
         </button>
       </div>
       <div className="flex flex-col gap-[10px]">

--- a/src/pages/TempWrite/PostSuccessModal.tsx
+++ b/src/pages/TempWrite/PostSuccessModal.tsx
@@ -1,5 +1,4 @@
 import BaseModal from "../../components/Modal/BaseModal";
-import exitIcon from "/public/icons/exiticon.svg";
 // import { useNavigate } from "react-router-dom";
 export default function PostSuccessModal({ onClose }: { onClose: () => void }) {
   //   const navigate = useNavigate();
@@ -14,7 +13,7 @@ export default function PostSuccessModal({ onClose }: { onClose: () => void }) {
       <div className="flex flex-col justify-center mt-[39px] ml-[100px] ">
         <div className="flex w-full pl-[420px] ">
           <button onClick={onClose} className="w-6 h-6">
-            <img src={exitIcon} alt="닫기" className="" />
+            <img src="/icons/exiticon.svg" alt="닫기" className="" />
           </button>
         </div>
         <div className="flex flex-col w-[381px] gap-[40px] items-center">

--- a/src/pages/TempWrite/PostSuccessModal.tsx
+++ b/src/pages/TempWrite/PostSuccessModal.tsx
@@ -1,5 +1,5 @@
 import BaseModal from "../../components/Modal/BaseModal";
-import exitIcon from "../../../public/icons/exiticon.svg";
+import exitIcon from "/public/icons/exiticon.svg";
 // import { useNavigate } from "react-router-dom";
 export default function PostSuccessModal({ onClose }: { onClose: () => void }) {
   //   const navigate = useNavigate();

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -148,7 +148,7 @@ const TempWritePage = () => {
             </div>
           )}
           {showSaveAlert && (
-            <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+            <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               저장되었습니다.
             </div>
           )}

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -16,24 +16,31 @@ const TempWritePage = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [blocks, setBlocks] = useState<BlockData[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
+
   const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
   const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
     useState(false);
   const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
+
   const [selectedErrorType, setSelectedErrorType] = useState<string | null>(
     null
   );
-  const [showAlert, setShowAlert] = useState(false);
-  const [isFirstBlockSaved, setIsFirstBlockSaved] = useState(false);
+
+  const [showAlert, setShowAlert] = useState(false); // 제목/에러 종류 미입력 alert
+  const [showSaveAlert, setShowSaveAlert] = useState(false); // 저장되었습니다 alert
+  const [showBlockAlert, setShowBlockAlert] = useState(false); // 첫번째 블록 비었을 때 alert
 
   const handleEnd = () => {
     if (!title.trim() || !selectedErrorType) {
       setShowAlert(true);
-      setTimeout(() => setShowAlert(false), 3000); // 3초 후 사라짐
+      setTimeout(() => setShowAlert(false), 3000);
       return;
     }
-
-    setShowAlert(false);
+    if (!blocks[0]?.content.trim()) {
+      setShowBlockAlert(true);
+      setTimeout(() => setShowBlockAlert(false), 3000);
+      return;
+    }
     setIsPostSaveModalOpen(true);
   };
 
@@ -43,23 +50,22 @@ const TempWritePage = () => {
       if (nextStep >= questionData.length) return prev;
 
       const stepData = questionData[nextStep];
-      const { question, title, checklistItems } = stepData;
-
       const newBlock: BlockData = {
         id: Date.now(),
         content: "",
         checklist: [],
-        checklistItems: checklistItems ?? [],
-        checklistTitle: title ?? "",
-        question,
+        checklistItems: stepData.checklistItems ?? [],
+        checklistTitle: stepData.title ?? "",
+        question: stepData.question,
         isSaved: false,
       };
+
       const newBlocks = [...prev, newBlock];
       setActiveIndex(newBlocks.length - 1);
-      return [...prev, newBlock];
+      return newBlocks;
     });
-    setActiveIndex(blocks.length);
   };
+
   const handleChangeBlockContent = (
     index: number,
     updated: Partial<BlockData>
@@ -91,36 +97,23 @@ const TempWritePage = () => {
     });
   };
 
-  const handleSave = (index: number) => {
-    setBlocks((prev) => {
-      const newBlocks = [...prev];
-      newBlocks[index].isSaved = true;
-      return newBlocks;
-    });
-
-    setTimeout(() => {
-      setBlocks((prev) => {
-        const newBlocks = [...prev];
-        if (newBlocks[index]) newBlocks[index].isSaved = false;
-        return newBlocks;
-      });
-    }, 3000);
+  // Save Alert 보여주기
+  const handleShowSaveAlert = () => {
+    setShowSaveAlert(true);
+    setTimeout(() => setShowSaveAlert(false), 3000);
   };
 
-  // PostSaveModal에서 다음
+  // PostSaveModal → 다음
   const handleNextInPostSaveModal = () => {
     setIsPostSaveModalOpen(false);
     setIsTemplateSelectModalOpen(true);
   };
 
-  // TemplateSelectModal에서 요약
+  // TemplateSelectModal → 요약
   const handleConfirmTemplate = () => {
     setIsTemplateSelectModalOpen(false);
     setIsLoadingModalOpen(true);
-
-    setTimeout(() => {
-      setIsLoadingModalOpen(false);
-    }, 60000);
+    setTimeout(() => setIsLoadingModalOpen(false), 60000);
   };
 
   const defaultCheckListItems = questionData[0]?.checklistItems || [];
@@ -137,14 +130,26 @@ const TempWritePage = () => {
     "Third-Party Library Error",
     "Others",
   ];
+
   return (
     <div>
       <HeaderWoSearch />
-      <div className="flex justify-center px-[225px] pt-[68px]  items-start">
+      <div className="flex justify-center px-[225px] pt-[68px] items-start">
         <div className="flex-1 flex w-[1500px] flex-col gap-[36px]">
+          {/* Alert 메시지 */}
           {showAlert && (
-            <div className="fixed top-[100px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100-100 border border-purple-400 text-purple-700 px-4 py-2 rounded shadow">
+            <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               제목과 에러 종류를 모두 입력해주세요.
+            </div>
+          )}
+          {showBlockAlert && (
+            <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              첫 번째 블록의 내용을 입력해주세요.
+            </div>
+          )}
+          {showSaveAlert && (
+            <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              저장되었습니다.
             </div>
           )}
 
@@ -162,18 +167,16 @@ const TempWritePage = () => {
                 options={errorOptions}
                 placeholder="에러 종류를 선택하세요"
                 width="w-[340px]"
-                onSelect={(selectedError) => {
-                  console.log("선택된 에러 종류:", selectedError);
-                  setSelectedErrorType(selectedError);
-                }}
+                onSelect={(selectedError) =>
+                  setSelectedErrorType(selectedError)
+                }
               />
-
               <CategoryTag value={selectedTags} onChange={setSelectedTags} />
             </div>
           </div>
 
-          {/* 추가될 블록들 */}
-          <div className="">
+          {/* 블록들 */}
+          <div>
             {blocks
               .slice()
               .reverse()
@@ -189,67 +192,52 @@ const TempWritePage = () => {
                     onChange={handleChangeBlockContent}
                     onToggleChecklist={handleToggleChecklist}
                     onAddBlock={handleAddBlock}
-                    onSave={handleSave}
                     onEnd={handleEnd}
                     title={title}
                     selectedErrorType={selectedErrorType}
+                    onShowSaveAlert={handleShowSaveAlert}
                   />
                 );
               })}
 
-            {/* 어떤오류~ 블록*/}
+            {/* 첫 번째 블록 (어떤오류~) */}
             <div className="flex flex-row gap-[25px]">
               <div className="flex flex-col gap-[16px] w-[1200px]">
                 <div className="flex justify-between items-start">
                   <span className="font-bold text-black text-[24px]">
                     {questionData[0].question}
                   </span>
-                  <div className="flex flex-col items-end gap-2 min-w-[160px]">
-                    {isFirstBlockSaved && (
-                      <div className="inline-flex gap-[5px] px-[16px] justify-center bg-white shadow-2xs items-center rounded-lg ">
-                        <img src="/src/assets/images/checkicon.svg" />
-                        <p className="text-14-black"> 저장되었습니다.</p>
-                      </div>
-                    )}
-
+                  {/* Save / Next 버튼을 조건부로 렌더링 */}
+                  {blocks.length === 0 && (
                     <div className="flex flex-col items-end gap-2 min-w-[160px]">
-                      {activeIndex === -1 && (
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => {
-                              setIsFirstBlockSaved(true);
-                              setTimeout(
-                                () => setIsFirstBlockSaved(false),
-                                3000
-                              );
-                            }}
-                            className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-100"
-                          >
-                            Save
-                          </button>
-
-                          <button
-                            onClick={handleAddBlock}
-                            className="px-4 py-2 bg-purple-500 text-white rounded-lg text-sm hover:bg-purple-600"
-                          >
-                            Next
-                          </button>
-                        </div>
-                      )}
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleShowSaveAlert}
+                          className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={handleAddBlock}
+                          className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600"
+                        >
+                          Next
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  )}
                 </div>
-                <div data-color-mode="light">
-                  <MDEditor
-                    value={content}
-                    onChange={(value) => setContent(value || "")}
-                    height={240}
-                    style={{ width: "1200px" }}
-                    preview="edit"
-                  />
-                </div>
+
+                <MDEditor
+                  value={content}
+                  onChange={(value) => setContent(value || "")}
+                  height={240}
+                  style={{ width: "1200px" }}
+                  preview="edit"
+                />
               </div>
-              {/*체크리스트*/}
+
+              {/* 체크리스트 */}
               <div className="flex flex-col gap-2 mt-14">
                 <h3 className="text-base font-semibold text-gray4 flex items-center gap-2">
                   <img
@@ -264,47 +252,34 @@ const TempWritePage = () => {
                     key={index}
                     className="flex items-start gap-2 text-sm text-gray-700 cursor-pointer"
                   >
-                    <input
-                      type="checkbox"
-                      className="peer hidden"
-                      id={`check-${index}`}
-                    />
-
-                    <span
-                      className={`
-        inline-block w-5 h-5 bg-no-repeat bg-center bg-contain
-        peer-checked:bg-[url('/public/icons/checkedbox.svg')]
-        bg-[url('/public/icons/noncheckedbox.svg')]
-      `}
-                    ></span>
+                    <input type="checkbox" className="peer hidden" />
+                    <span className="inline-block w-5 h-5 bg-no-repeat bg-center bg-contain peer-checked:bg-[url('/public/icons/checkedbox.svg')] bg-[url('/public/icons/noncheckedbox.svg')]"></span>
                     <span>{item}</span>
                   </label>
                 ))}
               </div>
             </div>
-            <div />
           </div>
+
+          {isPostSaveModalOpen && (
+            <PostSaveModal
+              onClose={() => setIsPostSaveModalOpen(false)}
+              onNext={handleNextInPostSaveModal}
+            />
+          )}
+          {isTemplateSelectModalOpen && (
+            <TemplateSelectModal
+              onConfirm={handleConfirmTemplate}
+              onClose={() => setIsTemplateSelectModalOpen(false)}
+            />
+          )}
+          {isLoadingModalOpen && (
+            <PostLoadingModal
+              onClose={() => setIsLoadingModalOpen(false)}
+              progress={100}
+            />
+          )}
         </div>
-        {isPostSaveModalOpen && (
-          <PostSaveModal
-            onClose={() => setIsPostSaveModalOpen(false)}
-            onNext={handleNextInPostSaveModal}
-          />
-        )}
-
-        {isTemplateSelectModalOpen && (
-          <TemplateSelectModal
-            onConfirm={handleConfirmTemplate}
-            onClose={() => setIsTemplateSelectModalOpen(false)}
-          />
-        )}
-
-        {isLoadingModalOpen && (
-          <PostLoadingModal
-            onClose={() => setIsLoadingModalOpen(false)}
-            progress={100}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/pages/TempWrite/TemplateSelectModal.tsx
+++ b/src/pages/TempWrite/TemplateSelectModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import BaseModal from "../../components/Modal/BaseModal";
 import CancelButton from "../../components/Button/CancelButton";
-import exitIcon from "../../../public/icons/exiticon.svg";
+import exitIcon from "/public/icons/exiticon.svg";
 import SaveButton from "@/components/Button/SaveButton";
 const templates = ["자기소개서", "면접 대비", "블로그", "Issue 관리"];
 

--- a/src/pages/TempWrite/TemplateSelectModal.tsx
+++ b/src/pages/TempWrite/TemplateSelectModal.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import BaseModal from "../../components/Modal/BaseModal";
 import CancelButton from "../../components/Button/CancelButton";
-import exitIcon from "/public/icons/exiticon.svg";
 import SaveButton from "@/components/Button/SaveButton";
 const templates = ["자기소개서", "면접 대비", "블로그", "Issue 관리"];
 
@@ -40,7 +39,11 @@ export default function TemplateSelectModal({
         <div className="flex w-[763px] justify-between items-center">
           <span className="text-head-32-bold ">어떤 방식으로 요약할까요?</span>
           <button onClick={onClose} className="w-6 h-6">
-            <img src={exitIcon} alt="닫기" className="w-full h-full" />
+            <img
+              src="/icons/exiticon.svg"
+              alt="닫기"
+              className="w-full h-full"
+            />
           </button>
         </div>
       </div>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -13,11 +13,9 @@ import EditProfile from "@/pages/EditProfile/EditProfile";
 import HomePage from "@/pages/Home/HomePage";
 import StatisticsPage from "@/pages/MyPage/StatisticsPage";
 import LikedPostsPage from "@/pages/MyPage/LikedPostsPage";
-
 import TempWritePage from "@/pages/TempWrite/TempWritePage";
-
+import FreeFormWritePage from "@/pages/FreeFormWrite/FreeFormWritePage";
 import SearchResultPage from "@/pages/Search/SearchResultPage";
-
 
 export const router = createBrowserRouter([
   {
@@ -95,6 +93,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <TempWritePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: "freeformwriting",
+    element: (
+      <ProtectedRoute>
+        <FreeFormWritePage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## 🔥 Issues

#41 

## ✅ What to do

- [x] 템플릿 양식 컴포넌트 재사용하여 자유양식 화면 구현

## 📄 Description

- 자유양식 글 작성 시 나오는 첫 페이지 구현 -> `FreeFormWritePage.tsx`
- Next 버튼 마다 추가 되는 블럭 구현 -> `EditorBlockFF.tsx`

## 🤔 Considerations

블록 개수를 제한해야 될 것 같은데 정해진 바가 없어서 일단 10개로 구현했습니다

## 🛠️ Improvements to Make

icon 내에 파일들 비슷해 보일수 있는데, 색깔이나 크기가 다른거라 동일한건 없는것 같습니다
close.svg-> exiticon.svg 가 동일해 이것 하나만 합쳤습니다

## 👀 References
<img width="2560" height="1440" alt="스크린샷 2025-07-31 00 28 25(2)" src="https://github.com/user-attachments/assets/c0928af1-5a88-4dfb-ba25-494e3b1c63b0" />
<img width="2560" height="1440" alt="스크린샷 2025-07-31 00 28 58(2)" src="https://github.com/user-attachments/assets/3c7b0d6d-064d-45ee-bf69-839b9adfafbb" />
<img width="2560" height="1440" alt="스크린샷 2025-07-31 00 29 19(2)" src="https://github.com/user-attachments/assets/b1fd09fc-4952-4482-8fd1-4df86d063458" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 자유 형식 글쓰기 페이지가 추가되어 여러 블록으로 글을 작성할 수 있습니다.
  * 각 블록은 제목과 마크다운 에디터를 지원하며, 최대 10개까지 추가 가능합니다.
  * 글 작성 완료 시 템플릿 선택 및 저장, 로딩, 성공 모달이 순차적으로 제공됩니다.

* **버그 수정/개선**
  * 여러 모달 및 버튼의 아이콘 경로가 일관적으로 수정되었습니다.
  * 카테고리 태그, 카카오 로그인 버튼 등에서 이미지 경로가 절대 경로로 변경되었습니다.
  * 임시 저장 및 알림 메시지 표시 방식이 개선되었습니다.

* **UI/스타일**
  * 버튼, 알림, 체크박스 등 다양한 UI 요소의 스타일이 개선되었습니다.

* **라우팅**
  * 자유 형식 글쓰기 페이지가 보호된 경로로 라우터에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->