### PR TITLE
REFACTOR: 실서버 연동 세팅 및 회원가입/로그인 관련 설정 수정

### DIFF
--- a/src/api/apiHeaders.ts
+++ b/src/api/apiHeaders.ts
@@ -1,4 +1,20 @@
-export const getAuthHeaders = () => ({
-  Authorization: `Bearer ${import.meta.env.VITE_FIXED_AUTH}`,
-  EnvType: import.meta.env.VITE_ENV_TYPE,
-});
+export const getEnvType = () => import.meta.env.VITE_ENV_TYPE ?? "local";
+
+type AuthHeaderOptions = {
+  includeFixedToken?: boolean; // true면 고정 토큰을 시도
+};
+
+export const getAuthHeaders = (opts: AuthHeaderOptions = {}) => {
+  const headers: Record<string, string> = { EnvType: getEnvType() };
+
+  if (opts.includeFixedToken) {
+    const fixed = import.meta.env.VITE_FIXED_AUTH as string | undefined;
+    if (fixed && fixed.trim().length > 0) {
+      headers.Authorization = `Bearer ${fixed}`;
+    } else {
+      console.warn("[Auth] VITE_FIXED_AUTH not set; skip Authorization");
+    }
+  }
+
+  return headers;
+};

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -9,13 +9,13 @@ import type {
   EmailCheckResponse,
 } from "@/models/auth.model";
 
-const FIXED = import.meta.env.VITE_FIXED_AUTH;
-const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
+// const FIXED = import.meta.env.VITE_FIXED_AUTH;
+// const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
 
 // 회원가입
 export const postRegister = (payload: RegisterRequest) =>
   authInstance.post<RegisterResponse>("/auth/register", payload, {
-    headers: getAuthHeaders(),
+    headers: getAuthHeaders(/* { includeFixedToken: true } 필요시만 */),
   });
 
 // 로그인
@@ -26,14 +26,21 @@ export const postLogin = (email: string, password: string) =>
     { headers: getAuthHeaders() }
   );
 
-// 이메일 중복 확인
+// // 이메일 중복 확인
+// export const postEmailCheck = (email: string) =>
+//   authInstance.post<EmailCheckResponse>("/auth/email-check", null, {
+//     params: { email },
+//     headers: {
+//       Authorization: `Bearer ${FIXED}`,
+//       EnvType: ENVTYPE,
+//     },
+//   });
+
+// 이메일 중복 확인 (고정토큰 제거)
 export const postEmailCheck = (email: string) =>
   authInstance.post<EmailCheckResponse>("/auth/email-check", null, {
     params: { email },
-    headers: {
-      Authorization: `Bearer ${FIXED}`,
-      EnvType: ENVTYPE,
-    },
+    headers: getAuthHeaders(), // EnvType만 붙음, Authorization은 인터셉터가 있으면 자동
   });
 
 // 리프레시 토큰 재발급

