### PR TITLE
FEAT: 프로젝트 목록, 상세 조회, 수정, 삭제 api 연동 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "msw": "^2.10.4",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
@@ -359,6 +360,57 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1006,6 +1058,144 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1083,6 +1273,24 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.5.tgz",
+      "integrity": "sha512-B9nHSJYtsv79uo7QdkZ/b/WoKm20IkVSmTc/WCKarmDtFwM0dRx2ouEniqwNkzCSLn3fydzKmnMzjtfdOWt3VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1120,6 +1328,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1464,6 +1697,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1565,6 +1805,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/styled-components": {
       "version": "5.1.34",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
@@ -1576,6 +1823,13 @@
         "@types/react": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2035,6 +2289,35 @@
       },
       "engines": {
         "node": ">=0.8 <=9"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -2682,6 +2965,94 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -4180,6 +4551,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4353,6 +4734,16 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4725,6 +5116,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -5129,6 +5527,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6666,6 +7071,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.4.tgz",
+      "integrity": "sha512-6R1or/qyele7q3RyPwNuvc0IxO8L8/Aim6Sz5ncXEgcWUNxSKE+udriTOWHtpMwmfkLYlacA2y7TIx4cL5lgHA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -6894,6 +7361,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -7353,6 +7827,19 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7370,6 +7857,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7950,6 +8444,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -8496,6 +9007,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -8950,6 +9468,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9010,6 +9544,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -9259,6 +9806,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9315,6 +9872,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util": {
@@ -9765,6 +10333,16 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9785,6 +10363,80 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -9793,6 +10445,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "11th-troublelog-fe",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@uiw/react-md-editor": "^4.0.7",
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,17 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "msw": "^2.10.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "tailwind:init": "tailwindcss init -p"
+    "tailwind:init": "tailwindcss init -p",
+    "msw:init": "msw init public --save",
+    "postinstall": "msw init public --save --no-open || true"
   },
   "dependencies": {
     "@uiw/react-md-editor": "^4.0.7",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,344 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.10.4'
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -21,3 +21,11 @@ export const getProjectList = () =>
     url: "/project/list",
     method: "GET",
   });
+
+/// 프로젝트 상세 조회
+
+export const getProjectDetail = (projectId: number) =>
+  getAPIResponseData<ProjectListItem>({
+    url: `/project/${projectId}`,
+    method: "GET",
+  });

--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -29,3 +29,22 @@ export const getProjectDetail = (projectId: number) =>
     url: `/project/${projectId}`,
     method: "GET",
   });
+
+/// 프로젝트 수정
+
+export const putUpdateProject = (
+  projectId: number,
+  payload: CreateProjectRequest
+) =>
+  getAPIResponseData<ProjectData, CreateProjectRequest>({
+    url: `/project/${projectId}`,
+    method: "PUT",
+    data: payload,
+  });
+
+/// 프로젝트 삭제
+export const deleteProject = (projectId: number) =>
+  getAPIResponseData<null>({
+    url: `/project/${projectId}`,
+    method: "DELETE",
+  });

--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -2,6 +2,7 @@ import type {
   ProjectData,
   CreateProjectRequest,
   ProjectListItem,
+  DeleteProjectResponse,
 } from "@/types/project.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 
