### PR TITLE
FEAT: 팔로우 api 구현

### DIFF
--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -29,35 +29,35 @@ export const patchProfile = (updatedProfile: UpdatedProfileData) =>
   });
 
 // 팔로워 목록 조회
-export const getFollowers = (userId: number) =>
+export const getFollowers = (targetUserId: number) =>
   getAPIResponseData<FollowingData[]>({
     url: "/user/followers",
     method: "GET",
-    params: { userId },
+    params: { targetUserId },
   });
 
 // 팔로잉 목록 조회
-export const getFollowings = (userId: number) =>
+export const getFollowings = (targetUserId: number) =>
   getAPIResponseData<FollowingData[]>({
     url: "/user/followings",
     method: "GET",
-    params: { userId },
+    params: { targetUserId },
   });
 
 // 팔로우
-export const postFollow = (userId: number) =>
+export const postFollow = (targetUserId: number) =>
   getAPIResponseData({
     url: "/user/follow",
     method: "POST",
-    params: { userId },
+    params: { targetUserId },
   });
 
 // 언팔로우
-export const postUnfollow = (userId: number) =>
+export const postUnfollow = (targetUserId: number) =>
   getAPIResponseData({
     url: "/user/unfollow",
     method: "POST",
-    params: { userId },
+    params: { targetUserId },
   });
 
 // 탈퇴

--- a/src/components/MyPage/FollowingBtn.tsx
+++ b/src/components/MyPage/FollowingBtn.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import userIcon from "@/assets/icons/user.svg";
 
 interface FollowingProps {
+  userId: number;
   nickname: string;
   email: string;
   profileUrl: string;
@@ -10,6 +11,7 @@ interface FollowingProps {
 }
 
 const FollowingBtn = ({
+  userId,
   nickname,
   email,
   profileUrl,
@@ -19,8 +21,11 @@ const FollowingBtn = ({
   const nav = useNavigate();
   return (
     <div className="flex justify-between w-[948px] items-center self-stretch py-[25px] border-b border-gray1">
-      <div className="flex items-center gap-3" onClick={() => nav(profileUrl)}>
-        <img src={userIcon} alt="user" className="w-[52px] h-[52px]" />
+      <div
+        className="flex items-center gap-3"
+        onClick={() => nav(`/user/mypage/${userId}`)}
+      >
+        <img src={profileUrl} alt="user" className="w-[52px] h-[52px]" />
 
         <div className="flex w-[143px] flex-col items-start gap-0.5">
           <p className="font-sans text-2xl font-bold leading-normal">

--- a/src/components/MyPage/MyFollowing.tsx
+++ b/src/components/MyPage/MyFollowing.tsx
@@ -23,8 +23,10 @@ const MyFollowing = () => {
 
         if (path === "following") {
           data = await getFollowings(userId);
+          console.log(data);
         } else if (path === "follower") {
           data = await getFollowers(userId);
+          console.log(data);
         }
 
         setFollowList(data);
@@ -34,7 +36,7 @@ const MyFollowing = () => {
     };
 
     fetchData();
-  }, [userId]);
+  }, [userId, location.pathname]);
 
   const handleFollowClick = async (id: number) => {
     try {
@@ -59,10 +61,11 @@ const MyFollowing = () => {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 w-[948px]">
       {followList.map((user) => (
         <FollowingBtn
           key={user.userId}
+          userId={user.userId}
           nickname={user.nickname}
           email={user.email}
           isFollowed={user.isFollowed}

--- a/src/components/MyPage/MyFollowing.tsx
+++ b/src/components/MyPage/MyFollowing.tsx
@@ -23,10 +23,8 @@ const MyFollowing = () => {
 
         if (path === "following") {
           data = await getFollowings(userId);
-          console.log(data);
         } else if (path === "follower") {
           data = await getFollowers(userId);
-          console.log(data);
         }
 
         setFollowList(data);

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -46,7 +46,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       try {
         const data = await getUserInfo(Number(id));
         setUserInfo(data);
-        console.log(data);
+        console.log(userInfo);
       } catch (error) {
         console.error("사용자 정보 불러오기 실패:", error);
       }
@@ -82,8 +82,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
 
   const handleFollowClick = async (id: number) => {
     try {
-      const res = await postFollow(id);
-      console.log("팔로우 응답:", res);
+      await postFollow(id);
     } catch (e) {
       console.error("팔로우 실패", e);
     }

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -9,7 +9,7 @@ import userIcon from "@/assets/icons/user.svg";
 import circleYIcon from "@/assets/icons/circle_y.svg";
 import circleGIcon from "@/assets/icons/circle_g.svg";
 import circleBIcon from "@/assets/icons/circle_b.svg";
-import { getUserInfo } from "@/api/user.api"; // 사용자 정보 조회 API import
+import { getUserInfo, postFollow } from "@/api/user.api";
 import type { UserInfoData } from "@/models/user.model";
 
 type MyPageSideBarProps =
@@ -46,6 +46,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       try {
         const data = await getUserInfo(Number(id));
         setUserInfo(data);
+        console.log(data);
       } catch (error) {
         console.error("사용자 정보 불러오기 실패:", error);
       }
@@ -76,6 +77,15 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       setSelectedTag(null);
     } else {
       setSelectedTag(tag);
+    }
+  };
+
+  const handleFollowClick = async (id: number) => {
+    try {
+      const res = await postFollow(id);
+      console.log("팔로우 응답:", res);
+    } catch (e) {
+      console.error("팔로우 실패", e);
     }
   };
 
@@ -111,7 +121,11 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
                 onClick={handleNavigate(MYPAGE_SUBPATH.EDIT_PROFILE)}
               />
             ) : (
-              <FollowButton label="팔로우" colorClass="bg-primary" />
+              <FollowButton
+                label="팔로우"
+                colorClass="bg-primary"
+                onClick={() => handleFollowClick(Number(id))}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## 🔥 Issues

#39 

## ✅ What to do

- [x] 팔로우/언팔로우 구현
- [x] 팔로워/팔로잉 목록 조회 구현

## 🛠️ Improvements to Make

<img width="357" height="410" alt="image" src="https://github.com/user-attachments/assets/62ba4471-11ec-47fb-a8b5-8a64ab8d341a" />

다른 사람 프로필에서 팔로우 여부를 백에서 받은 후 코드 수정할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 마이페이지 사이드바 팔로우 버튼에 동작 추가(클릭 시 팔로우 요청 수행).
  - 팔로잉 목록에서 사용자 행 클릭 시 해당 유저 마이페이지로 이동.

- 버그 수정
  - 팔로워/팔로잉 탭 전환 등 경로 변경 시 목록이 즉시 새로고침되도록 개선.

- UI/UX
  - 사용자 아바타가 기본 아이콘 대신 제공된 프로필 이미지로 표시.
  - 팔로잉 목록에서 사용자 정보 전체 영역을 클릭 가능하도록 확장.
  - 목록 컨테이너 너비를 조정해 레이아웃 일관성 개선.

- 문서/정리
  - 공개 API의 파라미터 명칭 일관성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->