### PR TITLE
FEAT: 마이페이지 통계 시각화 부분 API 연동 

### DIFF
--- a/src/api/statistics.api.ts
+++ b/src/api/statistics.api.ts
@@ -1,0 +1,19 @@
+import type { DailyStat } from "@/types/statistics.model";
+import getAPIResponseData from "@/utils/getAPIResponseData";
+
+// 동일 시점 다중 호출을 하나로 묶기 위한 in-flight Promise
+let inflightDaily: Promise<DailyStat[] | null> | null = null;
+
+// 일일 트러블로그 활동 통계
+export async function getDailyActivity(): Promise<DailyStat[] | null> {
+  if (!inflightDaily) {
+    inflightDaily = getAPIResponseData<DailyStat[] | null>({
+      url: "/statistics/daily",
+      method: "GET",
+    }).finally(() => {
+      // 요청 종료 후 해제(연속 클릭 등 대비)
+      setTimeout(() => (inflightDaily = null), 0);
+    });
+  }
+  return inflightDaily;
+}

--- a/src/api/statistics.api.ts
+++ b/src/api/statistics.api.ts
@@ -1,9 +1,14 @@
-import type { DailyStat, ErrorTagStat } from "@/types/statistics.model";
+import type {
+  DailyStat,
+  ErrorTagStat,
+  SummaryTypeStat,
+} from "@/types/statistics.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 
 // 동일 시점 다중 호출을 하나로 묶기 위한 in-flight Promise
 let inflightDaily: Promise<DailyStat[] | null> | null = null;
 let inflightErrorTags: Promise<ErrorTagStat[] | null> | null = null;
+let inflightSummaryTypes: Promise<SummaryTypeStat[] | null> | null = null;
 
 // 일일 트러블로그 활동 통계
 export async function getDailyActivity(): Promise<DailyStat[] | null> {
@@ -31,4 +36,17 @@ export async function getErrorTagTop3(): Promise<ErrorTagStat[] | null> {
     });
   }
   return inflightErrorTags;
+}
+
+// 요약본 종류 통계
+export async function getSummaryTypes(): Promise<SummaryTypeStat[] | null> {
+  if (!inflightSummaryTypes) {
+    inflightSummaryTypes = getAPIResponseData<SummaryTypeStat[] | null>({
+      url: "/statistics/summary",
+      method: "GET",
+    }).finally(() => {
+      setTimeout(() => (inflightSummaryTypes = null), 0);
+    });
+  }
+  return inflightSummaryTypes;
 }

--- a/src/api/statistics.api.ts
+++ b/src/api/statistics.api.ts
@@ -1,8 +1,9 @@
-import type { DailyStat } from "@/types/statistics.model";
+import type { DailyStat, ErrorTagStat } from "@/types/statistics.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 
 // 동일 시점 다중 호출을 하나로 묶기 위한 in-flight Promise
 let inflightDaily: Promise<DailyStat[] | null> | null = null;
+let inflightErrorTags: Promise<ErrorTagStat[] | null> | null = null;
 
 // 일일 트러블로그 활동 통계
 export async function getDailyActivity(): Promise<DailyStat[] | null> {
@@ -16,4 +17,18 @@ export async function getDailyActivity(): Promise<DailyStat[] | null> {
     });
   }
   return inflightDaily;
+}
+
+// 에러 태그별 통계
+export async function getErrorTagTop3(): Promise<ErrorTagStat[] | null> {
+  if (!inflightErrorTags) {
+    inflightErrorTags = getAPIResponseData<ErrorTagStat[] | null>({
+      url: "/statistics/errors",
+      method: "GET",
+    }).finally(() => {
+      // 요청 종료 후 해제
+      setTimeout(() => (inflightErrorTags = null), 0);
+    });
+  }
+  return inflightErrorTags;
 }

--- a/src/api/statistics.api.ts
+++ b/src/api/statistics.api.ts
@@ -2,6 +2,7 @@ import type {
   DailyStat,
   ErrorTagStat,
   SummaryTypeStat,
+  TechTagStat,
 } from "@/types/statistics.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 
@@ -9,6 +10,7 @@ import getAPIResponseData from "@/utils/getAPIResponseData";
 let inflightDaily: Promise<DailyStat[] | null> | null = null;
 let inflightErrorTags: Promise<ErrorTagStat[] | null> | null = null;
 let inflightSummaryTypes: Promise<SummaryTypeStat[] | null> | null = null;
+let inflightTechTags: Promise<TechTagStat[] | null> | null = null;
 
 // 일일 트러블로그 활동 통계
 export async function getDailyActivity(): Promise<DailyStat[] | null> {
@@ -49,4 +51,17 @@ export async function getSummaryTypes(): Promise<SummaryTypeStat[] | null> {
     });
   }
   return inflightSummaryTypes;
+}
+
+// 기술 태그별 통계
+export async function getTechTagsTop5(): Promise<TechTagStat[] | null> {
+  if (!inflightTechTags) {
+    inflightTechTags = getAPIResponseData<TechTagStat[] | null>({
+      url: "/statistics/tags",
+      method: "GET",
+    }).finally(() => {
+      setTimeout(() => (inflightTechTags = null), 0);
+    });
+  }
+  return inflightTechTags;
 }