@@ -44,7 +45,7 @@ export const putUpdateProject = (
 
 /// 프로젝트 삭제
 export const deleteProject = (projectId: number) =>
-  getAPIResponseData<null>({
+  getAPIResponseData<DeleteProjectResponse>({
     url: `/project/${projectId}`,
     method: "DELETE",
   });

--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -1,9 +1,23 @@
-import type { ProjectData, CreateProjectRequest } from "@/types/project.model";
+import type {
+  ProjectData,
+  CreateProjectRequest,
+  ProjectListItem,
+} from "@/types/project.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
+
+/// 프로젝트 생성
 
 export const postCreateProject = (payload: CreateProjectRequest) =>
   getAPIResponseData<ProjectData, CreateProjectRequest>({
     url: "/project",
     method: "POST",
     data: payload,
+  });
+
+/// 전체 프로젝트 목록 조회
+
+export const getProjectList = () =>
+  getAPIResponseData<ProjectListItem[]>({
+    url: "/project/list",
+    method: "GET",
   });

--- a/src/components/Button/CancelButton.tsx
+++ b/src/components/Button/CancelButton.tsx
@@ -12,6 +12,7 @@ const CancelButton = ({
   return (
     <button
       onClick={onClick}
+      type="button"
       disabled={disabled}
       className="flex px-[57px] py-4 justify-center items-center rounded-xl border border-gray1 text-gray3 text-head-20-semibold"
     >

--- a/src/components/Button/CancelButton.tsx
+++ b/src/components/Button/CancelButton.tsx
@@ -1,12 +1,18 @@
 interface CancelButtonProps {
   onClick: () => void;
   label?: string;
+  disabled?: boolean;
 }
 
-const CancelButton = ({ onClick, label = "취소" }: CancelButtonProps) => {
+const CancelButton = ({
+  onClick,
+  label = "취소",
+  disabled = false,
+}: CancelButtonProps) => {
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       className="flex px-[57px] py-4 justify-center items-center rounded-xl border border-gray1 text-gray3 text-head-20-semibold"
     >
       {label}

--- a/src/components/Button/SaveButton.tsx
+++ b/src/components/Button/SaveButton.tsx
@@ -1,12 +1,18 @@
 interface SaveButtonProps {
   onClick: () => void;
   label?: string;
+  disabled?: boolean;
 }
 
-const SaveButton = ({ onClick, label = "저장" }: SaveButtonProps) => {
+const SaveButton = ({
+  onClick,
+  label = "저장",
+  disabled = false,
+}: SaveButtonProps) => {
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       className="flex px-[57px] py-4 justify-center items-center rounded-xl bg-primary text-white text-head-20-semibold"
     >
       {label}

--- a/src/components/Button/SaveButton.tsx
+++ b/src/components/Button/SaveButton.tsx
@@ -2,16 +2,19 @@ interface SaveButtonProps {
   onClick: () => void;
   label?: string;
   disabled?: boolean;
+  type?: "button" | "submit" | "reset";
 }
 
 const SaveButton = ({
   onClick,
   label = "저장",
   disabled = false,
+  type = "button",
 }: SaveButtonProps) => {
   return (
     <button
       onClick={onClick}
+      type={type}
       disabled={disabled}
       className="flex px-[57px] py-4 justify-center items-center rounded-xl bg-primary text-white text-head-20-semibold"
     >

--- a/src/components/Modal/ConfirmDeleteModal.tsx
+++ b/src/components/Modal/ConfirmDeleteModal.tsx
@@ -6,6 +6,7 @@ interface ConfirmDeleteModalProps {
   onConfirm: () => void;
   title: string;
   description: string;
+  loading?: boolean;
 }
 
 export default function ConfirmDeleteModal({
@@ -13,6 +14,7 @@ export default function ConfirmDeleteModal({
   onConfirm,
   title,
   description,
+  loading = false,
 }: ConfirmDeleteModalProps) {
   return (
     <BaseModal
@@ -27,8 +29,12 @@ export default function ConfirmDeleteModal({
       </div>
 
       <div className="flex items-center gap-[17px]">
-        <CancelButton onClick={onClose} />
-        <SaveButton onClick={onConfirm} label="삭제" />
+        <CancelButton onClick={onClose} disabled={loading} />
+        <SaveButton
+          onClick={onConfirm}
+          label={loading ? "삭제 중..." : "삭제"}
+          disabled={loading}
+        />
       </div>
     </BaseModal>
   );

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -3,19 +3,17 @@ import BaseModal from "./BaseModal";
 import CancelButton from "../Button/CancelButton";
 import SaveButton from "../Button/SaveButton";
 import { getProjectDetail } from "@/api/project.api";
+import type { CreateProjectRequest } from "@/types/project.model";
 
 interface FolderModalProps {
   mode: "new" | "edit";
   projectId?: number;
   onClose: () => void;
-  onSubmit?: (data: {
-    name: string;
-    description: string;
-    thumbnail: string | null;
-  }) => void;
+  onSubmit?: (data: CreateProjectRequest) => void;
   initialName?: string;
   initialDescription?: string;
   initialThumbnail?: string | null;
+  loading?: boolean;
 }
 
 export default function FolderModal({
@@ -26,6 +24,7 @@ export default function FolderModal({
   initialName = "",
   initialDescription = "",
   initialThumbnail = null,
+  loading = false,
 }: FolderModalProps) {
   const [thumbnail, setThumbnail] = useState<string | null>(initialThumbnail);
   const [name, setName] = useState(initialName);
@@ -81,12 +80,22 @@ export default function FolderModal({
   }, [thumbnail]);
 
   const handleUploadClick = () => {
+    if (loading || syncing) return;
     fileInputRef.current?.click();
   };
 
   const handleSubmit = () => {
-    onSubmit?.({ name, description, thumbnail });
+    if (loading || syncing) return;
+
+    const payload: CreateProjectRequest = {
+      name,
+      description,
+      thumbnailImageUrl: thumbnail ?? "",
+    };
+    onSubmit?.(payload);
   };
+
+  const disabled = loading || syncing;
 
   return (
     <BaseModal
@@ -124,6 +133,7 @@ export default function FolderModal({
               />
               <button
                 onClick={() => setThumbnail(null)}
+                disabled={disabled}
                 className="z-20 absolute bottom-[18px] flex px-[23px] pt-[10px] pb-[11px] rounded-[8px] border-[1.5px] border-gray1 bg-white"
               >
                 <span className="text-body-14-regular">썸네일 삭제</span>
@@ -138,6 +148,7 @@ export default function FolderModal({
               />
               <button
                 onClick={handleUploadClick}
+                disabled={disabled}
                 className="flex px-[17px] pt-[10px] pb-[11px] justify-center items-center rounded-[8px] border-[1.5px] border-gray1 bg-white"
               >
                 <span className="text-body-14-regular">썸네일 업로드</span>
@@ -151,6 +162,7 @@ export default function FolderModal({
             ref={fileInputRef}
             onChange={handleImageSelect}
             className="hidden"
+            disabled={disabled}
           />
         </div>
 
@@ -161,6 +173,7 @@ export default function FolderModal({
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
+              disabled={disabled}
               className="flex pl-[15px] pt-[15px] pr-[230px] pb-[14px] items-center rounded-[8px] border border-gray1 bg-white text-body-14-regular"
               placeholder="폴더 이름을 입력해주세요."
             />
@@ -170,6 +183,7 @@ export default function FolderModal({
             <input
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              disabled={disabled}
               className="flex pl-[15px] pt-[15px] pr-[230px] pb-[14px] items-center rounded-[8px] border border-gray1 bg-white text-body-14-regular"
               placeholder="한 줄 소개를 입력해주세요."
             />
@@ -182,7 +196,8 @@ export default function FolderModal({
         <CancelButton onClick={onClose} />
         <SaveButton
           onClick={handleSubmit}
-          label={syncing ? "동기화 중..." : "완료"}
+          label={syncing ? "불러오는 중..." : loading ? "저장 중..." : "완료"}
+          disabled={disabled}
         />
       </div>
     </BaseModal>

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -2,9 +2,11 @@ import { useRef, useState, useEffect } from "react";
 import BaseModal from "./BaseModal";
 import CancelButton from "../Button/CancelButton";
 import SaveButton from "../Button/SaveButton";
+import { getProjectDetail } from "@/api/project.api";
 
 interface FolderModalProps {
   mode: "new" | "edit";
+  projectId?: number;
   onClose: () => void;
   onSubmit?: (data: {
     name: string;
@@ -18,6 +20,7 @@ interface FolderModalProps {
 
 export default function FolderModal({
   mode,
+  projectId,
   onClose,
   onSubmit,
   initialName = "",
@@ -27,6 +30,35 @@ export default function FolderModal({
   const [thumbnail, setThumbnail] = useState<string | null>(initialThumbnail);
   const [name, setName] = useState(initialName);
   const [description, setDescription] = useState(initialDescription);
+  const [syncing, setSyncing] = useState(false);
+
+  // edit 모드일 때 프로젝트 상세 조회 api 호출
+  useEffect(() => {
+    if (mode !== "edit" || !projectId) return;
+
+    let isMounted = true;
+    (async () => {
+      try {
+        setSyncing(true);
+        const detail = await getProjectDetail(projectId);
+        if (!isMounted) return;
+
+        // 상세 응답으로 폼 값 덮어쓰기
+        setName(detail.name ?? "");
+        setDescription(detail.description ?? "");
+        setThumbnail(detail.thumbnailImageUrl ?? null);
+      } catch (e) {
+        console.error("프로젝트 상세 조회 실패:", e);
+      } finally {
+        if (isMounted) setSyncing(false);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [mode, projectId]);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -148,7 +180,10 @@ export default function FolderModal({
       {/* 버튼 영역 */}
       <div className="flex justify-end gap-[17px] mb-[24px] px-[36px] w-full">
         <CancelButton onClick={onClose} />
-        <SaveButton onClick={handleSubmit} label="완료" />
+        <SaveButton
+          onClick={handleSubmit}
+          label={syncing ? "동기화 중..." : "완료"}
+        />
       </div>
     </BaseModal>
   );

--- a/src/components/Project/ProjectAccordion.tsx
+++ b/src/components/Project/ProjectAccordion.tsx
@@ -47,11 +47,15 @@ export default function ProjectAccordion({
       </div>
 
       {/* 펼쳐진 내용 */}
-      {isOpen && (
-        <div id={panelId} className="flex flex-col gap-[36px] sm:gap-[60px]">
-          {children}
-        </div>
-      )}
+      <div
+        id={panelId}
+        aria-hidden={!isOpen}
+        className={
+          (isOpen ? "flex" : "hidden") + " flex-col gap-[36px] sm:gap-[60px]"
+        }
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/Project/ProjectAccordion.tsx
+++ b/src/components/Project/ProjectAccordion.tsx
@@ -1,40 +1,56 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 
 interface ProjectAccordionProps {
   title: React.ReactNode;
+  headerExtra?: React.ReactNode;
+  defaultOpen?: boolean;
   children: React.ReactNode;
 }
 
 export default function ProjectAccordion({
   title,
+  headerExtra,
+  defaultOpen = true,
   children,
 }: ProjectAccordionProps) {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const panelId = useId();
 
   return (
     <div className="flex flex-col w-full">
-      {/* 아코디언 버튼 */}
-      <button
-        onClick={() => setIsOpen((prev) => !prev)}
-        className="flex items-center gap-[8px] sm:gap-[12px] mb-[24px] sm:mb-[36px]"
-      >
-        <img
-          src="/icons/arrow-forward.svg"
-          alt="arrow"
-          className={`w-[28px] h-[28px] sm:w-[36px] sm:h-[36px] transition-transform duration-200 ${
-            isOpen ? "rotate-0" : "-rotate-90"
-          }`}
-        />
-        {typeof title === "string" ? (
-          <span className="text-head-32-regular">{title}</span>
-        ) : (
-          title
-        )}
-      </button>
+      {/* 헤더: 좌측 토글 버튼 + 우측 액션 */}
+      <div className="flex items-stretch gap-[8px] sm:gap-[12px] mb-[24px] sm:mb-[36px] h-9 sm:h-[36px]">
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="flex items-center gap-[8px] sm:gap-[12px]"
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+        >
+          <img
+            src="/icons/arrow-forward.svg"
+            alt=""
+            aria-hidden
+            className={`w-[28px] h-[28px] sm:w-[36px] sm:h-[36px] transition-transform duration-200 ${
+              isOpen ? "rotate-0" : "-rotate-90"
+            }`}
+          />
+          {typeof title === "string" ? (
+            <span className="text-head-32-regular">{title}</span>
+          ) : (
+            title
+          )}
+        </button>
+
+        {/* 우측 액션 */}
+        {headerExtra ? <div>{headerExtra}</div> : null}
+      </div>
 
       {/* 펼쳐진 내용 */}
       {isOpen && (
-        <div className="flex flex-col gap-[36px] sm:gap-[60px]">{children}</div>
+        <div id={panelId} className="flex flex-col gap-[36px] sm:gap-[60px]">
+          {children}
+        </div>
       )}
     </div>
   );

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -7,18 +7,18 @@ import FolderModal from "../Modal/FolderModal";
 import ConfirmDeleteModal from "../Modal/ConfirmDeleteModal";
 
 export interface ProjectFolderCardProps {
-  id: string;
+  id: number;
   name: string;
   description?: string;
   tags: string[];
-  thumbnailUrl?: string;
+  thumbnail?: string;
 }
 
 export default function ProjectFolderCard({
   name,
   description = "",
   tags,
-  thumbnailUrl,
+  thumbnail,
 }: ProjectFolderCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -52,9 +52,9 @@ export default function ProjectFolderCard({
           <div className="flex items-center gap-[16px]">
             {/* 썸네일 자리 */}
             <div className="flex w-[100px] h-[100px] items-center justify-center rounded-[8px] bg-[rgba(217,217,217,0.5)] overflow-hidden">
-              {thumbnailUrl && (
+              {thumbnail && (
                 <img
-                  src={thumbnailUrl}
+                  src={thumbnail}
                   alt="thumbnail"
                   className="w-full h-full object-cover"
                 />
@@ -98,7 +98,7 @@ export default function ProjectFolderCard({
           onClose={handleModalClose}
           initialName={name}
           initialDescription={description}
-          initialThumbnail={thumbnailUrl ?? null}
+          initialThumbnail={thumbnail ?? null}
           onSubmit={(data) => {
             console.log("수정된 폴더 데이터:", data);
             setShowEditModal(false);

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -15,6 +15,7 @@ export interface ProjectFolderCardProps {
 }
 
 export default function ProjectFolderCard({
+  id,
   name,
   description = "",
   tags,
@@ -95,10 +96,8 @@ export default function ProjectFolderCard({
       {showEditModal && (
         <FolderModal
           mode="edit"
+          projectId={id}
           onClose={handleModalClose}
-          initialName={name}
-          initialDescription={description}
-          initialThumbnail={thumbnail ?? null}
           onSubmit={(data) => {
             console.log("수정된 폴더 데이터:", data);
             setShowEditModal(false);

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -5,6 +5,8 @@ import KebabMenuButton from "../Menu/KebabMenuButton";
 import KebabDropdown from "../Menu/KebabDropdown";
 import FolderModal from "../Modal/FolderModal";
 import ConfirmDeleteModal from "../Modal/ConfirmDeleteModal";
+import type { CreateProjectRequest } from "@/types/project.model";
+import { deleteProject, putUpdateProject } from "@/api/project.api";
 
 export interface ProjectFolderCardProps {
   id: number;
@@ -12,6 +14,8 @@ export interface ProjectFolderCardProps {
   description?: string;
   tags: string[];
   thumbnail?: string;
+  onUpdated?: () => void;
+  onDeleted?: () => void;
 }
 
 export default function ProjectFolderCard({
@@ -20,10 +24,13 @@ export default function ProjectFolderCard({
   description = "",
   tags,
   thumbnail,
+  onUpdated,
+  onDeleted,
 }: ProjectFolderCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [loading, setLoading] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
   const handleEdit = useCallback(() => {
@@ -41,10 +48,39 @@ export default function ProjectFolderCard({
     () => setShowDeleteModal(false),
     []
   );
-  const handleDeleteConfirm = useCallback(() => {
-    console.log("삭제 확정");
-    setShowDeleteModal(false);
-  }, []);
+
+  // 수정 api 호출
+  const handleEditSubmit = useCallback(
+    async (data: CreateProjectRequest) => {
+      try {
+        setLoading(true);
+        await putUpdateProject(id, data);
+        console.log("프로젝트 수정 완료");
+        setShowEditModal(false);
+        onUpdated?.();
+      } catch (err) {
+        console.error("프로젝트 수정 실패:", err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [id, onUpdated]
+  );
+
+  // 삭제 api 호출
+  const handleDeleteConfirm = useCallback(async () => {
+    try {
+      setLoading(true);
+      await deleteProject(id);
+      console.log("프로젝트 삭제 완료");
+      setShowDeleteModal(false);
+      onDeleted?.();
+    } catch (err) {
+      console.error("프로젝트 삭제 실패:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [id, onDeleted]);
 
   return (
     <>
@@ -98,10 +134,8 @@ export default function ProjectFolderCard({
           mode="edit"
           projectId={id}
           onClose={handleModalClose}
-          onSubmit={(data) => {
-            console.log("수정된 폴더 데이터:", data);
-            setShowEditModal(false);
-          }}
+          onSubmit={handleEditSubmit}
+          loading={loading}
         />
       )}
 
@@ -112,6 +146,7 @@ export default function ProjectFolderCard({
           onConfirm={handleDeleteConfirm}
           title="프로젝트 삭제"
           description={`정말 삭제하시겠습니까?\n삭제 후 복구되지 않습니다.`}
+          loading={loading}
         />
       )}
     </>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,21 +5,35 @@ import App from "./App.tsx";
 
 async function enableMocking() {
   // 개발환경 + 환경변수로 제어 (원할 때만 mock)
-  if (import.meta.env.DEV && import.meta.env.VITE_API_MOCKING === "true") {
-    const { worker } = await import("./mocks/browser.ts");
-    await worker.start({
-      onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
-      serviceWorker: {
-        url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
-      },
-    });
-  }
+  if (!(import.meta.env.DEV && import.meta.env.VITE_API_MOCKING === "true"))
+    return;
+
+  // HMR 중복 방지
+  if (typeof window !== "undefined" && (window as any).__MSW_STARTED) return;
+
+  const { worker } = await import("./mocks/browser.ts");
+  await worker.start({
+    onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
+    serviceWorker: {
+      url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
+    },
+  });
+  (window as any).__MSW_STARTED = true;
 }
 
-enableMocking().then(() => {
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <App />
-    </StrictMode>
-  );
-});
+async function bootstrap() {
+  try {
+    await enableMocking();
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn("[MSW] start 실패, 실제 API로 진행합니다.", err);
+    }
+  } finally {
+    ReactDOM.createRoot(document.getElementById("root")!).render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+  }
+}
+bootstrap();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,25 @@
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import ReactDOM from "react-dom/client";
 import "./styles/global.css";
 import App from "./App.tsx";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+async function enableMocking() {
+  // 개발환경 + 환경변수로 제어 (원할 때만 mock)
+  if (import.meta.env.DEV && import.meta.env.VITE_API_MOCKING === "true") {
+    const { worker } = await import("./mocks/browser.ts");
+    await worker.start({
+      onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
+      serviceWorker: {
+        url: "/mockServiceWorker.js",
+      },
+    });
+  }
+}
+
+enableMocking().then(() => {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,13 +12,31 @@ async function enableMocking() {
   if (typeof window !== "undefined" && (window as any).__MSW_STARTED) return;
 
   const { worker } = await import("./mocks/browser.ts");
-  await worker.start({
+  const start = Date.now();
+
+  const startPromise = worker.start({
     onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
     serviceWorker: {
       url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
     },
   });
-  (window as any).__MSW_STARTED = true;
+
+  function withTimeout<T>(p: Promise<T>, ms = 3000) {
+    return Promise.race([
+      p,
+      new Promise<T>((_, rej) =>
+        setTimeout(() => rej(new Error("MSW start timeout")), ms)
+      ),
+    ]);
+  }
+
+  try {
+    await withTimeout(startPromise, 3000);
+    console.log(`[MSW] started in ${Date.now() - start}ms`);
+    (window as any).__MSW_STARTED = true;
+  } catch (e) {
+    console.warn("[MSW] start 실패/타임아웃. 실제 API로 진행합니다.", e);
+  }
 }
 
 async function bootstrap() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ async function enableMocking() {
     await worker.start({
       onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
       serviceWorker: {
-        url: "/mockServiceWorker.js",
+        url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
       },
     });
   }

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -38,6 +38,14 @@ export const handlers = [
   // GET /project/:projectId - 프로젝트 상세 조회
   http.get("/project/:projectId", ({ params }) => {
     const id = Number(params.projectId);
+
+    if (Number.isNaN(id)) {
+      return HttpResponse.json(
+        { status: 400, message: "잘못된 프로젝트 ID입니다.", data: null },
+        { status: 400 }
+      );
+    }
+
     const found = mockProjectList.find((p) => p.id === id);
 
     if (!found) {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,10 @@ import type {
   GetProjectDetailResponse,
   CreateProjectResponse,
   GetProjectListResponse,
+  CreateProjectRequest,
+  ProjectListItem,
+  ProjectData,
+  DeleteProjectResponse,
 } from "@/types/project.model";
 import { mockProject, mockProjectList } from "./mockProject";
 
@@ -50,6 +54,70 @@ export const handlers = [
         data: found,
       },
       { status: 200 }
+    );
+  }),
+
+  // PUT /project/:projectId - 프로젝트 수정
+  http.put("/project/:projectId", async ({ params, request }) => {
+    const id = Number(params.projectId);
+    const body = (await request.json()) as CreateProjectRequest;
+
+    const index = mockProjectList.findIndex((p) => p.id === id);
+    if (index === -1) {
+      return HttpResponse.json(
+        { status: 404, message: "프로젝트를 찾을 수 없습니다.", data: null },
+        { status: 404 }
+      );
+    }
+
+    const updated: ProjectListItem = {
+      ...mockProjectList[index],
+      name: body.name,
+      description: body.description,
+      thumbnailImageUrl: body.thumbnailImageUrl,
+    };
+    mockProjectList[index] = updated;
+
+    const data: ProjectData = {
+      id: updated.id,
+      name: updated.name,
+      description: updated.description,
+      thumbnailImageUrl: updated.thumbnailImageUrl,
+    };
+
+    return HttpResponse.json<CreateProjectResponse>(
+      {
+        status: 200,
+        message: "프로젝트가 수정되었습니다.",
+        data,
+      },
+      {
+        status: 200,
+      }
+    );
+  }),
+
+  // DELETE /project/:projectId - 프로젝트 삭제
+  http.delete("/project/:projectId", ({ params }) => {
+    const id = Number(params.projectId);
+    const index = mockProjectList.findIndex((p) => p.id === id);
+
+    if (index === -1) {
+      return HttpResponse.json<DeleteProjectResponse>(
+        { status: 404, message: "프로젝트를 찾을 수 없습니다.", data: null },
+        { status: 404 }
+      );
+    }
+
+    mockProjectList.splice(index, 1);
+
+    return HttpResponse.json<DeleteProjectResponse>(
+      {
+        status: 204,
+        message: "프로젝트가 삭제되었습니다.",
+        data: null,
+      },
+      { status: 204 }
     );
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -108,6 +108,14 @@ export const handlers = [
   // DELETE /project/:projectId - 프로젝트 삭제
   http.delete("/project/:projectId", ({ params }) => {
     const id = Number(params.projectId);
+
+    if (Number.isNaN(id)) {
+      return HttpResponse.json<DeleteProjectResponse>(
+        { status: 400, message: "잘못된 프로젝트 ID입니다.", data: null },
+        { status: 400 }
+      );
+    }
+
     const index = mockProjectList.findIndex((p) => p.id === id);
 
     if (index === -1) {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import type {
+  GetProjectDetailResponse,
   CreateProjectResponse,
   GetProjectListResponse,
 } from "@/types/project.model";
@@ -25,6 +26,28 @@ export const handlers = [
         status: 200,
         message: "OK",
         data: mockProjectList,
+      },
+      { status: 200 }
+    );
+  }),
+
+  // GET /project/:projectId - 프로젝트 상세 조회
+  http.get("/project/:projectId", ({ params }) => {
+    const id = Number(params.projectId);
+    const found = mockProjectList.find((p) => p.id === id);
+
+    if (!found) {
+      return HttpResponse.json(
+        { status: 404, message: "프로젝트를 찾을 수 없습니다.", data: null },
+        { status: 404 }
+      );
+    }
+
+    return HttpResponse.json<GetProjectDetailResponse>(
+      {
+        status: 200,
+        message: "프로젝트 상세 조회 성공",
+        data: found,
       },
       { status: 200 }
     );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -113,11 +113,11 @@ export const handlers = [
 
     return HttpResponse.json<DeleteProjectResponse>(
       {
-        status: 204,
+        status: 200,
         message: "프로젝트가 삭제되었습니다.",
         data: null,
       },
-      { status: 204 }
+      { status: 200 }
     );
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from "msw";
+import type {
+  CreateProjectResponse,
+  GetProjectListResponse,
+} from "@/types/project.model";
+import { mockProject, mockProjectList } from "./mockProject";
+
+export const handlers = [
+  // POST /project - 프로젝트 생성
+  http.post("/project", async () => {
+    return HttpResponse.json<CreateProjectResponse>(
+      {
+        status: 200,
+        message: "OK",
+        data: mockProject,
+      },
+      { status: 200 }
+    );
+  }),
+
+  // GET /project/list - 전체 프로젝트 목록 조회
+  http.get("/project/list", () => {
+    return HttpResponse.json<GetProjectListResponse>(
+      {
+        status: 200,
+        message: "OK",
+        data: mockProjectList,
+      },
+      { status: 200 }
+    );
+  }),
+];

--- a/src/mocks/mockProject.ts
+++ b/src/mocks/mockProject.ts
@@ -1,4 +1,6 @@
-import type { ProjectData } from "@/types/project.model";
+import type { ProjectData, ProjectListItem } from "@/types/project.model";
+
+/// 프로젝트 생성
 
 export const mockProject: ProjectData = {
   id: 1,
@@ -6,3 +8,22 @@ export const mockProject: ProjectData = {
   description: "개발자들을 위한 트러블슈팅 공유 서비스",
   thumbnailImageUrl: "https://image.url/project-thumbnail.png",
 };
+
+/// 전체 프로젝트 목록 조회
+
+export const mockProjectList: ProjectListItem[] = [
+  {
+    id: 1,
+    name: "Troublog",
+    description: "트러블슈팅 공유 플랫폼",
+    thumbnailImageUrl: "https://image.url/thumbnail1.png",
+    tags: ["Spring", "AWS"],
+  },
+  {
+    id: 2,
+    name: "TechBoard",
+    description: "기술 블로그 플랫폼",
+    thumbnailImageUrl: "https://image.url/thumbnail2.png",
+    tags: ["Next.js", "Typescript"],
+  },
+];

--- a/src/mocks/mockProject.ts
+++ b/src/mocks/mockProject.ts
@@ -11,7 +11,7 @@ export const mockProject: ProjectData = {
 
 /// 전체 프로젝트 목록 조회
 
-export const mockProjectList: ProjectListItem[] = [
+const initialProjectList: ProjectListItem[] = [
   {
     id: 1,
     name: "Troublog",
@@ -27,3 +27,9 @@ export const mockProjectList: ProjectListItem[] = [
     tags: ["Next.js", "Typescript"],
   },
 ];
+
+export let mockProjectList: ProjectListItem[] = [...initialProjectList];
+
+export const resetMockProjectList = () => {
+  mockProjectList = [...initialProjectList];
+};

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import PostButton from "@/components/Button/PostButton";
 import Snackbar from "@/components/Feedback/Snackbar";
 import TroublogCard from "@/components/Card/TroublogCard";
@@ -6,15 +6,40 @@ import ProjectAccordion from "@/components/Project/ProjectAccordion";
 import ProjectFolderCard from "@/components/Project/ProjectFolderCard";
 import FolderModal from "@/components/Modal/FolderModal";
 import { mockCards } from "@/mocks/mockCards";
-import { mockFolders } from "@/mocks/mockFolders";
 import useClickOutside from "@/hooks/useClickOutside";
-import { postCreateProject } from "@/api/project.api";
-import type { CreateProjectRequest } from "@/types/project.model";
+import { getProjectList, postCreateProject } from "@/api/project.api";
+import type {
+  ProjectListItem,
+  CreateProjectRequest,
+} from "@/types/project.model";
 
 export default function HomePage() {
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 프로젝트 목록 상태
+  const [projects, setProjects] = useState<ProjectListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<unknown>(null);
+
+  // 최초 로드 시 목록 가져오기
+  const fetchProjects = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const list = await getProjectList();
+      setProjects(Array.isArray(list) ? list : []);
+    } catch (e) {
+      setLoadError(e);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   // 새 프로젝트 생성 핸들러
   const handleCreateProject = async (data: {
@@ -31,6 +56,8 @@ export default function HomePage() {
 
       const response = await postCreateProject(payload);
 
+      await fetchProjects();
+
       console.log("생성된 프로젝트:", response);
       alert("프로젝트가 생성되었습니다!");
       setIsModalOpen(false);
@@ -41,17 +68,16 @@ export default function HomePage() {
   };
 
   const handlePostClick = useCallback(() => {
-    if (mockFolders.length === 0) {
+    if (projects.length === 0) {
       setShowSnackbar(true);
       setTimeout(() => setShowSnackbar(false), 1000);
     } else {
       setShowDropdown((prev) => !prev);
     }
-  }, []);
+  }, [projects.length]);
 
   const handleOpenModal = useCallback(() => setIsModalOpen(true), []);
   const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
-
   const dropdownRef = useClickOutside(() => setShowDropdown(false));
 
   return (
@@ -102,7 +128,17 @@ export default function HomePage() {
         }
       >
         {/* 폴더 존재 시 폴더 카드 목록, 없으면 텍스트 */}
-        {mockFolders.length === 0 ? (
+        {isLoading ? (
+          <div className="w-full flex h-[132px] justify-center items-center rounded-[8px] bg-white shadow-card">
+            <span className="text-body-20-regular">불러오는 중...</span>
+          </div>
+        ) : loadError ? (
+          <div className="w-full flex h-[132px] justify-center items-center rounded-[8px] bg-white shadow-card">
+            <span className="text-body-20-regular text-red-500">
+              목록 로드 실패
+            </span>
+          </div>
+        ) : projects.length === 0 ? (
           <div className="w-full flex h-[132px] justify-center items-center self-stretch rounded-[8px] bg-white shadow-card">
             <span className="text-body-20-regular">
               아직 요약하신 폴더가 없어요.
@@ -110,8 +146,15 @@ export default function HomePage() {
           </div>
         ) : (
           <div className="flex flex-wrap items-center gap-[24px] self-stretch">
-            {mockFolders.map((folder) => (
-              <ProjectFolderCard key={folder.id} {...folder} />
+            {projects.map((p) => (
+              <ProjectFolderCard
+                key={p.id}
+                id={p.id}
+                name={p.name}
+                description={p.description}
+                thumbnail={p.thumbnailImageUrl}
+                tags={p.tags}
+              />
             ))}
           </div>
         )}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -17,6 +17,7 @@ export default function HomePage() {
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
 
   // 프로젝트 목록 상태
   const [projects, setProjects] = useState<ProjectListItem[]>([]);
@@ -42,28 +43,25 @@ export default function HomePage() {
   }, [fetchProjects]);
 
   // 새 프로젝트 생성 핸들러
-  const handleCreateProject = async (data: {
-    name: string;
-    description: string;
-    thumbnail: string | null;
-  }) => {
+  const handleCreateProject = async (data: CreateProjectRequest) => {
     try {
+      setCreating(true);
       const payload: CreateProjectRequest = {
         name: data.name,
         description: data.description,
-        thumbnailImageUrl: data.thumbnail ?? "",
+        thumbnailImageUrl: data.thumbnailImageUrl ?? "",
       };
 
-      const response = await postCreateProject(payload);
-
+      await postCreateProject(payload);
       await fetchProjects();
 
-      console.log("생성된 프로젝트:", response);
       alert("프로젝트가 생성되었습니다!");
       setIsModalOpen(false);
     } catch (error) {
       console.error("프로젝트 생성 실패", error);
       alert("프로젝트 생성에 실패했습니다.");
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -79,6 +77,15 @@ export default function HomePage() {
   const handleOpenModal = useCallback(() => setIsModalOpen(true), []);
   const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
   const dropdownRef = useClickOutside(() => setShowDropdown(false));
+
+  // 프로젝트 폴더 수정/삭제 후 목록 리프레시
+  const handleCardUpdated = useCallback(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  const handleCardDeleted = useCallback(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   return (
     <div className="flex px-[156px] pt-[79px] pb-[158px] flex-col items-start gap-[40px]">
@@ -154,6 +161,8 @@ export default function HomePage() {
                 description={p.description}
                 thumbnail={p.thumbnailImageUrl}
                 tags={p.tags}
+                onUpdated={handleCardUpdated}
+                onDeleted={handleCardDeleted}
               />
             ))}
           </div>
@@ -184,6 +193,7 @@ export default function HomePage() {
           mode="new"
           onClose={handleCloseModal}
           onSubmit={handleCreateProject}
+          loading={creating}
         />
       )}
     </div>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -119,19 +119,19 @@ export default function HomePage() {
 
       {/* Project Folders 영역 */}
       <ProjectAccordion
-        title={
-          <div className="flex">
-            <span className="pr-[10px] text-head-32-regular">
-              Project Folders
-            </span>
-            <button onClick={handleOpenModal}>
-              <img
-                src="/icons/plus.svg"
-                alt="plus"
-                className="w-[36px] h-[36px]"
-              />
-            </button>
-          </div>
+        title="Project Folders"
+        headerExtra={
+          <button
+            type="button"
+            onClick={handleOpenModal}
+            aria-label="새 폴더 추가"
+          >
+            <img
+              src="/icons/plus.svg"
+              alt="plus"
+              className="w-[36px] h-[36px]"
+            />
+          </button>
         }
       >
         {/* 폴더 존재 시 폴더 카드 목록, 없으면 텍스트 */}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,102 +21,107 @@ import CommunityPage from "@/pages/Community/CommunityPage";
 import TroubleShootingList from "@/components/MyPage/TroubleShootingList";
 import CommunityPostDetail from "@/pages/Community/CommunityPostDetail";
 
-export const router = createBrowserRouter([
-  {
-    path: PATH.ROOT,
-    element: <LoginPage />,
-  },
-  { path: PATH.OAUTH, element: <Oauth /> },
-  {
-    path: PATH.SIGNUP,
-    element: <SignPageOne />,
-  },
-  {
-    path: PATH.SIGNUP_DETAIL,
-    element: <SignPageTwo />,
-  },
-  {
-    path: PATH.USER,
-    element: (
-      <ProtectedRoute>
-        <MainLayout />
-      </ProtectedRoute>
-    ),
-    children: [
-      {
-        path: PATH.HOME,
-        element: <HomePage />,
-      },
+export const router = createBrowserRouter(
+  [
+    {
+      path: PATH.ROOT,
+      element: <LoginPage />,
+    },
+    { path: PATH.OAUTH, element: <Oauth /> },
+    {
+      path: PATH.SIGNUP,
+      element: <SignPageOne />,
+    },
+    {
+      path: PATH.SIGNUP_DETAIL,
+      element: <SignPageTwo />,
+    },
+    {
+      path: PATH.USER,
+      element: (
+        <ProtectedRoute>
+          <MainLayout />
+        </ProtectedRoute>
+      ),
+      children: [
+        {
+          path: PATH.HOME,
+          element: <HomePage />,
+        },
 
-      {
-        path: PATH.SEARCH,
-        children: [
-          {
-            index: true,
-            element: <SearchResultPage />,
-          },
-        ],
-      },
-      {
-        path: ROUTE.MYPAGE,
-        element: <MyPageLayout />,
-        children: [
-          {
-            index: true,
-            element: <TroubleShootingList />,
-          },
-          {
-            path: "following",
-            element: <MyFollowing />,
-          },
-          {
-            path: "follower",
-            element: <MyFollowing />,
-          },
-          {
-            path: "statistics",
-            element: <StatisticsPage />,
-          },
-          {
-            path: "likes",
-            element: <LikedPostsPage />,
-          },
-        ],
-      },
-      {
-        path: ROUTE.MYPAGE_EDIT,
-        element: <EditProfile />,
-      },
-      {
-        path: ROUTE.PROJECT_DETAIL,
-        element: <ProjectDetailPage projectName="Cotato" />,
-      },
-      {
-        path: PATH.COMMUNITY,
-        element: <CommunityPage />,
-      },
-      {
-        path: ROUTE.COMMUNITY_POST,
-        element: <CommunityPostDetail />,
-      },
-    ],
-  },
+        {
+          path: PATH.SEARCH,
+          children: [
+            {
+              index: true,
+              element: <SearchResultPage />,
+            },
+          ],
+        },
+        {
+          path: ROUTE.MYPAGE,
+          element: <MyPageLayout />,
+          children: [
+            {
+              index: true,
+              element: <TroubleShootingList />,
+            },
+            {
+              path: "following",
+              element: <MyFollowing />,
+            },
+            {
+              path: "follower",
+              element: <MyFollowing />,
+            },
+            {
+              path: "statistics",
+              element: <StatisticsPage />,
+            },
+            {
+              path: "likes",
+              element: <LikedPostsPage />,
+            },
+          ],
+        },
+        {
+          path: ROUTE.MYPAGE_EDIT,
+          element: <EditProfile />,
+        },
+        {
+          path: ROUTE.PROJECT_DETAIL,
+          element: <ProjectDetailPage projectName="Cotato" />,
+        },
+        {
+          path: PATH.COMMUNITY,
+          element: <CommunityPage />,
+        },
+        {
+          path: ROUTE.COMMUNITY_POST,
+          element: <CommunityPostDetail />,
+        },
+      ],
+    },
+    {
+      path: PATH.TEMP_WRITING,
+      element: (
+        <ProtectedRoute>
+          <TempWritePage />
+        </ProtectedRoute>
+      ),
+    },
+    {
+      path: PATH.FREEFORM_WRITING,
+      element: (
+        <ProtectedRoute>
+          <FreeFormWritePage />
+        </ProtectedRoute>
+      ),
+    },
+  ],
   {
-    path: PATH.TEMP_WRITING,
-    element: (
-      <ProtectedRoute>
-        <TempWritePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: PATH.FREEFORM_WRITING,
-    element: (
-      <ProtectedRoute>
-        <FreeFormWritePage />
-      </ProtectedRoute>
-    ),
-  },
-]);
+    basename: import.meta.env.BASE_URL,
+  }
+);
 
 export default router;

--- a/src/types/project.model.ts
+++ b/src/types/project.model.ts
@@ -1,3 +1,5 @@
+/// 프로젝트 생성
+
 export interface CreateProjectRequest {
   name: string;
   description: string;
@@ -15,4 +17,16 @@ export interface CreateProjectResponse {
   status: number;
   message: string;
   data: ProjectData;
+}
+
+/// 전체 프로젝트 목록 조회
+
+export interface ProjectListItem extends ProjectData {
+  tags: string[];
+}
+
+export interface GetProjectListResponse {
+  status: number;
+  message: string;
+  data: ProjectListItem[];
 }

--- a/src/types/project.model.ts
+++ b/src/types/project.model.ts
@@ -30,3 +30,11 @@ export interface GetProjectListResponse {
   message: string;
   data: ProjectListItem[];
 }
+
+/// 프로젝트 상세 조회
+
+export interface GetProjectDetailResponse {
+  status: number;
+  message: string;
+  data: ProjectListItem;
+}

--- a/src/types/project.model.ts
+++ b/src/types/project.model.ts
@@ -1,3 +1,9 @@
+export interface ApiResponse<T> {
+  status: number;
+  message: string;
+  data: T;
+}
+
 /// 프로젝트 생성
 
 export interface CreateProjectRequest {
@@ -13,11 +19,7 @@ export interface ProjectData {
   thumbnailImageUrl: string;
 }
 
-export interface CreateProjectResponse {
-  status: number;
-  message: string;
-  data: ProjectData;
-}
+export type CreateProjectResponse = ApiResponse<ProjectData>;
 
 /// 전체 프로젝트 목록 조회
 
@@ -25,11 +27,7 @@ export interface ProjectListItem extends ProjectData {
   tags: string[];
 }
 
-export interface GetProjectListResponse {
-  status: number;
-  message: string;
-  data: ProjectListItem[];
-}
+export type GetProjectListResponse = ApiResponse<ProjectListItem[]>;
 
 /// 프로젝트 상세 조회
 
@@ -38,3 +36,7 @@ export interface GetProjectDetailResponse {
   message: string;
   data: ProjectListItem;
 }
+
+/// 프로젝트 삭제
+
+export type DeleteProjectResponse = ApiResponse<null>;

--- a/src/types/project.model.ts
+++ b/src/types/project.model.ts
@@ -31,11 +31,7 @@ export type GetProjectListResponse = ApiResponse<ProjectListItem[]>;
 
 /// 프로젝트 상세 조회
 
-export interface GetProjectDetailResponse {
-  status: number;
-  message: string;
-  data: ProjectListItem;
-}
+export type GetProjectDetailResponse = ApiResponse<ProjectListItem>;
 
 /// 프로젝트 삭제
 

--- a/src/utils/getAPIResponseData.ts
+++ b/src/utils/getAPIResponseData.ts
@@ -5,7 +5,12 @@ const getAPIResponseData = async <T, D = T>(
   option: AxiosRequestConfig<D>
 ): Promise<T> => {
   try {
-    const { data } = await instance(option);
+    const { data, status } = await instance(option);
+
+    // 204 No Content 응답이면 null 반환
+    if (status === 204) {
+      return null as T;
+    }
 
     // 만약 data 내부에 data가 있으면 자동으로 한 단계 제거
     if (data && typeof data === "object" && "data" in data) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH || "/",
   plugins: [react()],
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
-export default defineConfig({
-  base: process.env.VITE_BASE_PATH || "/",
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), "VITE_");
+
+  const rawBase = (env.VITE_BASE_PATH ?? "/").trim();
+  const normalizedBase = rawBase.endsWith("/") ? rawBase : `${rawBase}/`;
+  const base = command === "serve" ? "/" : normalizedBase;
+
+  return {
+    base,
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
+  };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,32 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@esbuild/win32-x64@0.25.5":
+"@bundled-es-modules/cookie@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz"
+  integrity sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==
+  dependencies:
+    cookie "^0.7.2"
+
+"@bundled-es-modules/statuses@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz"
+  integrity sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==
+  dependencies:
+    statuses "^2.0.1"
+
+"@bundled-es-modules/tough-cookie@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz"
+  integrity sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==
+  dependencies:
+    "@types/tough-cookie" "^4.0.5"
+    tough-cookie "^4.1.4"
+
+"@esbuild/darwin-arm64@0.25.5":
   version "0.25.5"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz"
-  integrity sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz"
+  integrity sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
   version "4.7.0"
@@ -298,6 +320,38 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@inquirer/confirm@^5.0.0":
+  version "5.1.14"
+  resolved "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz"
+  integrity sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==
+  dependencies:
+    "@inquirer/core" "^10.1.15"
+    "@inquirer/type" "^3.0.8"
+
+"@inquirer/core@^10.1.15":
+  version "10.1.15"
+  resolved "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz"
+  integrity sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==
+  dependencies:
+    "@inquirer/figures" "^1.0.13"
+    "@inquirer/type" "^3.0.8"
+    ansi-escapes "^4.3.2"
+    cli-width "^4.1.0"
+    mute-stream "^2.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^6.2.0"
+    yoctocolors-cjs "^2.1.2"
+
+"@inquirer/figures@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz"
+  integrity sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==
+
+"@inquirer/type@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz"
+  integrity sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -347,6 +401,18 @@
   resolved "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz"
   integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
 
+"@mswjs/interceptors@^0.39.1":
+  version "0.39.5"
+  resolved "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.5.tgz"
+  integrity sha512-B9nHSJYtsv79uo7QdkZ/b/WoKm20IkVSmTc/WCKarmDtFwM0dRx2ouEniqwNkzCSLn3fydzKmnMzjtfdOWt3VQ==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -368,6 +434,24 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0", "@open-draft/until@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
@@ -378,10 +462,10 @@
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz"
   integrity sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==
 
-"@rollup/rollup-win32-x64-msvc@4.41.1":
+"@rollup/rollup-darwin-arm64@4.41.1":
   version "4.41.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz"
-  integrity sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz"
+  integrity sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -415,6 +499,11 @@
   integrity sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==
   dependencies:
     "@babel/types" "^7.20.7"
+
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
 "@types/debug@^4.0.0":
   version "4.1.12"
@@ -474,7 +563,7 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^24.0.7":
+"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^24.0.7", "@types/node@>=18":
   version "24.0.7"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz"
   integrity sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==
@@ -498,6 +587,11 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/statuses@^2.0.4":
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
+
 "@types/styled-components@5.1.34":
   version "5.1.34"
   resolved "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz"
@@ -506,6 +600,11 @@
     "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     csstype "^3.0.2"
+
+"@types/tough-cookie@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
@@ -718,6 +817,13 @@ amqplib@0.5.2:
     buffer-more-ints "0.0.2"
     readable-stream "1.x >=1.1.9"
     safe-buffer "^5.0.1"
+
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -1091,6 +1197,20 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
@@ -1195,6 +1315,11 @@ cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookie@^1.0.1:
   version "1.0.2"
@@ -1574,7 +1699,7 @@ esbuild@^0.25.0:
     "@esbuild/win32-ia32" "0.25.5"
     "@esbuild/win32-x64" "0.25.5"
 
-escalade@^3.2.0:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -1924,6 +2049,11 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1950,6 +2080,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -2059,6 +2194,11 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+graphql@^16.8.1:
+  version "16.11.0"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -2304,6 +2444,11 @@ hastscript@^9.0.0:
     property-information "^7.0.0"
     space-separated-tokens "^2.0.0"
 
+headers-polyfill@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz"
+  integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
+
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
@@ -2522,6 +2667,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.1.1:
   version "1.1.1"
@@ -3395,6 +3545,35 @@ ms@2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
+msw@^2.10.4:
+  version "2.10.4"
+  resolved "https://registry.npmjs.org/msw/-/msw-2.10.4.tgz"
+  integrity sha512-6R1or/qyele7q3RyPwNuvc0IxO8L8/Aim6Sz5ncXEgcWUNxSKE+udriTOWHtpMwmfkLYlacA2y7TIx4cL5lgHA==
+  dependencies:
+    "@bundled-es-modules/cookie" "^2.0.1"
+    "@bundled-es-modules/statuses" "^1.0.1"
+    "@bundled-es-modules/tough-cookie" "^0.1.6"
+    "@inquirer/confirm" "^5.0.0"
+    "@mswjs/interceptors" "^0.39.1"
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/until" "^2.1.0"
+    "@types/cookie" "^0.6.0"
+    "@types/statuses" "^2.0.4"
+    graphql "^16.8.1"
+    headers-polyfill "^4.0.2"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    strict-event-emitter "^0.5.1"
+    type-fest "^4.26.1"
+    yargs "^17.7.2"
+
+mute-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz"
+  integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
+
 mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz"
@@ -3527,6 +3706,11 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 own-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz"
@@ -3619,6 +3803,11 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -3761,7 +3950,14 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-punycode@^2.1.0:
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -3770,6 +3966,11 @@ qs@6.5.2:
   version "6.5.2"
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -4097,6 +4298,16 @@ remark-stringify@^11.0.0:
     mdast-util-to-markdown "^2.0.0"
     unified "^11.0.0"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
@@ -4347,7 +4558,7 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -4374,6 +4585,11 @@ stack-trace@0.0.10:
   resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
   integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
+statuses@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
 "statuses@>= 1.4.0 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
@@ -4393,6 +4609,11 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -4415,7 +4636,16 @@ string_decoder@~0.10.x:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4649,6 +4879,16 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz"
@@ -4680,6 +4920,16 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.26.1:
+  version "4.41.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 type-is@~1.6.16:
   version "1.6.18"
@@ -4743,7 +4993,7 @@ typescript-eslint@^8.30.1:
     "@typescript-eslint/parser" "8.33.1"
     "@typescript-eslint/utils" "8.33.1"
 
-typescript@^5.8.3, typescript@>=4.8.4, "typescript@>=4.8.4 <5.9.0":
+typescript@^5.8.3, "typescript@>= 4.8.x", typescript@>=4.8.4, "typescript@>=4.8.4 <5.9.0":
   version "5.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
@@ -4823,6 +5073,11 @@ unist-util-visit@^5.0.0, unist-util-visit@~5.0.0:
     unist-util-is "^6.0.0"
     unist-util-visit-parents "^6.0.0"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
@@ -4847,6 +5102,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
@@ -5020,6 +5283,24 @@ word-wrap@^1.2.5:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
@@ -5036,6 +5317,11 @@ ws@6.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
@@ -5046,10 +5332,33 @@ yaml@^2.3.4, yaml@^2.4.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yoctocolors-cjs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz"
+  integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
 zustand@^5.0.6:
   version "5.0.6"


### PR DESCRIPTION
## 🔥 Issues

- closed #47 
- closed #48 
- closed #49 
- closed #50 

## ✅ What to do

- [x] 프로젝트 전체 목록 조회 api 연동 세팅
- [x] 프로젝트 상세 조회 api 연동 세팅
- [x] 프로젝트 수정 api 연동 세팅
- [x] 프로젝트 삭제 api 연동 세팅
- [x] msw 설정

## 📄 Description

- 임시 데이터를 사용해서 실제로 api 연동이 잘 되는지 확인하기 위해 msw(mock service worker)를 사용하였습니다.
  - `mocks/handlers.ts`에 mock 데이터를 활용할 api들만 선언하고 `main.tsx`에서 개발환경 및 환경변수로 제어할 수 있도록 하여 개발 환경에서만, 그리고 핸들러로 선언한 api 호출 로직에 대해서만 mock 데이터를 활용할 수 있도록 구현하였습니다.

- 전체적으로 `loading` 변수와 `disabled` 속성을 적극 활용하여 api 호출을 진행 중일 때에는 사용자의 입력을 받지 못하도록 구현하였습니다.
- 프로젝트 목록에 변화가 생길 수 있는 동작을 실행하는 경우 프로젝트 목록 조회 api를 다시 호출하도록 하였습니다.

## 🤔 Considerations

- 그냥 서비스 인터페이스 + 환경변수 스위치 방법을 통해 mock 데이터를 활용하여 테스트를 진행할지, msw를 세팅할지 고민하다가 msw를 사용해보고 싶기도 하고 추후에 실제 api 연동 시에 더 간편하게 수정할 수 있을 것 같아 msw를 선택했습니다..!

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

- 개발 환경에서만 mock데이터를 활용하기 위해 `.env.development`, `.env.production` 파일을 추가했습니다. 각 파일에 들어가는 코드는 노션 `프론트 > 자료 > .env 파일`에 넣어두었습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로젝트 목록, 상세 조회, 수정, 삭제 등 프로젝트 관리 API 연동 기능이 추가되었습니다.
  * 프로젝트 폴더 카드에서 수정 및 삭제 시 실시간으로 목록이 갱신됩니다.
  * 프로젝트 생성/수정/삭제 시 로딩 상태와 버튼 비활성화, 진행 중 메시지가 표시됩니다.
  * 개발 환경에서 API Mocking을 위한 서비스 워커 및 핸들러가 도입되어 실제 서버 없이도 기능 테스트가 가능합니다.
  * 프로젝트 아코디언 헤더에 추가 콘텐츠 렌더링과 접근성 개선이 이루어졌습니다.
  * 라우터에 자유 글쓰기 페이지 경로가 새롭게 추가되었습니다.

* **버그 수정**
  * 프로젝트 폴더 카드의 썸네일 및 id 타입이 일관성 있게 적용되었습니다.

* **개선 사항**
  * 홈 화면이 더 이상 목데이터가 아닌 실제 API를 통해 프로젝트 목록을 불러옵니다.
  * 프로젝트 생성, 수정, 삭제 시 UI가 비동기 상태를 반영하여 사용자 경험이 향상되었습니다.
  * 버튼 컴포넌트에 disabled 속성 추가로 사용자 조작 제어가 강화되었습니다.
  * 모달 컴포넌트에 로딩 상태 지원이 추가되어 작업 중임을 명확히 표시합니다.
  * Vite 설정에 환경변수 기반 베이스 경로 설정이 추가되었습니다.
  * 메인 엔트리 포인트에서 개발 환경에 따라 비동기 방식으로 Mocking 활성화가 이루어집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->