### PR TITLE
REFACTOR: 라우팅 경로 상수화

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { useSearchStore } from "@/store/useSearchStore";
 import useClickOutside from "@/hooks/useClickOutside";
 import UserMenuDropdown from "../Menu/UserMenuDropdown";
 import NotificationModal from "../Modal/NotificationModal";
+import { PATH } from "@/constants/paths";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -37,15 +38,20 @@ const Header = () => {
   useEffect(() => {
     const path = location.pathname;
 
-    if (path.startsWith("/user/profile/")) {
-      const username = path.split("/user/profile/")[1]?.split("/")[0];
-      setPlaceholder(
-        `키워드나 태그 등의 검색어를 통해 ${username}님의 트러블슈팅을 검색해보세요!`
-      );
-    } else if (
-      path.startsWith("/user/mypage") ||
-      path.startsWith("/user/home")
-    ) {
+    const mypageMatch = path.match(/^\/user\/mypage\/([^/]+)/);
+    const pageUserId = mypageMatch?.[1];
+
+    if (path.startsWith(PATH.MYPAGE(""))) {
+      if (pageUserId === myUserId) {
+        setPlaceholder(
+          "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
+        );
+      } else {
+        setPlaceholder(
+          `키워드나 태그 등의 검색어를 통해 ${pageUserId}님의 트러블슈팅을 검색해보세요!`
+        );
+      }
+    } else if (path.startsWith(PATH.HOME)) {
       setPlaceholder(
         "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
       );
@@ -54,7 +60,7 @@ const Header = () => {
         "키워드나 태그 등의 검색어를 통해 다른 사람들의 트러블슈팅을 검색해보세요!"
       );
     }
-  }, [location.pathname, setPlaceholder]);
+  }, [location.pathname, setPlaceholder, myUserId]);
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
@@ -65,23 +71,23 @@ const Header = () => {
 
     const currentPath = location.pathname;
     let scope = "community";
-    let username = "";
+    let pageUserId = "";
 
-    if (currentPath.startsWith("/user/profile/")) {
-      scope = "user";
-      username = currentPath.split("/user/profile/")[1]?.split("/")[0];
-    } else if (currentPath === "/user/mypage") {
-      scope = "mypage";
-    } else if (currentPath.startsWith("/user/home")) {
+    const mypageMatch = currentPath.match(/^\/user\/mypage\/([^/]+)/);
+    pageUserId = mypageMatch?.[1] ?? "";
+
+    if (currentPath.startsWith(PATH.MYPAGE(""))) {
+      scope = pageUserId === myUserId ? "mypage" : "user";
+    } else if (currentPath.startsWith(PATH.HOME)) {
       scope = "my";
     }
 
     const searchParams = new URLSearchParams();
     searchParams.set("query", search);
     searchParams.set("scope", scope);
-    if (username) searchParams.set("username", username);
+    if (scope === "user") searchParams.set("userId", pageUserId);
 
-    navigate(`/user/search?${searchParams.toString()}`);
+    navigate(`${PATH.SEARCH}?${searchParams.toString()}`);
   };
 
   return (
@@ -90,7 +96,7 @@ const Header = () => {
         src="/icons/logo.svg"
         alt="logo"
         className="w-[70px] h-[51px] cursor-pointer"
-        onClick={() => navigate("/user/home")}
+        onClick={() => navigate(PATH.HOME)}
       />
       <div className="flex gap-[72px] items-center">
         <div className="flex w-[1200px] h-12 p-2 justify-between items-center gap-1 rounded-md border border-gray1">
@@ -138,7 +144,7 @@ const Header = () => {
                 <UserMenuDropdown
                   onClose={() => setIsUserDropdownOpen(false)}
                   onNavigateToMyPage={() => {
-                    navigate(`/user/mypage/${myUserId}`);
+                    navigate(PATH.MYPAGE(myUserId));
                     setIsUserDropdownOpen(false);
                   }}
                 />

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useLocation, useParams } from "react-router-dom";
 import FollowButton from "../Button/FollowButton";
 import { useMyPageStore } from "@/store/useMyPageStore";
 import type { StatusType } from "@/types/project";
+import { PATH } from "@/constants/paths";
 
 type MyPageSideBarProps =
   | {
@@ -33,7 +34,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     useMyPageStore();
   const { selectedTag, setSelectedTag, resetSelectedTag } = useMyPageStore();
 
-  const basePath = `/user/mypage/${id}`;
+  const basePath = PATH.MYPAGE(id!);
   const isOnMainPage = location.pathname === basePath;
 
   const handleNavigate =

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -3,6 +3,7 @@ import FollowButton from "../Button/FollowButton";
 import { useMyPageStore } from "@/store/useMyPageStore";
 import type { StatusType } from "@/types/project";
 import { PATH } from "@/constants/paths";
+import { MYPAGE_SUBPATH } from "@/constants/routes";
 
 type MyPageSideBarProps =
   | {
@@ -73,11 +74,11 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
             <p className="text-head-32-semibold">{mockProfile.name}</p>
 
             <div className="flex gap-1 text-body-20-regular text-gray4">
-              <button onClick={handleNavigate("following")}>
+              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWING)}>
                 팔로잉 {mockProfile.followingCount}
               </button>
               <span>·</span>
-              <button onClick={handleNavigate("follower")}>
+              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWER)}>
                 팔로워 {mockProfile.followerCount}
               </button>
             </div>
@@ -88,7 +89,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
               <FollowButton
                 label="프로필 수정"
                 colorClass="bg-primary"
-                onClick={handleNavigate("editprofile")}
+                onClick={handleNavigate(MYPAGE_SUBPATH.EDIT_PROFILE)}
               />
             ) : (
               <FollowButton label="팔로우" colorClass="bg-primary" />
@@ -158,16 +159,18 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
 
           {/* 일반 메뉴 버튼들 */}
           <button
-            onClick={handleNavigate("statistics", true)}
+            onClick={handleNavigate(MYPAGE_SUBPATH.STATISTICS, true)}
             className={getMenuButtonClass(
-              location.pathname.includes("statistics")
+              location.pathname.includes(MYPAGE_SUBPATH.STATISTICS)
             )}
           >
             통계 시각화
           </button>
           <button
-            onClick={handleNavigate("likes", true)}
-            className={getMenuButtonClass(location.pathname.includes("likes"))}
+            onClick={handleNavigate(MYPAGE_SUBPATH.LIKES, true)}
+            className={getMenuButtonClass(
+              location.pathname.includes(MYPAGE_SUBPATH.LIKES)
+            )}
           >
             좋아요한 포스트
           </button>

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -1,0 +1,24 @@
+export const PATH = {
+  ROOT: "/",
+  LOGIN: "/",
+  SIGNUP: "/signup",
+  SIGNUP_DETAIL: "/signup/detail",
+  OAUTH: "/oauth",
+
+  USER: "/user",
+  HOME: "/user/home",
+  SEARCH: "/user/search",
+  MYPAGE: (id: string) => `/user/mypage/${id}`,
+  MYPAGE_EDIT: (id: string) => `/user/mypage/${id}/editprofile`,
+  FOLLOWING: (id: string) => `/user/mypage/${id}/following`,
+  FOLLOWER: (id: string) => `/user/mypage/${id}/follower`,
+  STATISTICS: (id: string) => `/user/mypage/${id}/statistics`,
+  LIKES: (id: string) => `/user/mypage/${id}/likes`,
+
+  PROJECT_DETAIL: (id: string) => `/user/project/${id}`,
+  COMMUNITY: "/user/community",
+  COMMUNITY_POST: (postId: number) => `/user/community/${postId}`,
+
+  TEMP_WRITING: "/tempwriting",
+  FREEFORM_WRITING: "/freeformwriting",
+};

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,23 @@
+export const MYPAGE_SUBPATH = {
+  FOLLOWING: "following",
+  FOLLOWER: "follower",
+  EDIT_PROFILE: "editprofile",
+  STATISTICS: "statistics",
+  LIKES: "likes",
+};
+
+export const ROUTE = {
+  USER: "user",
+  HOME: "home",
+  SEARCH: "search",
+  MYPAGE: "mypage/:id",
+  MYPAGE_EDIT: `mypage/:id/${MYPAGE_SUBPATH.EDIT_PROFILE}`,
+  FOLLOWING: `mypage/:id/${MYPAGE_SUBPATH.FOLLOWING}`,
+  FOLLOWER: `mypage/:id/${MYPAGE_SUBPATH.FOLLOWER}`,
+  STATISTICS: `mypage/:id/${MYPAGE_SUBPATH.STATISTICS}`,
+  LIKES: `mypage/:id/${MYPAGE_SUBPATH.LIKES}`,
+
+  PROJECT_DETAIL: "project/:id",
+  COMMUNITY: "community",
+  COMMUNITY_POST: "community/:postId",
+};

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -1,5 +1,6 @@
 import TroublogCard from "@/components/Card/TroublogCard";
 import GenericDropdown from "@/components/Menu/GenericDropdown";
+import { PATH } from "@/constants/paths";
 import { mockCards } from "@/mocks/mockCards";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -96,7 +97,7 @@ export default function CommunityPage() {
               <div
                 key={card.id}
                 className="cursor-pointer"
-                onClick={() => navigate(`/user/community/${card.id}`)}
+                onClick={() => navigate(PATH.COMMUNITY_POST(card.id))}
               >
                 <TroublogCard {...card} />
               </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -5,6 +5,7 @@ import PostComment, {
 import PostGuide from "@/components/Community/PostGuide";
 import KebabDropdown from "@/components/Menu/KebabDropdown";
 import KebabMenuButton from "@/components/Menu/KebabMenuButton";
+import { PATH } from "@/constants/paths";
 import useClickOutside from "@/hooks/useClickOutside";
 import { mockPost } from "@/mocks/mockPost";
 import { useEffect, useRef, useState } from "react";
@@ -41,7 +42,7 @@ export default function CommunityPostDetail() {
 
   // 작성자 프로필 클릭 핸들러
   const handleProfileClick = () => {
-    navigate(`/user/mypage/1`); // 임시
+    navigate(PATH.MYPAGE("1")); // 임시
   };
 
   // 케밥 메뉴

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import ConfirmDeleteModal from "@/components/Modal/ConfirmDeleteModal";
 import WithdrawCompleteModal from "@/components/Modal/WithdrawCompleteModal";
 import type { ProfileData } from "@/models/user.model";
+import { PATH } from "@/constants/paths";
 
 const EditProfile = () => {
   const navigate = useNavigate();
@@ -86,7 +87,7 @@ const EditProfile = () => {
 
   const handleSave = () => {
     console.log("저장할 데이터:", profile);
-    navigate(`/user/mypage/${id}`);
+    navigate(PATH.MYPAGE(id!));
   };
 
   const handleCancel = () => {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import { PATH } from "@/constants/paths";
+import { ROUTE } from "@/constants/routes";
 import Oauth from "@/pages/Login/Oauth";
 import SignPageOne from "@/pages/Login/SignPageOne";
 import ProtectedRoute from "@/components/Common/ProtectedRouter";
@@ -57,7 +58,7 @@ export const router = createBrowserRouter([
         ],
       },
       {
-        path: "mypage/:id",
+        path: ROUTE.MYPAGE,
         element: <MyPageLayout />,
         children: [
           {
@@ -83,11 +84,11 @@ export const router = createBrowserRouter([
         ],
       },
       {
-        path: "mypage/:id/editprofile",
+        path: ROUTE.MYPAGE_EDIT,
         element: <EditProfile />,
       },
       {
-        path: "project/:id",
+        path: ROUTE.PROJECT_DETAIL,
         element: <ProjectDetailPage projectName="Cotato" />,
       },
       {
@@ -95,7 +96,7 @@ export const router = createBrowserRouter([
         element: <CommunityPage />,
       },
       {
-        path: "community/:postId",
+        path: ROUTE.COMMUNITY_POST,
         element: <CommunityPostDetail />,
       },
     ],

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
+import { PATH } from "@/constants/paths";
 import Oauth from "@/pages/Login/Oauth";
 import SignPageOne from "@/pages/Login/SignPageOne";
 import ProtectedRoute from "@/components/Common/ProtectedRouter";
@@ -21,20 +22,20 @@ import CommunityPostDetail from "@/pages/Community/CommunityPostDetail";
 
 export const router = createBrowserRouter([
   {
-    path: "/",
+    path: PATH.ROOT,
     element: <LoginPage />,
   },
-  { path: "oauth", element: <Oauth /> },
+  { path: PATH.OAUTH, element: <Oauth /> },
   {
-    path: "signup",
+    path: PATH.SIGNUP,
     element: <SignPageOne />,
   },
   {
-    path: "signup/detail",
+    path: PATH.SIGNUP_DETAIL,
     element: <SignPageTwo />,
   },
   {
-    path: "user",
+    path: PATH.USER,
     element: (
       <ProtectedRoute>
         <MainLayout />
@@ -42,12 +43,12 @@ export const router = createBrowserRouter([
     ),
     children: [
       {
-        path: "home",
+        path: PATH.HOME,
         element: <HomePage />,
       },
 
       {
-        path: "search",
+        path: PATH.SEARCH,
         children: [
           {
             index: true,
@@ -90,7 +91,7 @@ export const router = createBrowserRouter([
         element: <ProjectDetailPage projectName="Cotato" />,
       },
       {
-        path: "community",
+        path: PATH.COMMUNITY,
         element: <CommunityPage />,
       },
       {
@@ -100,7 +101,7 @@ export const router = createBrowserRouter([
     ],
   },
   {
-    path: "tempwriting",
+    path: PATH.TEMP_WRITING,
     element: (
       <ProtectedRoute>
         <TempWritePage />
@@ -108,7 +109,7 @@ export const router = createBrowserRouter([
     ),
   },
   {
-    path: "freeformwriting",
+    path: PATH.FREEFORM_WRITING,
     element: (
       <ProtectedRoute>
         <FreeFormWritePage />


### PR DESCRIPTION
## 🔥 Issues

closed #44 

## ✅ What to do

- [x] 라우팅 경로 상수화

## 📄 Description

- `navigate()` 등에 사용되는 클라이언트 라우터 경로 (전역 URL 접근 경로) -> `paths.ts`
- 라우터 설정 경로 `ROUTE` + 경로 조각 상수 `MYPAGE_SUBPATH` (내부 라우팅 설정) -> `routes.ts`

- `Header.tsx`에서 현재 페이지 경로 별 검색창의 placeholder를 설정할 때 다른 사용자의 마이페이지에 대한 경로를 `/user/profile`로 잘못 가정하고 있었던 부분 수정 -> 내 마이페이지, 다른 사용자의 프로필 페이지 전부 `/user/mypage/:id`로 통일 (`id`값만 달라짐)

## 🤔 Considerations

- `paths.ts`에 정의된 정적 URL(PATH)과 라우터 등록용 경로(ROUTE)의 역할이 분리되지 않아, 관심사 분리를 위해 `routes.ts`로 분리
- `MYPAGE_SUBPATH`와 `ROUTE`는 경로 조립과 라우팅 정의에서 같은 맥락이므로 하나의 파일에서 관리하는 것이 유지보수성과 재사용성에 더 유리하다고 판단했습니다.

## 🛠️ Improvements to Make

- 수이님이 `axios` 부분 수정해주신 것 머지되면 api url도 상수화해두면 좋을 것 같습니다!

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 전체 경로 및 라우팅 처리를 하드코딩된 문자열 대신 상수로 통일하여 관리하도록 개선했습니다.  
  * 사용자 관련 페이지, 커뮤니티, 프로필 편집 등에서 경로 생성 및 이동 로직이 일관성 있게 변경되었습니다.
  * 검색 입력란의 안내 문구와 범위가 상황에 맞게 더 정확하게 표시됩니다.

* **Chores**
  * 경로 및 라우트 상수 파일이 새로 추가되어, 코드 유지보수성과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->