### PR TITLE
FEAT: 유저 api 작업 일부

### DIFF
--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -1,6 +1,7 @@
 import type {
   FollowingData,
   ProfileData,
+  UpdatedProfileData,
   UserInfoData,
 } from "@/models/user.model";
 import getAPIResponseData from "../utils/getAPIResponseData";
@@ -20,7 +21,7 @@ export const getUserInfo = (userId: number) =>
   });
 
 // 프로필 수정
-export const patchProfile = (updatedProfile: ProfileData) =>
+export const patchProfile = (updatedProfile: UpdatedProfileData) =>
   getAPIResponseData({
     url: "/user",
     method: "PATCH",

--- a/src/components/MyPage/MyInput.tsx
+++ b/src/components/MyPage/MyInput.tsx
@@ -12,7 +12,7 @@ const MyInput = ({ label, placeholder, value, onChange }: MyInputProps) => {
       <input
         className="flex h-14 py-[19px] px-[15px] items-center self-stretch rounded-lg border border-gray1 w-full"
         placeholder={placeholder}
-        value={value}
+        value={value ?? ""}
         onChange={onChange}
       />
     </div>

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useLocation, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
 import FollowButton from "@/components/Button/FollowButton";
 import { useMyPageStore } from "@/store/useMyPageStore";
 import type { StatusType } from "@/types/project";
@@ -8,6 +9,8 @@ import userIcon from "@/assets/icons/user.svg";
 import circleYIcon from "@/assets/icons/circle_y.svg";
 import circleGIcon from "@/assets/icons/circle_g.svg";
 import circleBIcon from "@/assets/icons/circle_b.svg";
+import { getUserInfo } from "@/api/user.api"; // 사용자 정보 조회 API import
+import type { UserInfoData } from "@/models/user.model";
 
 type MyPageSideBarProps =
   | {
@@ -24,13 +27,6 @@ type MyPageSideBarProps =
       sortedTags: [string, number][];
     };
 
-const mockProfile = {
-  name: "안수이",
-  followingCount: 8,
-  followerCount: 6,
-  bio: "안녕하세요. 프론트엔드 개발자입니다!",
-};
-
 const MyPageSideBar = (props: MyPageSideBarProps) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -39,8 +35,23 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     useMyPageStore();
   const { selectedTag, setSelectedTag, resetSelectedTag } = useMyPageStore();
 
+  const [userInfo, setUserInfo] = useState<UserInfoData | null>(null);
+
   const basePath = PATH.MYPAGE(id!);
   const isOnMainPage = location.pathname === basePath;
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchUserInfo = async () => {
+      try {
+        const data = await getUserInfo(Number(id));
+        setUserInfo(data);
+      } catch (error) {
+        console.error("사용자 정보 불러오기 실패:", error);
+      }
+    };
+    fetchUserInfo();
+  }, [id]);
 
   const handleNavigate =
     (subPath: string = "", clearStatus = false) =>
@@ -72,22 +83,26 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     <div className="flex w-[296px] flex-col items-start gap-[140px]">
       {/* 상단 프로필 영역 */}
       <div className="flex flex-col items-center gap-3 self-stretch">
-        <img src={userIcon} alt="user" className="w-[288px] h-[288px]" />
+        <img
+          src={userInfo?.profileUrl || userIcon}
+          alt="user"
+          className="w-[288px] h-[288px]"
+        />
         <div className="flex flex-col items-start gap-3">
           <div className="flex flex-col items-start gap-2">
-            <p className="text-head-32-semibold">{mockProfile.name}</p>
+            <p className="text-head-32-semibold">{userInfo?.nickname}</p>
 
             <div className="flex gap-1 text-body-20-regular text-gray4">
               <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWING)}>
-                팔로잉 {mockProfile.followingCount}
+                팔로잉 {userInfo?.followingNum}
               </button>
               <span>·</span>
               <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWER)}>
-                팔로워 {mockProfile.followerCount}
+                팔로워 {userInfo?.followerNum}
               </button>
             </div>
 
