### PR TITLE
FEAT: 프로젝트 생성 api 연동 세팅

### DIFF
--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -1,0 +1,9 @@
+import type { ProjectData, CreateProjectRequest } from "@/types/project.model";
+import getAPIResponseData from "@/utils/getAPIResponseData";
+
+export const postCreateProject = (payload: CreateProjectRequest) =>
+  getAPIResponseData<ProjectData, CreateProjectRequest>({
+    url: "/project",
+    method: "POST",
+    data: payload,
+  });

--- a/src/mocks/mockProject.ts
+++ b/src/mocks/mockProject.ts
@@ -1,0 +1,8 @@
+import type { ProjectData } from "@/types/project.model";
+
+export const mockProject: ProjectData = {
+  id: 1,
+  name: "Troublog",
+  description: "개발자들을 위한 트러블슈팅 공유 서비스",
+  thumbnailImageUrl: "https://image.url/project-thumbnail.png",
+};

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -4,15 +4,41 @@ import Snackbar from "@/components/Feedback/Snackbar";
 import TroublogCard from "@/components/Card/TroublogCard";
 import ProjectAccordion from "@/components/Project/ProjectAccordion";
 import ProjectFolderCard from "@/components/Project/ProjectFolderCard";
-import NewFolderModal from "@/components/Modal/FolderModal";
+import FolderModal from "@/components/Modal/FolderModal";
 import { mockCards } from "@/mocks/mockCards";
 import { mockFolders } from "@/mocks/mockFolders";
 import useClickOutside from "@/hooks/useClickOutside";
+import { postCreateProject } from "@/api/project.api";
+import type { CreateProjectRequest } from "@/types/project.model";
 
 export default function HomePage() {
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 새 프로젝트 생성 핸들러
+  const handleCreateProject = async (data: {
+    name: string;
+    description: string;
+    thumbnail: string | null;
+  }) => {
+    try {
+      const payload: CreateProjectRequest = {
+        name: data.name,
+        description: data.description,
+        thumbnailImageUrl: data.thumbnail ?? "",
+      };
+
+      const response = await postCreateProject(payload);
+
+      console.log("생성된 프로젝트:", response);
+      alert("프로젝트가 생성되었습니다!");
+      setIsModalOpen(false);
+    } catch (error) {
+      console.error("프로젝트 생성 실패", error);
+      alert("프로젝트 생성에 실패했습니다.");
+    }
+  };
 
   const handlePostClick = useCallback(() => {
     if (mockFolders.length === 0) {
@@ -110,7 +136,13 @@ export default function HomePage() {
       </ProjectAccordion>
 
       {/* 모달 표시 */}
-      {isModalOpen && <NewFolderModal mode="new" onClose={handleCloseModal} />}
+      {isModalOpen && (
+        <FolderModal
+          mode="new"
+          onClose={handleCloseModal}
+          onSubmit={handleCreateProject}
+        />
+      )}
     </div>
   );
 }

--- a/src/types/project.model.ts
+++ b/src/types/project.model.ts
@@ -1,0 +1,18 @@
+export interface CreateProjectRequest {
+  name: string;
+  description: string;
+  thumbnailImageUrl: string;
+}
+
+export interface ProjectData {
+  id: number;
+  name: string;
+  description: string;
+  thumbnailImageUrl: string;
+}
+
+export interface CreateProjectResponse {
+  status: number;
+  message: string;
+  data: ProjectData;
+}


### PR DESCRIPTION
## 🔥 Issues

- closed #46 

## ✅ What to do

- [x] 프로젝트 생성 api(`POST /project`) 연동 세팅

## 📄 Description

- 타입 정의 -> `project.model.ts`
- api 함수 작성 -> `project.api.ts`
- mock 데이터 구성 -> `mockProject.ts`
- 컴포넌트에서 호출 -> `HomePage.tsx`-`handleCreateProject`

## 🤔 Considerations

- 프로젝트 생성 성공 여부에 따라 `alert`를 추가했는데 넣는 게 좋을지, 기능명세서에 따로 없으니 빼는 게 좋을지 고민입니다..!

## 🛠️ Improvements to Make

- 썸네일 이미지 s3 업로드 연동 구조 설계 (백엔드 구현에 따라)
- api 응답에 따라 프로젝트 목록 실시간 갱신 -> 프로젝트 목록 조회 api 연동 세팅 후 구현 예정
- 프로젝트 수정 모드 구현

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 프로젝트 생성 모달에서 새 프로젝트를 생성할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 프로젝트 생성 시 성공 및 실패 알림이 개선되었습니다.

* **기타**
  * 프로젝트 데이터 예시(mock data)가 추가되었습니다.
  * 프로젝트 관련 데이터 구조가 명확하게 정의되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->