--- a/src/api/trouble.api.ts
+++ b/src/api/trouble.api.ts
@@ -14,7 +14,7 @@ export const getTroubleList = (
   sortBy: TroubleSort = "latest"
 ) =>
   getAPIResponseData<GetTroubleListResponse>(
-    api.get<GetTroubleListResponse>("/troubles/list", {
+    api.get<GetTroubleListResponse>("/troubles/my/list", {
       params: { page, size, sortBy },
     })
   );

--- a/src/components/MyPage/SummaryTypeBarChart.tsx
+++ b/src/components/MyPage/SummaryTypeBarChart.tsx
@@ -9,7 +9,7 @@ const SummaryTypeBarChart = ({ summaryData }: SummaryTypeBarChartProps) => {
   return (
     <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
       <span className="text-head-24-bold">내 요약본 종류</span>
-      <span className="text-body-18-regular">{`{${mostUsed.label}}을 가장 많이 사용했어요.`}</span>
+      <span className="text-body-18-regular">{`{${mostUsed.label}}을(를) 가장 많이 사용했어요.`}</span>
 
       {/* 막대 그래프 */}
       <div className="flex justify-center items-end gap-[28px] mt-[36px] h-[245px]">

--- a/src/components/MyPage/TagBubbleChart.tsx
+++ b/src/components/MyPage/TagBubbleChart.tsx
@@ -80,7 +80,7 @@ const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
           return (
             <div
               key={item.label}
-              className={`absolute flex justify-center items-center rounded-full text-white ${textClass}`}
+              className={`absolute grid place-items-center rounded-full text-white ${textClass} text-center leading-tight px-2`}
               style={{
                 width: size,
                 height: size,
@@ -91,7 +91,7 @@ const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
               }}
               title={`${item.label}: ${item.count}`}
             >
-              {item.label}
+              <span className="break-words">{item.label}</span>
             </div>
           );
         })}

--- a/src/components/MyPage/TagBubbleChart.tsx
+++ b/src/components/MyPage/TagBubbleChart.tsx
@@ -1,21 +1,68 @@
+import { useMemo } from "react";
+
 interface TagBubbleChartProps {
   bubbleData: Array<{ label: string; count: number; color: string }>;
 }
 
-const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
-  const getSize = (count: number) => {
-    if (count >= 20) return { size: 150, textClass: "text-head-32-regular" };
-    if (count >= 10) return { size: 110, textClass: "text-body-20-regular" };
-    return { size: 80, textClass: "text-body-16-regular" };
-  };
+const sizeToText = (size: number) =>
+  size >= 150
+    ? "text-head-32-regular"
+    : size >= 110
+    ? "text-body-20-regular"
+    : "text-body-16-regular";
 
-  const positions = [
-    { top: "30%", left: "30%" },
-    { top: "35%", left: "64%" },
-    { top: "73%", left: "50%" },
-    { top: "75%", left: "25%" },
-    { top: "70%", left: "75%" },
-  ];
+// 순위별(1~5) 고정 레이아웃: 위치 + 크기
+const RANK_PRESETS: Record<
+  number,
+  Array<{ top: string; left: string; size: number }>
+> = {
+  1: [{ top: "50%", left: "50%", size: 150 }],
+  2: [
+    { top: "50%", left: "33%", size: 150 },
+    { top: "56%", left: "68%", size: 120 },
+  ],
+  3: [
+    { top: "30%", left: "50%", size: 150 },
+    { top: "78%", left: "39%", size: 110 },
+    { top: "72%", left: "65%", size: 90 },
+  ],
+  4: [
+    { top: "30%", left: "33%", size: 150 },
+    { top: "35%", left: "68%", size: 115 },
+    { top: "78%", left: "40%", size: 100 },
+    { top: "73%", left: "63%", size: 80 },
+  ],
+  5: [
+    { top: "30%", left: "30%", size: 150 },
+    { top: "34%", left: "65%", size: 120 },
+    { top: "71%", left: "50%", size: 100 },
+    { top: "75%", left: "26%", size: 80 },
+    { top: "70%", left: "72%", size: 70 },
+  ],
+};
+
+const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
+  // count 기준 내림차순 → 상위 5개만 사용(순위 결정)
+  const top = useMemo(() => {
+    return [...bubbleData]
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+      .slice(0, 5);
+  }, [bubbleData]);
+
+  // 현재 아이템 개수에 맞는 고정 레이아웃 가져오기
+  const layout = RANK_PRESETS[top.length] ?? RANK_PRESETS[5];
+
+  // 0개면 빈 상태 UI로 대체
+  if (top.length === 0) {
+    return (
+      <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+        <span className="text-head-24-bold">내 태그 분석</span>
+        <span className="text-body-18-regular mt-1">
+          아직 기술 태그가 없어요.
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
@@ -24,11 +71,11 @@ const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
         가장 많이 사용한 태그를 분석했어요.
       </span>
 
-      {/* 버블 영역 */}
+      {/* 버블 영역 (순위별 고정 위치/크기 적용) */}
       <div className="relative w-full h-full mt-[24px] flex justify-center items-center">
-        {bubbleData.map((item, idx) => {
-          const { size, textClass } = getSize(item.count);
-          const position = positions[idx] || { top: "50%", left: "50%" };
+        {top.map((item, idx) => {
+          const { top: t, left: l, size } = layout[idx];
+          const textClass = sizeToText(size);
 
           return (
             <div
@@ -38,10 +85,11 @@ const TagBubbleChart = ({ bubbleData }: TagBubbleChartProps) => {
                 width: size,
                 height: size,
                 backgroundColor: item.color,
-                top: position.top,
-                left: position.left,
+                top: t,
+                left: l,
                 transform: "translate(-50%, -50%)",
               }}
+              title={`${item.label}: ${item.count}`}
             >
               {item.label}
             </div>

--- a/src/hooks/useDailyActivityMap.ts
+++ b/src/hooks/useDailyActivityMap.ts
@@ -1,0 +1,68 @@
+import { getDailyActivity } from "@/api/statistics.api";
+import {
+  makeDebugDailyStats,
+  mergeDailyStatsToYearMap,
+} from "@/utils/activityMap";
+import { useEffect, useRef, useState } from "react";
+
+export function useDailyActivityMap(year = new Date().getFullYear()) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activityMap, setActivityMap] = useState<Record<string, number>>({});
+
+  // 최신 요청만 결과를 반영하기 위한 ID
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    let alive = true;
+    const myReqId = ++reqIdRef.current;
+
+    // 매 실행마다 명시적으로 로딩 시작
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const stats = await getDailyActivity();
+
+        // 디버그 모드: localStorage로 제어
+        //   - "replace" : 서버 응답 무시하고 더미만 사용
+        //   - "merge"   : 서버 응답 + 더미 합쳐서 사용
+        //   - 그 외/없음 : 서버 응답만 사용
+        const debugMode = (
+          localStorage.getItem("debug.dailyActivity") || ""
+        ).toLowerCase();
+        const dummy = makeDebugDailyStats(year);
+
+        let effective = stats ?? [];
+        if (debugMode === "replace") {
+          effective = dummy;
+        } else if (debugMode === "merge") {
+          effective = [...(stats ?? []), ...dummy];
+        }
+
+        const map = mergeDailyStatsToYearMap(effective, year);
+
+        if (alive && reqIdRef.current === myReqId) {
+          setActivityMap(map);
+        }
+      } catch (e: any) {
+        // axios 취소이면 조용히 무시
+        if (e?.code === "ERR_CANCELED") return;
+        if (alive && reqIdRef.current === myReqId) {
+          setError(e?.message ?? "통계 조회 실패");
+        }
+      } finally {
+        if (alive && reqIdRef.current === myReqId) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [year]);
+
+  return { loading, error, activityMap };
+}

--- a/src/hooks/useErrorTagsTop3.ts
+++ b/src/hooks/useErrorTagsTop3.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+import { getErrorTagTop3 } from "@/api/statistics.api";
+import type { ErrorTagStat } from "@/types/statistics.model";
+import { makeDebugErrorTags, mergeErrorTagStats } from "@/utils/errorTagStats";
+
+export function useErrorTagsTop3() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [labels, setLabels] = useState<string[]>([]);
+  const [data, setData] = useState<number[]>([]);
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    let alive = true;
+    const myReqId = ++reqIdRef.current;
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const res = (await getErrorTagTop3()) ?? []; // [] or 실제 배열
+        // 디버그 플래그: localStorage.debug.errorTags = 'replace' | 'merge'
+        const debug = (
+          localStorage.getItem("debug.errorTags") || ""
+        ).toLowerCase();
+        const dummy = makeDebugErrorTags();
+
+        let effective: ErrorTagStat[] =
+          debug === "replace"
+            ? dummy
+            : debug === "merge"
+            ? mergeErrorTagStats(res, dummy)
+            : res;
+
+        // 안전: 정렬 + Top3로 자르기
+        effective = effective
+          .slice()
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 3);
+
+        if (alive && reqIdRef.current === myReqId) {
+          setLabels(effective.map((x) => x.name));
+          setData(effective.map((x) => x.count));
+        }
+      } catch (e: any) {
+        if (alive && reqIdRef.current === myReqId) {
+          setError(e?.message ?? "에러 태그 통계 조회 실패");
+        }
+      } finally {
+        if (alive && reqIdRef.current === myReqId) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      alive = false; // 소프트 캔슬
+    };
+  }, []);
+
+  return { loading, error, labels, data };
+}

--- a/src/hooks/useSummaryTypes.ts
+++ b/src/hooks/useSummaryTypes.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+import { getSummaryTypes } from "@/api/statistics.api";
+import type { SummaryTypeStat } from "@/types/statistics.model";
+import {
+  makeDebugSummaryTypes,
+  mergeSummaryTypeStats,
+} from "@/utils/summaryTypes";
+
+type SummaryDatum = { label: string; value: number };
+
+export function useSummaryTypes() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [summaryData, setSummaryData] = useState<SummaryDatum[]>([]);
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    let alive = true;
+    const myReqId = ++reqIdRef.current;
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const res = (await getSummaryTypes()) ?? []; // [] 가능
+        const debug = (
+          localStorage.getItem("debug.summaryTypes") || ""
+        ).toLowerCase();
+        const dummy = makeDebugSummaryTypes();
+
+        const effective: SummaryTypeStat[] =
+          debug === "replace"
+            ? dummy
+            : debug === "merge"
+            ? mergeSummaryTypeStats(res, dummy)
+            : res;
+
+        // 이름 중복 합산(안전), 값 내림차순 정렬
+        const merged = mergeSummaryTypeStats(effective, []);
+        merged.sort((a, b) => b.count - a.count);
+
+        const chartData: SummaryDatum[] = merged.map(({ name, count }) => ({
+          label: name,
+          value: count,
+        }));
+
+        if (alive && reqIdRef.current === myReqId) setSummaryData(chartData);
+      } catch (e: any) {
+        if (alive && reqIdRef.current === myReqId) {
+          setError(e?.message ?? "요약본 통계 조회 실패");
+        }
+      } finally {
+        if (alive && reqIdRef.current === myReqId) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    }; // 소프트 캔슬
+  }, []);
+
+  return { loading, error, summaryData };
+}

