### PR TITLE
FIX: 커뮤니티 관련 에러 해결 및 리팩토링

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import UserMenuDropdown from "../Menu/UserMenuDropdown";
 import NotificationModal from "../Modal/NotificationModal";
 import { PATH } from "@/constants/paths";
 import logo from "@/assets/icons/logo.svg";
+import { useViewerId } from "@/store/auth";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -21,18 +22,9 @@ const Header = () => {
   const userDropdownRef = useClickOutside(() => setIsUserDropdownOpen(false));
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 로그인 후 저장된 userId 사용
-  const [myUserId, setMyUserId] = useState<string | null>(null);
-  useEffect(() => {
-    // 초기 로드
-    setMyUserId(localStorage.getItem("userId"));
-    // 다른 탭에서 로그인/로그아웃 시 동기화
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === "userId") setMyUserId(e.newValue);
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
-  }, []);
+  // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
+  const viewerId = useViewerId();
+  const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
   const handleMouseEnter = () => {
     if (timeoutRef.current) {
@@ -76,7 +68,7 @@ const Header = () => {
     const pageUserId = mypageMatch?.[1];
 
     if (path.startsWith(PATH.MYPAGE(""))) {
-      if (pageUserId && myUserId && pageUserId === myUserId) {
+      if (pageUserId && myUserIdStr && pageUserId === myUserIdStr) {
         setPlaceholder(
           "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
         );
@@ -97,7 +89,7 @@ const Header = () => {
         "키워드나 태그 등의 검색어를 통해 다른 사람들의 트러블슈팅을 검색해보세요!"
       );
     }
-  }, [location.pathname, setPlaceholder, myUserId]);
+  }, [location.pathname, setPlaceholder, myUserIdStr]);
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
@@ -128,7 +120,7 @@ const Header = () => {
       pageUserId = mypageMatch?.[1] ?? "";
 
       if (currentPath.startsWith(PATH.MYPAGE(""))) {
-        scope = pageUserId === myUserId ? "mypage" : "user";
+        scope = pageUserId === myUserIdStr ? "mypage" : "user";
       } else if (
         currentPath.startsWith(PATH.HOME) ||
         currentPath.startsWith(PATH.PROJECT_DETAIL(""))
@@ -206,8 +198,8 @@ const Header = () => {
                 <UserMenuDropdown
                   onClose={() => setIsUserDropdownOpen(false)}
                   onNavigateToMyPage={() => {
-                    if (myUserId) {
-                      navigate(PATH.MYPAGE(myUserId));
+                    if (myUserIdStr) {
+                      navigate(PATH.MYPAGE(myUserIdStr));
                     } else {
                       // 미로그인/정보없음: 루트(또는 로그인)로 유도
                       navigate(PATH.ROOT);

--- a/src/components/Header/HeaderWoSearch.tsx
+++ b/src/components/Header/HeaderWoSearch.tsx
@@ -17,7 +17,7 @@ const HeaderWoSearch = () => {
   const userDropdownRef = useClickOutside(() => setIsUserDropdownOpen(false));
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const myUserId = "123"; // 실제 로그인한 사용자 ID로 대체 필요
+  const myUserId = localStorage.getItem("userId") || "";
 
   const handleMouseEnter = () => {
     if (timeoutRef.current) {

--- a/src/components/Header/HeaderWoSearch.tsx
+++ b/src/components/Header/HeaderWoSearch.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import useClickOutside from "@/hooks/useClickOutside";
 import NotificationModal from "../Modal/NotificationModal";
 import UserMenuDropdown from "../Menu/UserMenuDropdown";
+import { useViewerId } from "@/store/auth";
 
 const HeaderWoSearch = () => {
   const navigate = useNavigate();
@@ -17,7 +18,9 @@ const HeaderWoSearch = () => {
   const userDropdownRef = useClickOutside(() => setIsUserDropdownOpen(false));
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const myUserId = localStorage.getItem("userId") || "";
+  // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
+  const viewerId = useViewerId();
+  const myUserId = viewerId != null ? String(viewerId) : null;
 
   const handleMouseEnter = () => {
     if (timeoutRef.current) {
@@ -85,7 +88,7 @@ const HeaderWoSearch = () => {
               <UserMenuDropdown
                 onClose={() => setIsUserDropdownOpen(false)}
                 onNavigateToMyPage={() => {
-                  navigate(PATH.MYPAGE(myUserId));
+                  navigate(PATH.MYPAGE(String(myUserId)));
                   setIsUserDropdownOpen(false);
                 }}
               />

--- a/src/components/Header/HeaderWoSearch.tsx
+++ b/src/components/Header/HeaderWoSearch.tsx
@@ -4,7 +4,7 @@ import { FaUserCircle } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import logo from "@/assets/icons/logo.svg";
 import { PATH } from "@/constants/paths";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useClickOutside from "@/hooks/useClickOutside";
 import NotificationModal from "../Modal/NotificationModal";
 import UserMenuDropdown from "../Menu/UserMenuDropdown";
@@ -31,6 +31,15 @@ const HeaderWoSearch = () => {
       setIsNotificationModalOpen(false);
     }, 200);
   };
+
+  // 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="flex w-full py-[25px] px-[88px] gap-[10px] justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -60,8 +60,12 @@ const TroubleShootingList = () => {
 
   const sortedCards = statusFiltered;
 
-  const handleDeleted = () => {
-    void reload();
+  const handleDeleted = async () => {
+    try {
+      await reload();
+    } catch (error) {
+      console.error("Failed to reload after deletion:", error);
+    }
   };
 
   return (

--- a/src/hooks/useTroubleCards.ts
+++ b/src/hooks/useTroubleCards.ts
@@ -12,6 +12,7 @@ import type {
   ProjectTroubleQuery,
   TroubleListItem,
 } from "@/types/trouble.model";
+import { useViewerId } from "@/store/auth";
 
 // 내 전체 목록 정렬용 (서버 스펙)
 type SortParam = "latest" | "likes";
@@ -176,6 +177,9 @@ export default function useTroubleCards(source: Source, options: Options = {}) {
     requestedPagesRef.current = new Set();
   }, []);
 
+  const viewerId = useViewerId();
+  const myUserIdStr = viewerId != null ? String(viewerId) : null;
+
   // 소유자 플래그 오버라이드 헬퍼
   const applyOwnerFlag = useCallback(
     (vms: TroublogCardVM[]) => {
@@ -183,15 +187,14 @@ export default function useTroubleCards(source: Source, options: Options = {}) {
         return vms.map((x) => ({ ...x, isMine: true }));
       }
       if (source.type === "user") {
-        const myId =
-          typeof window !== "undefined" ? localStorage.getItem("userId") : null;
+        const myId = typeof window !== "undefined" ? myUserIdStr : null;
         const ownerIsMe =
           myId != null && String(source.userId) === String(myId);
         return vms.map((x) => ({ ...x, isMine: ownerIsMe }));
       }
       return vms;
     },
-    [source]
+    [source, myUserIdStr]
   );
 
   // 전체 목록: 특정 페이지 로드

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -3,11 +3,15 @@ import { Outlet } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import useTroubleCards from "@/hooks/useTroubleCards";
 import { useMemo, useState } from "react";
+import { useViewerId } from "@/store/auth";
 
 const MyPageLayout = () => {
   const { id } = useParams<{ id: string }>();
-  const myUserId =
-    typeof window !== "undefined" ? localStorage.getItem("userId") : null;
+
+  const viewerId = useViewerId();
+  const myUserIdStr = viewerId != null ? String(viewerId) : null;
+
+  const myUserId = typeof window !== "undefined" ? myUserIdStr : null;
   const isMyPage = !!myUserId && id === myUserId;
 
   // 정렬 상태

--- a/src/mappers/communityComment.mapper.ts
+++ b/src/mappers/communityComment.mapper.ts
@@ -11,15 +11,15 @@ const fmtYYMMDD = (iso: string) => {
   return `${yy}.${mm}.${dd}`;
 };
 
-const isMineByUserId = (userId?: number | null) => {
-  const me =
-    typeof window !== "undefined" ? localStorage.getItem("userId") : null;
-  return me != null && String(me) === String(userId ?? "");
-};
+const isMine = (
+  userId: number | null | undefined,
+  viewerId: number | string | null
+) => viewerId != null && String(viewerId) === String(userId ?? "");
 
 // 서버 댓글 -> 화면 댓글
 export const toPostComment = (
   c: CommunityCommentServerItem,
+  viewerId: number | string | null,
   override?: Partial<
     Pick<PostCommentProps, "isReply" | "parentId" | "name" | "profile">
   >
@@ -31,7 +31,7 @@ export const toPostComment = (
     profile: undefined,
     date: fmtYYMMDD(c.createdAt),
     content: c.content ?? "",
-    isMine: isMineByUserId(c.userId),
+    isMine: isMine(c.userId, viewerId),
     isReply: c.parentCommentId != null,
     parentId: c.parentCommentId != null ? String(c.parentCommentId) : undefined,
   };
@@ -41,11 +41,13 @@ export const toPostComment = (
 // 목록 매핑
 export const toPostComments = (
   list: CommunityCommentServerItem[],
+  viewerId: number | string | null,
   overrides?: Record<
     number,
     Partial<Pick<PostCommentProps, "isReply" | "parentId" | "name" | "profile">>
   >
-) => (list ?? []).map((c) => toPostComment(c, overrides?.[c.commentId]));
+) =>
+  (list ?? []).map((c) => toPostComment(c, viewerId, overrides?.[c.commentId]));
 
 // 낙관적(optimistic) 댓글/대댓글 생성용 헬퍼
 export const makeOptimisticComment = (args: {

--- a/src/mappers/communityComment.mapper.ts
+++ b/src/mappers/communityComment.mapper.ts
@@ -12,7 +12,8 @@ const fmtYYMMDD = (iso: string) => {
 };
 
 const isMineByUserId = (userId?: number | null) => {
-  const me = localStorage.getItem("userId");
+  const me =
+    typeof window !== "undefined" ? localStorage.getItem("userId") : null;
   return me != null && String(me) === String(userId ?? "");
 };
 

--- a/src/mappers/communityPostDetail.mapper.ts
+++ b/src/mappers/communityPostDetail.mapper.ts
@@ -10,15 +10,16 @@ const toYY = (d: string) => {
   return yyyy && mm && dd ? `${yyyy.slice(2)}.${mm}.${dd}` : d;
 };
 
-const isMineByUser = (author: CommunityUserInfoDetail) => {
-  const me = localStorage.getItem("userId");
-  return !!(me && String(author.userId) === String(me));
-};
+const isMineByUser = (
+  author: CommunityUserInfoDetail,
+  viewerId: number | string | null | undefined
+) => !!(viewerId != null && String(author.userId) === String(viewerId));
 
 export function toCommunityPostVM(
-  src: CommunityPostDetailServer
+  src: CommunityPostDetailServer,
+  viewerId: number | string | null
 ): CommunityPostDetailProps {
-  const isMine = isMineByUser(src.userInfoResDto);
+  const isMine = isMineByUser(src.userInfoResDto, viewerId);
   const sorted = [...(src.contents ?? [])].sort(
     (a, b) => a.sequence - b.sequence
   );

--- a/src/mappers/communityPostDetail.mapper.ts
+++ b/src/mappers/communityPostDetail.mapper.ts
@@ -30,6 +30,7 @@ export function toCommunityPostVM(
     tags: src.postTags ?? [],
     date: toYY(src.completedAt ?? ""),
     isMine,
+    authorId: src.userInfoResDto.userId ?? undefined,
     authorProfile: src.userInfoResDto.profileUrl ?? undefined,
     authorName: src.userInfoResDto.nickname ?? "",
     authorFollowers: src.userInfoResDto.followerNum ?? 0,

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -666,7 +666,7 @@ export default function CommunityPostDetail() {
             {cHasNext && postId && (
               <button
                 disabled={cLoading}
-                onClick={() => loadComments(Number(postId), cPage + 1)}
+                onClick={() => loadComments(Number(postId), cPage)}
                 className={`mt-4 px-6 py-2 rounded-full text-white ${
                   cLoading ? "bg-gray-300" : "bg-primary"
                 }`}

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -512,6 +512,9 @@ export default function CommunityPostDetail() {
                     <div
                       id={`section-${idx}`}
                       key={idx}
+                      ref={(el) => {
+                        sectionRefs.current[idx] = el;
+                      }}
                       className="scroll-mt-[200px]"
                     >
                       <PostGuideMd question={q} content={post.contents[idx]} />

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -30,6 +30,7 @@ import {
   toPostComment,
   toPostComments,
 } from "@/mappers/communityComment.mapper";
+import { useViewerId } from "@/store/auth";
 
 export interface CommunityPostDetailProps {
   errorType: string;
@@ -53,6 +54,9 @@ export interface CommunityPostDetailProps {
 export default function CommunityPostDetail() {
   const { postId } = useParams<{ postId: string }>(); // postId 불러오기
   const navigate = useNavigate();
+  // 중앙 상태의 로그인 사용자 ID
+  const viewerId = useViewerId();
+  const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
   const [loading, setLoading] = useState(true);
@@ -104,7 +108,7 @@ export default function CommunityPostDetail() {
     setCLoading(true);
     try {
       const resp = await getCommunityComments(id, page1, 10);
-      const mapped = toPostComments(resp.content);
+      const mapped = toPostComments(resp.content, viewerId);
 
       setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
 
@@ -150,7 +154,7 @@ export default function CommunityPostDetail() {
           return;
         }
 
-        const vm = toCommunityPostVM(data);
+        const vm = toCommunityPostVM(data, viewerId);
         setPost(vm);
         setIsLiked(vm.isLiked);
         setLikeCounts(vm.likeCounts);
@@ -168,7 +172,7 @@ export default function CommunityPostDetail() {
     return () => {
       cancelled = true;
     };
-  }, [postId]);
+  }, [postId, viewerId]);
 
   // 스크롤 감시
   useEffect(() => {
@@ -198,7 +202,7 @@ export default function CommunityPostDetail() {
   const handleProfileClick = () => {
     // 작성자 마이페이지로
     if (!post) return;
-    navigate(PATH.MYPAGE(localStorage.getItem("userId") || ""));
+    navigate(PATH.MYPAGE(myUserIdStr || ""));
   };
 
   // 포스트 좋아요 토글
@@ -275,7 +279,7 @@ export default function CommunityPostDetail() {
       const created = await createCommunityComment(Number(postId), {
         contents,
       });
-      const mapped = toPostComment(created, { isReply: false });
+      const mapped = toPostComment(created, viewerId, { isReply: false });
       setComments((prev) => {
         const i = prev.findIndex((c) => c.id === optimistic.id);
         if (i === -1) return [mapped, ...prev];
@@ -313,7 +317,10 @@ export default function CommunityPostDetail() {
       );
 
       // 백엔드에서 parentCommentId가 null로 올 수 있으므로 강제 보정
-      const mapped = toPostComment(created, { isReply: true, parentId });
+      const mapped = toPostComment(created, viewerId, {
+        isReply: true,
+        parentId,
+      });
       setComments((prev) => {
         const i = prev.findIndex((c) => c.id === optimistic.id);
         if (i === -1) return [...prev, mapped];
@@ -341,7 +348,7 @@ export default function CommunityPostDetail() {
         contents: newContent,
       });
 
-      const vm = toPostComment(updated);
+      const vm = toPostComment(updated, viewerId);
 
       // 목록 반영 (id 일치하는 아이템 교체)
       setComments((prev) =>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -38,6 +38,7 @@ export interface CommunityPostDetailProps {
   tags: string[];
   date: string;
   isMine: boolean;
+  authorId: number;
   authorProfile?: string;
   authorName: string;
   authorFollowers: number;
@@ -56,7 +57,6 @@ export default function CommunityPostDetail() {
   const navigate = useNavigate();
   // 중앙 상태의 로그인 사용자 ID
   const viewerId = useViewerId();
-  const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
   const [loading, setLoading] = useState(true);
@@ -202,7 +202,8 @@ export default function CommunityPostDetail() {
   const handleProfileClick = () => {
     // 작성자 마이페이지로
     if (!post) return;
-    navigate(PATH.MYPAGE(myUserIdStr || ""));
+    // post 객체에 작성자 userId가 있다면 사용, 없으면 API 응답 구조 확인 필요
+    navigate(PATH.MYPAGE(String(post.authorId) || ""));
   };
 
   // 포스트 좋아요 토글

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -332,7 +332,8 @@ export default function CommunityPostDetail() {
     } catch {
       // 실패 → 롤백
       setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      throw new Error("reply-failed");
+      // 에러 메시지를 표시하거나 로깅
+      console.error("대댓글 작성 실패");
     }
   };
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -5,6 +5,7 @@ import mockimg from "../../assets/images/mockimg.jpg";
 import KakaoLoginButton from "./KakaoLoginButton";
 import { postLogin } from "@/api/auth.api";
 import { PATH } from "@/constants/paths";
+import { useAuthStore } from "@/store/auth";
 
 const LoginPage = () => {
   const [email, setEmail] = useState("");
@@ -62,9 +63,13 @@ const LoginPage = () => {
     try {
       const data = await postLogin(email, password);
       localStorage.setItem("accessToken", data.accessToken);
-      if (data.userId != null) {
-        localStorage.setItem("userId", String(data.userId));
-      }
+
+      // 중앙 상태에 사용자 정보 저장
+      const { setUser } = useAuthStore.getState();
+      if (data.userId == null) throw new Error("userId가 없습니다.");
+      setUser({
+        userId: data.userId,
+      });
 
       // next 또는 홈으로 이동
       const params = new URLSearchParams(location.search);

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -32,8 +32,10 @@ export default function ProjectDetailPage() {
     !location.state?.projectName && !isInvalid
   );
 
+  const hasProjectName = Boolean(location.state?.projectName);
+
   useEffect(() => {
-    if (isInvalid || location.state?.projectName) return;
+    if (isInvalid || hasProjectName) return;
     (async () => {
       try {
         setTitleLoading(true);
@@ -46,7 +48,7 @@ export default function ProjectDetailPage() {
         setTitleLoading(false);
       }
     })();
-  }, [projectId, isInvalid, location.state?.projectName]);
+  }, [projectId, isInvalid, hasProjectName]);
 
   // UI 필터 상태
   const visibilityOptions: VisibilityOption[] = ["전체", "공개", "비공개"];
@@ -85,14 +87,17 @@ export default function ProjectDetailPage() {
     return base;
   }, [selectedStatus, selectedSort, selectedVisibility, selectedSummaryType]);
 
+  const troubleParams = useMemo(
+    () => ({ type: "project" as const, projectId, query }),
+    [projectId, query]
+  );
+
+  const troubleOpts = useMemo(() => ({ enabled: !isInvalid }), [isInvalid]);
+
   // 프로젝트별 트러블슈팅 목록 로드
   const { cards, isLoading, error } = useTroubleCards(
-    {
-      type: "project",
-      projectId,
-      query,
-    },
-    { enabled: !isInvalid }
+    troubleParams,
+    troubleOpts
   );
 
   return (

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export type Viewer = {
+  userId: number;
+};
+
+type AuthState = {
+  user: Viewer | null;
+  setUser: (u: Viewer) => void;
+  clearUser: () => void;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (u) => set({ user: u }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: "auth", // localStorage 키(자동 저장)
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ user: s.user }), // 필요한 것만 저장
+    }
+  )
+);
+
+// 컴포넌트에서 사용
+export const useViewerId = () => useAuthStore((s) => s.user?.userId ?? null);
+
+// 훅 못 쓰는 유틸/서비스 파일에서 사용
+export const getViewerId = () => useAuthStore.getState().user?.userId ?? null;


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] #77 코드래빗 리뷰 반영
- [x] 프로젝트 상세 화면 API 무한 호출 에러 수정

## 📄 Description

- `CommunityPostDetail`
  - 각 내용 섹션에 `ref` 등록 안되어있던 오류 수정 (목차 위치 추적용)
  - 작성자 id 받아올 수 있도록 하여 프로필 이미지 클릭 시 해당 사용자 페이지로 이동

- `userId` 받아오는 방식 수정: `localStorage` 직접 접근 대신 `useAuthSotre`로 중앙화하여 관리

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 중앙 인증 상태 도입으로 로그인/사용자 식별이 앱 전반에 즉시 반영
  - 커뮤니티 게시글 상세에서 작성자 페이지로 바로 이동 지원

- 버그 수정
  - 항목 삭제 후 목록 새로고침을 확실히 대기하여 실패 시 오류 로깅
  - 화면 전환 시 타이머 정리로 메모리 누수 방지

- 리팩터
  - 로컬 스토리지 의존 제거, 사용자 상태 관리 일원화
  - 소유자 판단을 현재 사용자 기준으로 통일해 마이페이지/댓글/게시글 동작 일관성 향상
  - 데이터 로딩 의존성 정리와 메모이제이션으로 불필요한 호출 감소 및 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->