-            <p className="text-body-20-regular pt-4 pb-1">{mockProfile.bio}</p>
+            <p className="text-body-20-regular pt-4 pb-1">{userInfo?.bio}</p>
 
             {props.isMyPage ? (
               <FollowButton
@@ -198,6 +213,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
         <div className="flex flex-col items-start gap-[12px] self-stretch">
           <div className="w-full">
             {/* 헤더 텍스트 */}
+
             <div className="flex flex-col items-start gap-[12px]">
               <span className="text-head-20-semibold">태그 분석</span>
               <div className="w-full h-[1px] bg-[#939393]" />

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -6,12 +6,20 @@ export interface ProfileData {
   githubUrl: string;
 }
 
-export interface UserInfoData {
+export interface UpdatedProfileData {
   userId: number;
   nickname: string;
   field: string;
   bio: string;
   githubUrl: string;
+  profileUrl: string;
+}
+
+export interface UserInfoData {
+  userId: number;
+  nickname: string;
+  profileUrl: string;
+  bio: string;
   followerNum: number;
   followingNum: number;
 }

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -7,32 +7,43 @@ import FollowButton from "@/components/Button/FollowButton";
 import { useNavigate, useParams } from "react-router-dom";
 import ConfirmDeleteModal from "@/components/Modal/ConfirmDeleteModal";
 import WithdrawCompleteModal from "@/components/Modal/WithdrawCompleteModal";
-import type { ProfileData } from "@/models/user.model";
+import type { ProfileData, UpdatedProfileData } from "@/models/user.model";
 import { deleteUser, getMyProfile, patchProfile } from "@/api/user.api";
 import { PATH } from "@/constants/paths";
 import userIcon from "@/assets/icons/user.svg";
+import useImageUpload from "@/utils/useImageUpload";
 
 const EditProfile = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const [profile, setProfile] = useState<ProfileData>({
+  const { upload } = useImageUpload();
+
+  const [profile, setProfile] = useState<UpdatedProfileData>({
     userId: 0,
     nickname: "",
     field: "",
     bio: "",
     githubUrl: "",
+    profileUrl: "",
   });
 
-  //프로필 사진 변경
+  // 프로필 이미지 미리보기
   const [profileImage, setProfileImage] = useState<string>(userIcon);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
   const handleImageUpload = () => {
     fileInputRef.current?.click();
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
+    if (!file) return;
+
+    try {
+      // 서버 업로드
+      const uploadedUrl = await upload(file);
+
+      // UI 미리보기
       const reader = new FileReader();
       reader.onloadend = () => {
         if (typeof reader.result === "string") {
@@ -40,13 +51,25 @@ const EditProfile = () => {
         }
       };
       reader.readAsDataURL(file);
+
+      // 프로필 state에 서버 URL 저장
+      setProfile((prev) => ({
+        ...prev,
+        profileUrl: uploadedUrl,
+      }));
+    } catch (err) {
+      console.error("이미지 업로드 실패", err);
     }
   };
 
   const handleImageDelete = () => {
     setProfileImage(userIcon);
+    setProfile((prev) => ({
+      ...prev,
+      profileUrl: "",
+    }));
     if (fileInputRef.current) {
-      fileInputRef.current.value = ""; // input 초기화
+      fileInputRef.current.value = "";
     }
   };
 
@@ -74,11 +97,19 @@ const EditProfile = () => {
     navigate("/");
   }, [navigate]);
 
-  /* useEffect(() => {
+  // 프로필 불러오기
+  useEffect(() => {
     const fetchProfile = async () => {
       try {
         const data = await getMyProfile();
-        setProfile(data);
+        setProfile({
+          userId: data.userId,
+          nickname: data.nickname,
+          field: data.field,
+          bio: data.bio,
+          githubUrl: data.githubUrl,
+          profileUrl: "",
+        });
       } catch (error) {
         console.error("정보를 불러오는 데 실패했습니다", error);
       }
@@ -86,20 +117,7 @@ const EditProfile = () => {
 
     fetchProfile();
   }, []);
-*/
 
-  useEffect(() => {
-    const mockData = {
-      userId: 0,
-      nickname: "안수이",
-      field: "관심분야 1",
-      bio: "안녕하세요. 프론트엔드 개발자입니다!",
-      githubUrl: "ddd@gmail.com",
-    };
-    setProfile(mockData);
-  }, []);
-
-  // 프로필 수정 완료
   const handleChange =
     (field: keyof ProfileData) => (e: React.ChangeEvent<HTMLInputElement>) => {
       setProfile((prev) => ({
@@ -108,7 +126,17 @@ const EditProfile = () => {
       }));
     };
 
+  // 저장
   const handleSave = async () => {
+    const nickname = profile.nickname?.trim() || "";
+    const field = profile.field?.trim() || "";
+    const bio = profile.bio?.trim() || "";
+
+    if (!nickname || !field || !bio) {
+      alert("닉네임, 분야, 한 줄 소개는 필수 입력 항목입니다.");
+      return;
+    }
+
     try {
       await patchProfile(profile);
       navigate(PATH.MYPAGE(id!));
@@ -117,6 +145,7 @@ const EditProfile = () => {
     }
   };
 
+  // 취소
   const handleCancel = () => {
     navigate(-1);
   };
@@ -185,7 +214,7 @@ const EditProfile = () => {
           </div>
         </div>
 
-        {/* 버튼 영역 */}
+        {/* 버튼 */}
         <div className="flex gap-4">
           <CancelButton onClick={handleCancel} />
           <SaveButton onClick={handleSave} label="저장" />


### PR DESCRIPTION
## 🔥 Issues

#39 

## ✅ What to do

- [x] 회원 탈퇴 구현
- [x] 내 프로필 조회 구현 (프로필 수정 페이지)
- [x] 사용자 정보 조회 구현 (프로필 사이드 바)

## 📄 Description

<img width="252" height="368" alt="image" src="https://github.com/user-attachments/assets/17fc1411-6527-4e58-a99a-cb1474a16b6c" />
<img width="903" height="523" alt="image" src="https://github.com/user-attachments/assets/0a93dae0-6d63-4813-8031-4924ca752f99" />

## 🛠️ Improvements to Make
- 팔로우/언팔로우 - 아직 확인 X.
- 프로필 수정 - 사진 업로드 api 백에서 해결하면 다시 확인해보기
- 프로필 조회 - 회원가입 시 전부 입력하면 field가 안 채워짐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 프로필 이미지 업로드/미리보기/삭제 지원. 저장 시 서버 URL로 반영.
  - 마이페이지 사이드바가 실제 사용자 데이터(닉네임, 프로필 이미지, 팔로워/팔로잉, 소개)로 표시.
  - 프로필 수정 시 필수 항목 공백 방지로 저장 흐름 개선.

- 버그 수정
  - 입력 컴포넌트가 값이 없을 때도 제어 컴포넌트로 유지되어 경고 및 UI 깨짐 방지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->