--- a/src/hooks/useTechTagsTop5.ts
+++ b/src/hooks/useTechTagsTop5.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import { getTechTagsTop5 } from "@/api/statistics.api";
+import type { TechTagStat } from "@/types/statistics.model";
+import {
+  makeDebugTechTags,
+  mergeTechTagStats,
+  toBubbleData,
+} from "@/utils/techTags";
+
+type BubbleDatum = { label: string; count: number; color: string };
+
+export function useTechTagsTop5() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [bubbleData, setBubbleData] = useState<BubbleDatum[]>([]);
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    let alive = true;
+    const myReqId = ++reqIdRef.current;
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const res = (await getTechTagsTop5()) ?? []; // [] 가능
+        const debug = (
+          localStorage.getItem("debug.techTags") || ""
+        ).toLowerCase();
+        const cfg = JSON.parse(
+          localStorage.getItem("debug.techTags.cfg") || "{}"
+        );
+        const dummy = makeDebugTechTags(cfg.len);
+
+        const effective: TechTagStat[] =
+          debug === "replace"
+            ? dummy
+            : debug === "merge"
+            ? mergeTechTagStats(res, dummy)
+            : res;
+
+        // 안전 합산 한번 더(혹시 서버 중복 포함), Top5 + 색 할당
+        const merged = mergeTechTagStats(effective, []);
+        const bubbles = toBubbleData(merged);
+
+        if (alive && reqIdRef.current === myReqId) {
+          setBubbleData(bubbles);
+        }
+      } catch (e: any) {
+        if (alive && reqIdRef.current === myReqId) {
+          setError(e?.message ?? "기술 태그 통계 조회 실패");
+        }
+      } finally {
+        if (alive && reqIdRef.current === myReqId) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      alive = false;
+    }; // 소프트 캔슬
+  }, []);
+
+  return { loading, error, bubbleData };
+}