--- a/src/api/authInstance.ts
+++ b/src/api/authInstance.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const authInstance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_BASE_URL,
   timeout: 10000,
   headers: { "Content-Type": "application/json" },
   withCredentials: true, //

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -15,6 +15,7 @@ const instance: AxiosInstance = axios.create({
 instance.interceptors.request.use(
   (config) => {
     // 요청이 전달되기 전 헤더에 accessToken 추가
+    config.headers = config.headers ?? {};
     const accessToken = localStorage.getItem("accessToken");
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
@@ -50,6 +51,7 @@ instance.interceptors.response.use(
           localStorage.setItem("accessToken", accessToken);
 
           // 실패했던 요청에 새 accessToken 적용
+          error.config.headers = error.config.headers ?? {};
           error.config.headers.Authorization = `Bearer ${accessToken}`;
           return axios(error.config);
         }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosInstance } from "axios";
 
-const baseURL = import.meta.env.VITE_BASE_URL;
+const baseURL =
+  import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_BASE_URL;
 
 const instance: AxiosInstance = axios.create({
   baseURL: baseURL,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,57 +1,84 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import "./styles/global.css";
-import App from "./App.tsx";
+import App from "./App";
+
+const ROOT = document.getElementById("root")!;
+
+function shouldUseMocking() {
+  // DEV 모드 + 환경변수 true 일 때만 MSW 시도
+  return (
+    import.meta.env.DEV && String(import.meta.env.VITE_API_MOCKING) === "true"
+  );
+}
 
 async function enableMocking() {
-  // 개발환경 + 환경변수로 제어 (원할 때만 mock)
-  if (!(import.meta.env.DEV && import.meta.env.VITE_API_MOCKING === "true"))
-    return;
+  if (!shouldUseMocking()) return;
 
-  // HMR 중복 방지
-  if (typeof window !== "undefined" && (window as any).__MSW_STARTED) return;
+  // 브라우저 환경/HMR 중복 방지
+  if (typeof window === "undefined" || (window as any).__MSW_STARTED) return;
 
-  const { worker } = await import("./mocks/browser.ts");
-  const start = Date.now();
+  try {
+    // mocks/browser.ts 가 없어도 try-catch로 안전하게 무시
+    const mod = await import("./mocks/browser");
+    if (!mod?.worker) {
+      console.warn('[MSW] "worker" 가 없어 mock을 건너뜁니다.');
+      return;
+    }
 
-  const startPromise = worker.start({
-    onUnhandledRequest: "bypass", // 지정하지 않은 api는 실제 호출
-    serviceWorker: {
-      url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
-    },
-  });
+    const start = Date.now();
 
-  function withTimeout<T>(p: Promise<T>, ms = 3000) {
-    return Promise.race([
-      p,
-      new Promise<T>((_, rej) =>
-        setTimeout(() => rej(new Error("MSW start timeout")), ms)
+    const startPromise = mod.worker.start({
+      onUnhandledRequest: "bypass",
+      serviceWorker: {
+        url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
+      },
+    });
+
+    // 안전 타임아웃 (3s)
+    await Promise.race([
+      startPromise,
+      new Promise((_, rej) =>
+        setTimeout(() => rej(new Error("MSW start timeout")), 3000)
       ),
     ]);
-  }
 
-  try {
-    await withTimeout(startPromise, 3000);
-    console.log(`[MSW] started in ${Date.now() - start}ms`);
     (window as any).__MSW_STARTED = true;
+    console.info(`[MSW] started in ${Date.now() - start}ms`);
   } catch (e) {
-    console.warn("[MSW] start 실패/타임아웃. 실제 API로 진행합니다.", e);
+    // 모듈 미존재/등록 실패 등 → 실서버로 진행
+    if (import.meta.env.DEV) {
+      console.warn("[MSW] 시작 실패. 실제 API로 진행합니다.", e);
+    }
   }
 }
 
-async function bootstrap() {
+// mocking이 꺼져있는데도 이전에 등록된 mock SW가 남아있으면 정리
+async function cleanupStaleMockSW() {
+  if (!("serviceWorker" in navigator)) return;
   try {
-    await enableMocking();
-  } catch (err) {
-    if (import.meta.env.DEV) {
-      console.warn("[MSW] start 실패, 실제 API로 진행합니다.", err);
-    }
-  } finally {
-    ReactDOM.createRoot(document.getElementById("root")!).render(
-      <StrictMode>
-        <App />
-      </StrictMode>
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(
+      regs
+        .filter((r) => r.active?.scriptURL?.includes("mockServiceWorker.js"))
+        .map((r) => r.unregister())
     );
+  } catch {
+    // 무시
   }
 }
-bootstrap();
+
+(async function bootstrap() {
+  // OFF 모드에서는 잔류 mock SW 정리
+  if (!shouldUseMocking()) {
+    cleanupStaleMockSW();
+  }
+
+  await enableMocking();
+
+  ReactDOM.createRoot(ROOT).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+})();

--- a/src/pages/Login/SignPageTwo.tsx
+++ b/src/pages/Login/SignPageTwo.tsx
@@ -49,6 +49,13 @@ const SignPageTwo = () => {
     if (!validateForm()) return;
 
     try {
+      if (!email || !password) {
+        setFormError(
+          "세션이 만료되었습니다. 처음부터 회원가입을 다시 진행해 주세요."
+        );
+        navigate(PATH.SIGNUP);
+        return;
+      }
       const payload: RegisterRequest = {
         email,
         password,
@@ -134,7 +141,6 @@ const SignPageTwo = () => {
                 <span className="text-white text-[20px] font-semibold font-pretendard">
                   회원가입
                 </span>
-                onClick={PATH.HOME}
               </button>
             </div>
           </form>

--- a/src/pages/Login/SignPageTwo.tsx
+++ b/src/pages/Login/SignPageTwo.tsx
@@ -59,7 +59,7 @@ const SignPageTwo = () => {
       };
 
       await postRegister(payload);
-      navigate("/login");
+      navigate(PATH.LOGIN);
     } catch (error: any) {
       console.error("회원가입 실패:", error);
       if (error.response?.data?.message) {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -61,7 +61,7 @@ export const router = createBrowserRouter(
         // 프로젝트 상세
         {
           path: ROUTE.PROJECT_DETAIL,
-          element: <ProjectDetailPage projectName="Cotato" />,
+          element: <ProjectDetailPage />,
         },
 
         // 커뮤니티


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] `.env.*` 정리: `VITE_API_BASE_URL`, `VITE_ENV_TYPE` 추가/분리 (`local`/`dev`/`prod`)
- [x] `authInstance.ts`/`axios.ts`
  - `baseURL` -> `VITE_API_BASE_URL` (없으면 `VITE_BASE_URL` 폴백)
- [x] `apiHeaders.ts`
  - `getEnvType()`, `getAuthHeaders({ includeFixedToken })` 유틸 수정 및 도입
  - `VITE_FIXED_AUTH` 미설정 시 Authorization 생략하도록 안전화
- [x] `auth.api.ts`
  - 로그인: 고정 토큰 제거, `EnvType`만 적용
  - 이메일 중복 확인: `getAuthHeaders()` 사용 (EnvType), `Authorization`은 인터셉터에 위임
- [x] `main.tsx`- MSW 토글/안전화
  - DEV + `VITE_API_MOCKING === "true"`일 때만 동적 import/start
  - OFF일 때 잔류 mockServiceWorker 자동 unregister 처리
- [x] `SignPageTwo.tsx` - 라우팅 경로 수정 ('/login' -> 'PATH.LOGIN')

## 📄 Description

MSW(mock) 기반 개발 환경에서 실서버로 안전하게 전환하기 위한 작업을 진행했습니다.
- 환경변수 분리로 환경 전환 시 코드 수정 없이 서버를 스위칭할 수 있도록 하였습니다.
- MSW는 기본 OFF이며, 필요 시에만 실행되도록 하였고, OFF 상태에서 과거 등록된 mock SW 또한 자동으로 정리합니다.

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

- **카카오 로그인 관련해서 콘솔에 계속 에러 로그가 찍히는 것 같은데 승희님 확인 한 번 부탁드립니다..!**
- **변경된 `.env.*` 파일들에 대한 정보는 노션 `Frontend>자료>.env 파일`에 업데이트 해두었으니 반드시 확인하여 반영 부탁드립니다!!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 환경 타입 헤더 포함과 고정 토큰 부착을 옵션화해 다양한 환경에서 호출 안정성 향상.
  - API 기본 URL 우선순위 개선으로 배포/테스트 환경 전환을 더 안전하게 처리.
  - 개발에서만 선택적으로 모킹하도록 변경하고 모킹 시작/타임아웃·정리 로직을 추가해 개발 경험 개선.
- Bug Fixes
  - 회원가입 흐름에 입력 누락 시 적절한 오류 처리 및 경로 이동 보강.
  - 프로젝트 상세 경로에서 하드코딩된 이름 제거로 라우팅 유연성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->