### PR TITLE
FIX: 카카오 로그인 관련 콘솔 에러 해결 + env 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,20 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Troublog</title>
+
+    <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script
-      src="https://developers.kakao.com/sdk/js/kakao.min.js"
-      defer
-      integrity="sha384-..."
-      crossorigin="anonymous"
-    ></script>
-    <script>
-      Kakao.init("%VITE_KAKAO_JS_SDK_KEY%");
-      console.log(Kakao.isInitialized());
-    </script>
+
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-export const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
-export const KAKAO_REDIRECT_URI = import.meta.env.VITE_APP_REDIRECT_URI;
-export const KAKAO_BASE_URL = "https://kauth.kakao.com/oauth/token";
-export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+export const KAKAO_REST_KEY = import.meta.env.VITE_KAKAO_REST_KEY;
+export const KAKAO_REDIRECT_URI = import.meta.env.VITE_APP_REDIRECT_URI; // http://localhost:5173/oauth
+export const KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+export const KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+export const KAKAO_CLIENT_SECRET = import.meta.env.VITE_KAKAO_CLIENT_SECRET;

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -1,31 +1,38 @@
-import { KAKAO_REDIRECT_URI } from "../../config";
 import kakaoLogoIcon from "@/assets/icons/kakaologo.svg";
+import { ensureKakaoReady } from "./kakaoLoader";
+import { KAKAO_REDIRECT_URI } from "../../config";
+import { useState } from "react";
 
 const KakaoLoginButton = () => {
-  const url = KAKAO_REDIRECT_URI;
+  const [loading, setLoading] = useState(false);
+  const redirectUri = KAKAO_REDIRECT_URI;
 
-  const KakaoLogin = () => {
-    const { Kakao } = window as any;
-    if (!Kakao || !Kakao.Auth) {
-      console.error("Kakao SDK not loaded");
-      return;
+  const onKakaoLogin = async () => {
+    try {
+      setLoading(true);
+      const Kakao = await ensureKakaoReady();
+      Kakao.Auth.authorize({
+        redirectUri,
+        scope: "profile_nickname",
+        throughTalk: false,
+      });
+    } catch (e) {
+      console.error(e);
+      alert("카카오 로그인 초기화에 실패했습니다.");
+      setLoading(false);
     }
-
-    Kakao.Auth.authorize({
-      redirectUri: url,
-      scope: "profile_nickname",
-    });
   };
 
   return (
     <button
       type="button"
-      onClick={KakaoLogin}
+      onClick={onKakaoLogin}
+      disabled={loading}
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
       <img src={kakaoLogoIcon} className="w-[18px] h-[18px]" alt="kakao" />
       <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
-        카카오 로그인
+        {loading ? "초기화 중..." : "카카오 로그인"}
       </span>
     </button>
   );

--- a/src/pages/Login/Oauth.tsx
+++ b/src/pages/Login/Oauth.tsx
@@ -2,9 +2,11 @@ import { useEffect } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import {
-  KAKAO_CLIENT_ID,
+  KAKAO_REST_KEY,
   KAKAO_REDIRECT_URI,
-  KAKAO_BASE_URL,
+  KAKAO_TOKEN_URL,
+  KAKAO_CLIENT_SECRET,
+  KAKAO_USERINFO_URL,
 } from "../../config";
 
 const Oauth = () => {
@@ -13,22 +15,19 @@ const Oauth = () => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
 
-    const GRANT_TYPE = "authorization_code";
-    const client_id = KAKAO_CLIENT_ID;
-    const redirect_uri = KAKAO_REDIRECT_URI;
-    const tokenUrl = KAKAO_BASE_URL;
-    const userInfoUrl = "https://kapi.kakao.com/v2/user/me";
-
     const getTokenAndUserInfo = async () => {
       try {
         // 1. Access Token 요청
         const tokenRes = await axios.post(
-          tokenUrl,
+          KAKAO_TOKEN_URL,
           new URLSearchParams({
-            grant_type: GRANT_TYPE,
-            client_id,
-            redirect_uri,
+            grant_type: "authorization_code",
+            client_id: KAKAO_REST_KEY,
+            redirect_uri: KAKAO_REDIRECT_URI,
             code: code || "",
+            ...(KAKAO_CLIENT_SECRET
+              ? { client_secret: KAKAO_CLIENT_SECRET }
+              : {}),
           }),
           {
             headers: {
@@ -37,11 +36,14 @@ const Oauth = () => {
           }
         );
 
+        // 성공/실패 후 쿼리
+        history.replaceState(null, "", location.pathname);
+
         const accessToken = tokenRes.data.access_token;
-        localStorage.setItem("kakao_access_token", accessToken); //  토큰 저장
+        localStorage.setItem("kakao_access_token", accessToken);
 
         // 2. 사용자 정보 요청
-        const userRes = await axios.get(userInfoUrl, {
+        const userRes = await axios.get(KAKAO_USERINFO_URL, {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },

--- a/src/pages/Login/kakaoLoader.ts
+++ b/src/pages/Login/kakaoLoader.ts
@@ -1,0 +1,35 @@
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}
+
+const SDK_URL = "https://developers.kakao.com/sdk/js/kakao.min.js";
+
+function injectScript(src: string) {
+  return new Promise<void>((resolve, reject) => {
+    if (document.querySelector(`script[src="${src}"]`)) {
+      resolve();
+      return;
+    }
+    const s = document.createElement("script");
+    s.src = src;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error("Failed to load Kakao SDK"));
+    document.head.appendChild(s);
+  });
+}
+
+export async function ensureKakaoReady() {
+  await injectScript(SDK_URL);
+
+  const Kakao = window.Kakao;
+  if (!Kakao) throw new Error("Kakao SDK not available");
+
+  if (!Kakao.isInitialized()) {
+    const jsKey = import.meta.env.VITE_KAKAO_JS_SDK_KEY;
+    if (!jsKey) throw new Error("Missing VITE_KAKAO_JS_SDK_KEY");
+    Kakao.init(jsKey);
+  }
+  return Kakao;
+}


### PR DESCRIPTION
## 🔥 Issues

## ✅ What to do

- [x] 카카오 로그인 REST API 키 / JavaScript 키 혼동 수정
- [x] `redirect_uri` 불일치 수정 (authorize와 token 요청 시 동일하게 유지)
- [x] 토큰 교환 시 `client_id`를 REST API 키로 교체
- [x] 인가 코드 재사용 방지 로직 추가 (`history.replaceState` 적용)
- [x] 카카오 콘솔 Redirect URI 설정값과 코드 상 값 일치 확인

## 📄 Description
카카오 로그인에서 SDK 미로드 및 KOE320 에러가 발생했습니다..
이는 REST API 키 대신 JavaScript 키를 사용함 + `redirect_uri` 불일치, 인가 코드를 재사용해서 발생한듯 했고
해당 부분을 수정하여 콘솔에 에러가 없도록 개선했는데 현재는 소셜로그인 api가 없어서 그런지 계정 생성 및 부가 활동은 불가합니다.

## 🤔 Considerations


## 🛠️ Improvements to Make

## 👀 References

<img width="2560" height="1440" alt="스크린샷 2025-08-13 02 29 18(2)" src="https://github.com/user-attachments/assets/9aeea763-e7b0-4f7b-b4b6-ce42ed22bd76" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 카카오 로그인 버튼에 로딩 상태(“초기화 중…”)와 비활성화 처리 추가, 초기화 실패 시 안내 알림 제공.
- Bug Fixes
  - 카카오 SDK 로딩/초기화 절차를 안정화하여 간헐적 로그인 실패 가능성 감소.
  - OAuth 완료 후 주소창에서 인증 코드를 제거해 깔끔한 URL 유지.
- Refactor
  - 카카오 SDK를 페이지 헤드에서 단일 스크립트로 로드하도록 변경하여 초기 구동 일관성 개선.
- Style
  - 사이트 제목을 “Troublog”로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->