--- a/src/hooks/useTechTagsTop5.ts
+++ b/src/hooks/useTechTagsTop5.ts
@@ -28,10 +28,20 @@ export function useTechTagsTop5() {
         const debug = (
           localStorage.getItem("debug.techTags") || ""
         ).toLowerCase();
-        const cfg = JSON.parse(
-          localStorage.getItem("debug.techTags.cfg") || "{}"
-        );
-        const dummy = makeDebugTechTags(cfg.len);
+        let cfg: any = {};
+        try {
+          cfg = JSON.parse(localStorage.getItem("debug.techTags.cfg") || "{}");
+        } catch {
+          cfg = {};
+        }
+        const rawLen = (cfg ?? {}).len;
+        const len =
+          typeof rawLen === "number"
+            ? rawLen
+            : Number.isFinite(Number.parseInt(rawLen, 10))
+            ? Number.parseInt(rawLen, 10)
+            : undefined;
+        const dummy = makeDebugTechTags(len);
 
         const effective: TechTagStat[] =
           debug === "replace"

--- a/src/pages/MyPage/StatisticsPage.tsx
+++ b/src/pages/MyPage/StatisticsPage.tsx
@@ -3,8 +3,8 @@ import SummaryTypeBarChart from "@/components/MyPage/SummaryTypeBarChart";
 import TagBubbleChart from "@/components/MyPage/TagBubbleChart";
 import TroublogActivityChart from "@/components/MyPage/TroublogActivityChart";
 import { useDailyActivityMap } from "@/hooks/useDailyActivityMap";
+import { useErrorTagsTop3 } from "@/hooks/useErrorTagsTop3";
 import {
-  mockErrorCategoryData,
   mockSummaryTypeData,
   mockTagBubbleData,
 } from "@/mocks/mockStatisticsData";
@@ -12,24 +12,48 @@ import {
 const StatisticsPage = () => {
   const year = new Date().getFullYear();
   const { loading, error, activityMap } = useDailyActivityMap(year);
+  const {
+    loading: errLoading,
+    error: errError,
+    labels: errLabels,
+    data: errData,
+  } = useErrorTagsTop3();
 
   return (
     <div className="flex w-[948px] flex-col items-start gap-[56px] pb-[349px]">
+      {/* 디버그 토글 (dev 전용) */}
       {import.meta.env.DEV && (
-        <button
-          className="ml-auto text-xs text-gray-500 underline"
-          onClick={() => {
-            const cur = localStorage.getItem("debug.dailyActivity");
-            const next =
-              cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
-            if (next) localStorage.setItem("debug.dailyActivity", next);
-            else localStorage.removeItem("debug.dailyActivity");
-            location.reload();
-          }}
-          title="replace → merge → off 순환"
-        >
-          [dev] activity debug toggle
-        </button>
+        <div className="ml-auto flex items-center gap-3">
+          <button
+            className="text-xs text-gray-500 underline"
+            onClick={() => {
+              const cur = localStorage.getItem("debug.dailyActivity");
+              const next =
+                cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
+              if (next) localStorage.setItem("debug.dailyActivity", next);
+              else localStorage.removeItem("debug.dailyActivity");
+              location.reload();
+            }}
+            title="activity: replace → merge → off"
+          >
+            [dev] activity debug
+          </button>
+
+          <button
+            className="text-xs text-gray-500 underline"
+            onClick={() => {
+              const cur = localStorage.getItem("debug.errorTags");
+              const next =
+                cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
+              if (next) localStorage.setItem("debug.errorTags", next);
+              else localStorage.removeItem("debug.errorTags");
+              location.reload();
+            }}
+            title="errorTags: replace → merge → off"
+          >
+            [dev] error tags debug
+          </button>
+        </div>
       )}
 
       {/* 트러블로그 활동 */}
@@ -51,7 +75,22 @@ const StatisticsPage = () => {
       )}
 
       {/* 에러 종류 분석 */}
-      <ErrorCategoryPieChart {...mockErrorCategoryData} />
+      {errLoading ? (
+        <div className="flex flex-col w-full p-[36px] h-[412px] rounded-[16px] bg-white shadow-card">
+          <div className="h-6 w-48 bg-gray-200 rounded mb-2" />
+          <div className="h-4 w-80 bg-gray-100 rounded mb-6" />
+          <div className="h-[260px] w-full bg-gray-100 rounded" />
+        </div>
+      ) : errError ? (
+        <div className="flex flex-col w-full p-[36px] h-[412px] rounded-[16px] bg-white shadow-card">
+          <span className="text-red-600">
+            에러 태그 통계를 불러오지 못했습니다.
+          </span>
+          <span className="text-gray-500 text-sm mt-1">{errError}</span>
+        </div>
+      ) : (
+        <ErrorCategoryPieChart labels={errLabels} data={errData} />
+      )}
 
       <div className="flex items-center gap-[24px] self-stretch">
         {/* 내 태그 분석 */}

--- a/src/pages/MyPage/StatisticsPage.tsx
+++ b/src/pages/MyPage/StatisticsPage.tsx
@@ -2,6 +2,7 @@ import ErrorCategoryPieChart from "@/components/MyPage/ErrorCategoryPieChart";
 import SummaryTypeBarChart from "@/components/MyPage/SummaryTypeBarChart";
 import TagBubbleChart from "@/components/MyPage/TagBubbleChart";
 import TroublogActivityChart from "@/components/MyPage/TroublogActivityChart";
+import { useDailyActivityMap } from "@/hooks/useDailyActivityMap";
 import {
   mockErrorCategoryData,
   mockSummaryTypeData,
@@ -9,10 +10,45 @@ import {
 } from "@/mocks/mockStatisticsData";
 
 const StatisticsPage = () => {
+  const year = new Date().getFullYear();
+  const { loading, error, activityMap } = useDailyActivityMap(year);
+
   return (
     <div className="flex w-[948px] flex-col items-start gap-[56px] pb-[349px]">
+      {import.meta.env.DEV && (
+        <button
+          className="ml-auto text-xs text-gray-500 underline"
+          onClick={() => {
+            const cur = localStorage.getItem("debug.dailyActivity");
+            const next =
+              cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
+            if (next) localStorage.setItem("debug.dailyActivity", next);
+            else localStorage.removeItem("debug.dailyActivity");
+            location.reload();
+          }}
+          title="replace → merge → off 순환"
+        >
+          [dev] activity debug toggle
+        </button>
+      )}
+
       {/* 트러블로그 활동 */}
-      <TroublogActivityChart />
+      {loading ? (
+        <div className="flex flex-col p-[36px] w-full h-[328px] rounded-[16px] bg-white shadow-card">
+          <div className="h-6 w-48 bg-gray-200 rounded mb-2" />
+          <div className="h-4 w-80 bg-gray-100 rounded mb-4" />
+          <div className="h-[180px] w-full bg-gray-100 rounded" />
+        </div>
+      ) : error ? (
+        <div className="flex flex-col p-[36px] w-full h-[328px] rounded-[16px] bg-white shadow-card">
+          <span className="text-red-600">
+            일일 활동 통계를 불러오지 못했습니다.
+          </span>
+          <span className="text-gray-500 text-sm mt-1">{error}</span>
+        </div>
+      ) : (
+        <TroublogActivityChart activityData={activityMap} />
+      )}
 
       {/* 에러 종류 분석 */}
       <ErrorCategoryPieChart {...mockErrorCategoryData} />

--- a/src/pages/MyPage/StatisticsPage.tsx
+++ b/src/pages/MyPage/StatisticsPage.tsx
@@ -5,7 +5,7 @@ import TroublogActivityChart from "@/components/MyPage/TroublogActivityChart";
 import { useDailyActivityMap } from "@/hooks/useDailyActivityMap";
 import { useErrorTagsTop3 } from "@/hooks/useErrorTagsTop3";
 import { useSummaryTypes } from "@/hooks/useSummaryTypes";
-import { mockTagBubbleData } from "@/mocks/mockStatisticsData";
+import { useTechTagsTop5 } from "@/hooks/useTechTagsTop5";
 
 const StatisticsPage = () => {
   const year = new Date().getFullYear();
@@ -21,6 +21,11 @@ const StatisticsPage = () => {
     error: sumError,
     summaryData,
   } = useSummaryTypes();
+  const {
+    loading: tagLoading,
+    error: tagError,
+    bubbleData,
+  } = useTechTagsTop5();
 
   return (
     <div className="flex w-[948px] flex-col items-start gap-[56px] pb-[349px]">
@@ -71,6 +76,21 @@ const StatisticsPage = () => {
           >
             [dev] summary types debug
           </button>
+
+          <button
+            className="text-xs text-gray-500 underline"
+            onClick={() => {
+              const cur = localStorage.getItem("debug.techTags");
+              const next =
+                cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
+              if (next) localStorage.setItem("debug.techTags", next);
+              else localStorage.removeItem("debug.techTags");
+              location.reload();
+            }}
+            title="techTags: replace → merge → off"
+          >
+            [dev] tech tags debug
+          </button>
         </div>
       )}
 
@@ -112,7 +132,29 @@ const StatisticsPage = () => {
 
       <div className="flex items-center gap-[24px] self-stretch">
         {/* 내 태그 분석 */}
-        <TagBubbleChart bubbleData={mockTagBubbleData} />
+        {tagLoading ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <div className="h-6 w-48 bg-gray-200 rounded mb-2" />
+            <div className="h-4 w-80 bg-gray-100 rounded mb-6" />
+            <div className="h-[260px] w-full bg-gray-100 rounded" />
+          </div>
+        ) : tagError ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <span className="text-red-600">
+              기술 태그 통계를 불러오지 못했습니다.
+            </span>
+            <span className="text-gray-500 text-sm mt-1">{tagError}</span>
+          </div>
+        ) : bubbleData.length === 0 ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <span className="text-head-24-bold">내 태그 분석</span>
+            <span className="text-body-18-regular mt-1">
+              아직 기술 태그가 없어요.
+            </span>
+          </div>
+        ) : (
+          <TagBubbleChart bubbleData={bubbleData} />
+        )}
 
         {/* 내 요약본 종류 */}
         {sumLoading ? (

--- a/src/pages/MyPage/StatisticsPage.tsx
+++ b/src/pages/MyPage/StatisticsPage.tsx
@@ -4,10 +4,8 @@ import TagBubbleChart from "@/components/MyPage/TagBubbleChart";
 import TroublogActivityChart from "@/components/MyPage/TroublogActivityChart";
 import { useDailyActivityMap } from "@/hooks/useDailyActivityMap";
 import { useErrorTagsTop3 } from "@/hooks/useErrorTagsTop3";
-import {
-  mockSummaryTypeData,
-  mockTagBubbleData,
-} from "@/mocks/mockStatisticsData";
+import { useSummaryTypes } from "@/hooks/useSummaryTypes";
+import { mockTagBubbleData } from "@/mocks/mockStatisticsData";
 
 const StatisticsPage = () => {
   const year = new Date().getFullYear();
@@ -18,6 +16,11 @@ const StatisticsPage = () => {
     labels: errLabels,
     data: errData,
   } = useErrorTagsTop3();
+  const {
+    loading: sumLoading,
+    error: sumError,
+    summaryData,
+  } = useSummaryTypes();
 
   return (
     <div className="flex w-[948px] flex-col items-start gap-[56px] pb-[349px]">
@@ -52,6 +55,21 @@ const StatisticsPage = () => {
             title="errorTags: replace → merge → off"
           >
             [dev] error tags debug
+          </button>
+
+          <button
+            className="text-xs text-gray-500 underline"
+            onClick={() => {
+              const cur = localStorage.getItem("debug.summaryTypes");
+              const next =
+                cur === "replace" ? "merge" : cur === "merge" ? "" : "replace";
+              if (next) localStorage.setItem("debug.summaryTypes", next);
+              else localStorage.removeItem("debug.summaryTypes");
+              location.reload();
+            }}
+            title="summaryTypes: replace → merge → off"
+          >
+            [dev] summary types debug
           </button>
         </div>
       )}
@@ -97,7 +115,29 @@ const StatisticsPage = () => {
         <TagBubbleChart bubbleData={mockTagBubbleData} />
 
         {/* 내 요약본 종류 */}
-        <SummaryTypeBarChart summaryData={mockSummaryTypeData} />
+        {sumLoading ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <div className="h-6 w-48 bg-gray-200 rounded mb-2" />
+            <div className="h-4 w-80 bg-gray-100 rounded mb-6" />
+            <div className="h-[260px] w-full bg-gray-100 rounded" />
+          </div>
+        ) : sumError ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <span className="text-red-600">
+              요약본 통계를 불러오지 못했습니다.
+            </span>
+            <span className="text-gray-500 text-sm mt-1">{sumError}</span>
+          </div>
+        ) : summaryData.length === 0 ? (
+          <div className="flex flex-col p-[36px] w-[462px] h-[412px] rounded-[16px] bg-white shadow-card">
+            <span className="text-head-24-bold">내 요약본 종류</span>
+            <span className="text-body-18-regular mt-1">
+              아직 생성한 요약본이 없어요.
+            </span>
+          </div>
+        ) : (
+          <SummaryTypeBarChart summaryData={summaryData} />
+        )}
       </div>
     </div>
   );

--- a/src/types/statistics.model.ts
+++ b/src/types/statistics.model.ts
@@ -10,4 +10,9 @@ export interface ErrorTagStat {
   count: number;
 }
 
+export interface SummaryTypeStat {
+  name: string;
+  count: number;
+}
+
 export type GetDailyStatsResponse = ApiEnvelope<DailyStat[]>;

--- a/src/types/statistics.model.ts
+++ b/src/types/statistics.model.ts
@@ -1,0 +1,8 @@
+import type { ApiEnvelope } from "./common.model";
+
+export interface DailyStat {
+  date: string;
+  count: number;
+}
+
+export type GetDailyStatsResponse = ApiEnvelope<DailyStat[]>;

--- a/src/types/statistics.model.ts
+++ b/src/types/statistics.model.ts
@@ -15,4 +15,9 @@ export interface SummaryTypeStat {
   count: number;
 }
 
+export interface TechTagStat {
+  name: string;
+  count: number;
+}
+
 export type GetDailyStatsResponse = ApiEnvelope<DailyStat[]>;

--- a/src/types/statistics.model.ts
+++ b/src/types/statistics.model.ts
@@ -5,4 +5,9 @@ export interface DailyStat {
   count: number;
 }
 
+export interface ErrorTagStat {
+  name: string;
+  count: number;
+}
+
 export type GetDailyStatsResponse = ApiEnvelope<DailyStat[]>;

--- a/src/utils/activityMap.ts
+++ b/src/utils/activityMap.ts
@@ -1,0 +1,67 @@
+import {
+  eachDayOfInterval,
+  startOfYear,
+  endOfYear,
+  format,
+  isAfter,
+} from "date-fns";
+import type { DailyStat } from "@/types/statistics.model";
+
+// 현재 연도에 랜덤 활동을 심는 디버그용 더미
+export function makeDebugDailyStats(
+  year = new Date().getFullYear(),
+  density = 0.45 // 활동 있는 날 비율
+): DailyStat[] {
+  const start = startOfYear(new Date(year, 0, 1));
+  const end = endOfYear(new Date(year, 11, 31));
+  const today = new Date();
+  const endClamp = isAfter(end, today) ? today : end;
+
+  const days = eachDayOfInterval({ start, end: endClamp });
+  const out: DailyStat[] = [];
+
+  for (const d of days) {
+    // density 확률로 활동 발생, count는 1~4 랜덤
+    if (Math.random() < density) {
+      out.push({
+        date: format(d, "yyyy-MM-dd"),
+        count: 1 + Math.floor(Math.random() * 4),
+      });
+    }
+  }
+
+  return out;
+}
+
+// 특정 연도 전체 날짜 키 맵을 0으로 채워서 생성
+export function buildYearZeroMap(
+  year = new Date().getFullYear()
+): Record<string, number> {
+  const start = startOfYear(new Date(year, 0, 1));
+  const end = endOfYear(new Date(year, 11, 31));
+  const days = eachDayOfInterval({ start, end });
+
+  const map: Record<string, number> = {};
+  for (const d of days) {
+    const key = format(d, "yyyy-MM-dd"); // 로컬(KST) 기준
+    map[key] = 0;
+  }
+  return map;
+}
+
+// 서버 응답을 연간 0맵에 덮어씌움 (중복 날짜는 합산 처리)
+export function mergeDailyStatsToYearMap(
+  stats: DailyStat[] | null | undefined,
+  year = new Date().getFullYear()
+): Record<string, number> {
+  const map = buildYearZeroMap(year);
+  if (!stats || stats.length === 0) return map;
+
+  for (const { date, count } of stats) {
+    // 응답에 범위 밖(다른 연도) 날짜가 섞여 올 수 있으니 필터
+    if (date.startsWith(String(year))) {
+      map[date] = (map[date] ?? 0) + (count ?? 0);
+    }
+  }
+  return map;
+}

--- a/src/utils/dailyStats.ts
+++ b/src/utils/dailyStats.ts
@@ -1,0 +1,43 @@
+import type { DailyStat } from "@/types/statistics.model";
+
+// 서울 기준 오늘 날짜(YYYY-MM-DD)
+export function todaySeoul(): string {
+  const now = new Date();
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  return kst.toISOString().slice(0, 10);
+}
+
+// "YYYY-MM-DD" 형식에서 days 만큼 과거로 이동
+function shiftDate(dateStr: string, days: number): string {
+  // 00:00:00+09:00로 고정 파싱 → 오프바이원 방지
+  const d = new Date(`${dateStr}T00:00:00+09:00`);
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+// end 포함, 과거 n일 범위 날짜 배열(오름차순)
+export function makeDateRange(end: string, days: number): string[] {
+  const out: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    out.push(shiftDate(end, i));
+  }
+  return out;
+}
+
+// 서버가 1회 이상만 내려줄 때를 대비해 누락 날짜를 0으로 메움
+export function normalizeDailyStats(
+  raw: DailyStat[] | undefined,
+  rangeDays = 14,
+  endDate = todaySeoul()
+): DailyStat[] {
+  const range = makeDateRange(endDate, rangeDays);
+  const map = new Map<string, number>();
+  range.forEach((d) => map.set(d, 0));
+
+  (raw ?? []).forEach(({ date, count }) => {
+    // 중복 날짜가 온다면 합산
+    map.set(date, (map.get(date) ?? 0) + (count ?? 0));
+  });
+
+  return range.map((d) => ({ date: d, count: map.get(d) ?? 0 }));
+}

--- a/src/utils/errorTagStats.ts
+++ b/src/utils/errorTagStats.ts
@@ -1,0 +1,31 @@
+import type { ErrorTagStat } from "@/types/statistics.model";
+
+// 디버그용 더미(랜덤)
+export function makeDebugErrorTags(): ErrorTagStat[] {
+  const pool = [
+    "빌드 오류",
+    "네트워크",
+    "상태관리",
+    "타입스크립트",
+    "의존성/버전",
+    "렌더링 성능",
+  ];
+  const n = 3 + Math.floor(Math.random() * 3); // 3~5개
+  const shuffled = [...pool].sort(() => Math.random() - 0.5).slice(0, n);
+  return shuffled.map((name, i) => ({
+    name,
+    count: 2 + Math.floor(Math.random() * (10 - i * 2)),
+  }));
+}
+
+// 동일 name끼리 count 합산
+export function mergeErrorTagStats(
+  a: ErrorTagStat[],
+  b: ErrorTagStat[]
+): ErrorTagStat[] {
+  const map = new Map<string, number>();
+  for (const x of [...a, ...b]) {
+    map.set(x.name, (map.get(x.name) ?? 0) + (x.count ?? 0));
+  }
+  return [...map.entries()].map(([name, count]) => ({ name, count }));
+}

--- a/src/utils/summaryTypes.ts
+++ b/src/utils/summaryTypes.ts
@@ -1,0 +1,24 @@
+import type { SummaryTypeStat } from "@/types/statistics.model";
+
+const CANDIDATES = ["자기소개서", "면접대비", "블로그", "이슈관리"];
+
+export function makeDebugSummaryTypes(): SummaryTypeStat[] {
+  // 2~4개 랜덤 선택 + 랜덤 카운트
+  const n = 2 + Math.floor(Math.random() * 3);
+  const picked = [...CANDIDATES].sort(() => Math.random() - 0.5).slice(0, n);
+  return picked.map((name, i) => ({
+    name,
+    count: 2 + Math.floor(Math.random() * (10 - i)),
+  }));
+}
+
+export function mergeSummaryTypeStats(
+  a: SummaryTypeStat[],
+  b: SummaryTypeStat[]
+): SummaryTypeStat[] {
+  const map = new Map<string, number>();
+  [...a, ...b].forEach(({ name, count }) => {
+    map.set(name, (map.get(name) ?? 0) + (count ?? 0));
+  });
+  return [...map.entries()].map(([name, count]) => ({ name, count }));
+}

--- a/src/utils/techTags.ts
+++ b/src/utils/techTags.ts
@@ -1,0 +1,50 @@
+import type { TechTagStat } from "@/types/statistics.model";
+
+const PALETTE = ["#9C4FFF", "#FFDC69", "#D5A7FF", "#FFEFB0", "#E8C6FF"];
+
+export function makeDebugTechTags(len?: number): TechTagStat[] {
+  const pool = [
+    "React",
+    "TypeScript",
+    "Flutter",
+    "GetX",
+    "Zustand",
+    "Axios",
+    "Vite",
+    "Tailwind",
+    "Node.js",
+    "NestJS",
+    "AWS",
+  ];
+  const n = len ?? 5 + Math.floor(Math.random() * 3); // 기본 5~7개
+  const picked = [...pool].sort(() => Math.random() - 0.5).slice(0, n);
+  return picked.map((name, i) => ({
+    name,
+    count: 6 + Math.floor(Math.random() * (28 - i * 3)),
+  }));
+}
+
+// 동일 name을 합산
+export function mergeTechTagStats(
+  a: TechTagStat[],
+  b: TechTagStat[]
+): TechTagStat[] {
+  const m = new Map<string, number>();
+  for (const x of [...a, ...b]) {
+    m.set(x.name, (m.get(x.name) ?? 0) + (x.count ?? 0));
+  }
+  return [...m.entries()].map(([name, count]) => ({ name, count }));
+}
+
+// 차트 props로 변환 + Top5 보정 + 색 부여
+export function toBubbleData(stats: TechTagStat[]) {
+  const sorted = stats
+    .slice()
+    .sort((x, y) => y.count - x.count)
+    .slice(0, 5);
+  return sorted.map((s, i) => ({
+    label: s.name,
+    count: s.count,
+    color: PALETTE[i % PALETTE.length],
+  }));
+}


### PR DESCRIPTION
## 🔥 Issues

- closed #66 

## ✅ What to do

- [x] 일일 트러블로그 활동 통계 조회 API 연동
- [x] 에러 태그별 통계 API 연동
- [x] 요약본 종류 통계 API 연동
- [x] 기술 태그별 통계 API 연동
- [x] 전체 트러블슈팅 목록 조회 API url 수정
- [x] 통계 시각화 부분 UI 일부 수정

## 📄 Description

- `statistics.api` - API 호출 함수
- `useDailyActivityMap`, `useErrorTagsTop3`, `useSummaryType`, `useTechTagsTop5` - UI 컴포넌트와의 연동을 위한 훅 (디버그 모드를 설정하여 localStorage를 통해 더미데이터로 활동 데이터를 삽입할 수 있도록 함)
- `statistics.model` - API 응답 데이터 타입 정의
- `activityMap`, `dailyStats`, `errorTagStats`, `summaryTypes`, `techTags`- 디버그용 더미데이터 추가 및 연동 관련 유틸 함수 포함
---
- `StatisticsPage`
  - **실제 활동 데이터가 부족한 상황에서 테스트를 위해 개발 환경에서만 mock 데이터를 포함한 데이터가 화면에 보여질 수 있도록 디버깅 플래그를 화면 상단에 텍스트 토글 버튼으로 추가하였습니다.(클릭 시마다 '더미데이터 -> 더미 + 실제 -> 실제 데이터'로 보여짐)**
  - 로딩 시 표시할 스켈레톤 UI 추가 및 훅 연동
- `TagBubbleChart` - 태그 아이템 개수(1~5)별 배치 고정 레이아웃 수정
---
- `trouble.api.ts`- 전체 트러블 슈팅 목록 조회 api url 수정 (`troubles/list` -> 'troubles/my/list`)

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

<img width="1934" height="2190" alt="image" src="https://github.com/user-attachments/assets/f8a93fbf-828f-4caa-b0c0-e82d92778b10" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 마이페이지 통계가 실데이터로 표시됩니다: 일간 활동, 에러 태그 Top3, 요약 유형, 기술 태그 Top5 시각화 및 로딩/오류/빈 상태 처리 추가
- **Bug Fixes**
  - 내 트러블 목록 경로를 수정해 개인 목록이 올바르게 표시되도록 개선
- **Style**
  - 막대 차트 문구를 “을(를)”로 자연스럽게 수정
- **Refactor**
  - 태그 버블 차트를 순위 기반 고정 레이아웃으로 변경해 가독성·일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->