### PR TITLE
FIX: 검색, 토큰 재발급 관련 오류 수정

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,7 +7,7 @@ const baseURL =
 const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
 
 const api = axios.create({
-  baseURL,
+  baseURL: "/api",
   timeout: 10000,
   withCredentials: true,
   headers: {
@@ -19,9 +19,19 @@ const api = axios.create({
 
 // 공통 유틸: 로그인 페이지로의 네비게이션을 1회만
 let authNavigationPromise: Promise<void> | null = null;
-const navigateToAuthOnce = (next: string) => {
+const getCurrentSpaPath = () => {
+  // 라우터가 있으면 라우터 위치를 우선 사용
+  const loc: Location | (typeof router)["state"]["location"] =
+    (router as any)?.state?.location ?? window.location;
+  return `${loc.pathname}${loc.search}${loc.hash}`;
+};
+
+const navigateToAuthOnce = (rawNext?: string) => {
   if (!authNavigationPromise) {
-    router.navigate(`${PATH.ROOT}?next=${next}`, { replace: true });
+    const nextPath = rawNext ?? getCurrentSpaPath(); // 미인코딩 경로
+    const params = new URLSearchParams();
+    params.set("next", nextPath); // 인코딩은 URLSearchParams가 처리
+    router.navigate(`${PATH.ROOT}?${params.toString()}`, { replace: true });
     authNavigationPromise = new Promise<void>((resolve) => {
       // 짧은 쿨다운 후 게이트 해제 (동시 발화 방지)
       setTimeout(() => {
@@ -95,8 +105,7 @@ api.interceptors.response.use(
       !tokenExists &&
       location.pathname !== PATH.ROOT
     ) {
-      const next = encodeURIComponent(location.pathname + location.search);
-      void navigateToAuthOnce(next);
+      void navigateToAuthOnce(); // 내부에서 안전하게 계산/인코딩
     }
     return res;
   },
@@ -118,8 +127,7 @@ api.interceptors.response.use(
     if (isRefresh) {
       localStorage.removeItem("accessToken");
       if (!onLogin) {
-        const next = encodeURIComponent(location.pathname + location.search);
-        await navigateToAuthOnce(next);
+        await navigateToAuthOnce();
       }
       return Promise.reject(error);
     }
@@ -131,8 +139,7 @@ api.interceptors.response.use(
         // 이미 재시도 한 번 했는데도 401 → 토큰 정리 후 이동
         localStorage.removeItem("accessToken");
         if (!onLogin) {
-          const next = encodeURIComponent(location.pathname + location.search);
-          await navigateToAuthOnce(next);
+          await navigateToAuthOnce();
         }
         return Promise.reject(error);
       }
@@ -155,16 +162,14 @@ api.interceptors.response.use(
       // 리프레시 실패
       localStorage.removeItem("accessToken");
       if (!onLogin) {
-        const next = encodeURIComponent(location.pathname + location.search);
-        await navigateToAuthOnce(next);
+        await navigateToAuthOnce();
       }
       return Promise.reject(error);
     }
 
     // 403 → 권한 부족: 로그인 이동(단 1회)
     if (status === 403 && !onLogin) {
-      const next = encodeURIComponent(location.pathname + location.search);
-      await navigateToAuthOnce(next);
+      await navigateToAuthOnce();
     }
 
     return Promise.reject(error);
@@ -172,3 +177,5 @@ api.interceptors.response.use(
 );
 
 export default api;
+
+if (import.meta.env.DEV) (window as any).__api = api;

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -31,6 +31,7 @@ export interface TroubleShootingCardProps {
   isSearchResult?: boolean;
   onDeleted?: (postId: number) => void;
   onClick?: (postId: number) => void;
+  disabled?: boolean;
 }
 
 const TroubleShootingCard = ({
@@ -52,6 +53,7 @@ const TroubleShootingCard = ({
   isSearchResult,
   onDeleted,
   onClick,
+  disabled,
 }: TroubleShootingCardProps) => {
   const [showMenu, setShowMenu] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -61,7 +63,7 @@ const TroubleShootingCard = ({
   const shouldShowVisibilityIcon = status === "complete" && visibility;
   const shouldShowSummaryType = status === "created";
 
-  const isClickable = typeof onClick === "function";
+  const isClickable = typeof onClick === "function" && !disabled;
   const handleRootClick = () => {
     if (isClickable) onClick(Number(id));
   };
@@ -69,8 +71,7 @@ const TroubleShootingCard = ({
   const handleRootKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (!isClickable) return;
     if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onClick(Number(id));
+      if (isClickable) onClick(Number(id));
     }
   };
 
@@ -101,12 +102,17 @@ const TroubleShootingCard = ({
   return (
     <div
       className={`w-full py-[30px] flex flex-col items-start gap-[10px] border-b border-gray3 bg-white ${
-        isClickable ? "cursor-pointer" : ""
+        isClickable
+          ? "cursor-pointer"
+          : disabled
+          ? "cursor-not-allowed opacity-60"
+          : ""
       }`}
       onClick={handleRootClick}
       role={isClickable ? "button" : undefined}
       tabIndex={isClickable ? 0 : undefined}
       onKeyDown={handleRootKeyDown}
+      aria-disabled={disabled || undefined}
     >
       <div className="w-full flex flex-col">
         {/* 작성자 */}

--- a/src/hooks/useInfiniteCommunityTroubleSearch.ts
+++ b/src/hooks/useInfiniteCommunityTroubleSearch.ts
@@ -4,13 +4,15 @@ import { searchCommunityTroubles } from "@/api/trouble.api";
 import type { MyTroubleServerItem } from "@/types/troubles.server";
 
 export function useInfiniteCommunityTroubleSearch(keyword: string, size = 10) {
-  // 공개글만 노출
-  const filterVisible = useCallback(
-    (x: MyTroubleServerItem) =>
-      x.isVisible === true ||
-      String(x.isVisible ?? "").toUpperCase() === "PUBLIC",
-    []
-  );
+  // 공개 + 완료만 (작성 중 제외)
+  const filterVisible = useCallback((x: MyTroubleServerItem) => {
+    const visible = x.isVisible === true; // 서버가 boolean로 내려줌
+    const statusRaw = String((x as any).postStatus ?? "");
+    const inProgress =
+      /작성\s*중/i.test(statusRaw) || /in[\s-_]*progress/i.test(statusRaw);
+    const completed = /완료/i.test(statusRaw) && !inProgress; // "요약 완료"/"작성 완료" 등
+    return visible && completed;
+  }, []);
 
   // fetcher 주입 (키워드 없으면 호출 안 함)
   const fetcher = useMemo(() => {

--- a/src/hooks/useInfiniteCommunityTroubleSearch.ts
+++ b/src/hooks/useInfiniteCommunityTroubleSearch.ts
@@ -7,9 +7,9 @@ export function useInfiniteCommunityTroubleSearch(keyword: string, size = 10) {
   // 공개 + 완료만 (작성 중 제외)
   const filterVisible = useCallback((x: MyTroubleServerItem) => {
     const visible = x.isVisible === true; // 서버가 boolean로 내려줌
-    const statusRaw = String((x as any).postStatus ?? "");
+    const statusRaw = String(x.postStatus ?? "");
     const inProgress =
-      /작성\s*중/i.test(statusRaw) || /in[\s-_]*progress/i.test(statusRaw);
+      /작성\s*중/i.test(statusRaw) || /in[\s_-]*progress/i.test(statusRaw);
     const completed = /완료/i.test(statusRaw) && !inProgress; // "요약 완료"/"작성 완료" 등
     return visible && completed;
   }, []);

--- a/src/hooks/useInfiniteMyTroubleSearch.ts
+++ b/src/hooks/useInfiniteMyTroubleSearch.ts
@@ -61,6 +61,7 @@ export function useInfiniteMyTroubleSearch(
   const [hasNext, setHasNext] = useState(false);
   const [totalElements, setTotalElements] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
+  const [displayTotal, setDisplayTotal] = useState(0); // 화면 표시용 개수
 
   // 중복 호출 방지 락
   const inflightRef = useRef(false);
@@ -74,6 +75,7 @@ export function useInfiniteMyTroubleSearch(
     setTotalPages(0);
     setError(null);
     lastKeyRef.current = "";
+    setDisplayTotal(0);
   }, []);
 
   const fetchPage = useCallback(
@@ -117,7 +119,9 @@ export function useInfiniteMyTroubleSearch(
           const map = new Map<string, TroubleShootingCardProps>();
           for (const it of prev) map.set(it.id, it);
           for (const it of mapped) map.set(it.id, it);
-          return Array.from(map.values());
+          const arr = Array.from(map.values());
+          setDisplayTotal(arr.length); // 현재 화면에 보여질 총 개수
+          return arr;
         });
 
         setPage(safe.page);
@@ -162,6 +166,7 @@ export function useInfiniteMyTroubleSearch(
     hasNext,
     totalElements,
     totalPages,
+    displayTotal,
     loadMore,
     reset,
   };

--- a/src/hooks/useInfiniteUserTroubleSearch.ts
+++ b/src/hooks/useInfiniteUserTroubleSearch.ts
@@ -8,13 +8,15 @@ export function useInfiniteUserTroubleSearch(
   userId: number | null,
   size = 10
 ) {
-  // 공개글만 (isVisible === true)
-  const filterVisible = useCallback(
-    (x: MyTroubleServerItem) =>
-      x.isVisible === true ||
-      String(x.isVisible ?? "").toUpperCase() === "PUBLIC",
-    []
-  );
+  // 공개 + 완료만 (작성 중 제외)
+  const filterVisible = useCallback((x: MyTroubleServerItem) => {
+    const visible = x.isVisible === true; // 서버가 boolean로 내려줌
+    const statusRaw = String((x as any).postStatus ?? "");
+    const inProgress =
+      /작성\s*중/i.test(statusRaw) || /in[\s-_]*progress/i.test(statusRaw);
+    const completed = /완료/i.test(statusRaw) && !inProgress; // "요약 완료"/"작성 완료" 등
+    return visible && completed;
+  }, []);
 
   const fetcher = useMemo(() => {
     return ({

--- a/src/hooks/useInfiniteUserTroubleSearch.ts
+++ b/src/hooks/useInfiniteUserTroubleSearch.ts
@@ -11,9 +11,9 @@ export function useInfiniteUserTroubleSearch(
   // 공개 + 완료만 (작성 중 제외)
   const filterVisible = useCallback((x: MyTroubleServerItem) => {
     const visible = x.isVisible === true; // 서버가 boolean로 내려줌
-    const statusRaw = String((x as any).postStatus ?? "");
+    const statusRaw = String(x.postStatus ?? "");
     const inProgress =
-      /작성\s*중/i.test(statusRaw) || /in[\s-_]*progress/i.test(statusRaw);
+      /작성\s*중/i.test(statusRaw) || /in[\s_-]*progress/i.test(statusRaw);
     const completed = /완료/i.test(statusRaw) && !inProgress; // "요약 완료"/"작성 완료" 등
     return visible && completed;
   }, []);

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -1,12 +1,15 @@
 import TroubleShootingCard from "@/components/MyPage/TroubleShootingCard";
+import { PATH } from "@/constants/paths";
 import { useInfiniteCommunityTroubleSearch } from "@/hooks/useInfiniteCommunityTroubleSearch";
 import { useInfiniteMyTroubleSearch } from "@/hooks/useInfiniteMyTroubleSearch";
 import { useInfiniteUserTroubleSearch } from "@/hooks/useInfiniteUserTroubleSearch";
 import { useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const SearchResultPage = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+
   const sp = new URLSearchParams(location.search);
   const query = sp.get("query") ?? "";
   // scope: 화이트리스트로 안전하게 정규화
@@ -33,6 +36,12 @@ const SearchResultPage = () => {
   const isMyScope = scope === "my" || scope === "mypage";
   const isUserScope = scope === "user" && !!userId;
   const isCommunityScope = scope === "community";
+
+  const isBlocked = (card: any) => {
+    const vis = String(card.visibility ?? "").toUpperCase(); // "PUBLIC" | "PRIVATE"
+    const st = String(card.status ?? "").toUpperCase(); // "COMPLETED" | "IN_PROGRESS" 등
+    return vis === "PRIVATE" || st === "IN_PROGRESS";
+  };
 
   // 현재 로그인한 사용자 트러블슈팅 문서 내 검색
   const my = useInfiniteMyTroubleSearch(
@@ -69,6 +78,7 @@ const SearchResultPage = () => {
   const error = active.error;
   const items = active.items;
   const totalElements = active.totalElements;
+  const displayTotal = (active as any).displayTotal ?? totalElements;
   const hasNext = active.hasNext;
 
   // 하단 센티널 관찰자
@@ -116,7 +126,7 @@ const SearchResultPage = () => {
       <span className="text-head-32-regular self-stretch">
         {loadingInitial
           ? "검색 중…"
-          : `총 ${totalElements}개의 포스트를 찾았어요.`}
+          : `총 ${displayTotal}개의 포스트를 찾았어요.`}
       </span>
 
       {/* 에러 */}
@@ -136,7 +146,26 @@ const SearchResultPage = () => {
             검색 결과가 없습니다.
           </div>
         ) : (
-          items.map((card) => <TroubleShootingCard key={card.id} {...card} />)
+          items.map((card) => {
+            const blocked = isBlocked(card);
+            return (
+              <TroubleShootingCard
+                key={card.id}
+                {...card}
+                // 클릭 막기: blocked면 onClick 전달 안 함
+                onClick={
+                  blocked
+                    ? undefined
+                    : () =>
+                        navigate(PATH.COMMUNITY_POST(Number(card.id)), {
+                          state: { from: "search", query, scope, userId },
+                        })
+                }
+                // 접근성 힌트(읽기 전용)
+                aria-disabled={blocked || undefined}
+              />
+            );
+          })
         )}
 
         {/* 로딩 인디케이터 / 센티널 */}

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -148,21 +148,26 @@ const SearchResultPage = () => {
         ) : (
           items.map((card) => {
             const blocked = isBlocked(card);
+            const idNum =
+              typeof card.id === "number"
+                ? card.id
+                : Number.parseInt(String(card.id), 10);
+            const idValid = Number.isFinite(idNum);
             return (
               <TroubleShootingCard
                 key={card.id}
                 {...card}
-                // 클릭 막기: blocked면 onClick 전달 안 함
+                // 클릭 막기: blocked 이거나 id가 유효하지 않으면 onClick 전달 안 함
                 onClick={
-                  blocked
+                  blocked || !idValid
                     ? undefined
                     : () =>
-                        navigate(PATH.COMMUNITY_POST(Number(card.id)), {
+                        navigate(PATH.COMMUNITY_POST(idNum), {
                           state: { from: "search", query, scope, userId },
                         })
                 }
-                // 접근성 힌트(읽기 전용)
-                aria-disabled={blocked || undefined}
+                // TroubleShootingCard가 직접 처리할 수 있도록 명시적 disabled 전달
+                disabled={blocked || !idValid}
               />
             );
           })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,37 @@ export default defineConfig(({ command, mode }) => {
   return {
     base,
     plugins: [react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: "http://3.37.163.222:8080",
+          changeOrigin: true,
+          secure: false,
+          // /api/auth/refresh  ->  /auth/refresh 로 백엔드에 전달
+          rewrite: (path) => path.replace(/^\/api/, ""),
+          configure: (proxy, options) => {
+            proxy.on("proxyReq", (proxyReq, req) => {
+              // dev 서버 콘솔에 경로와 Host 찍히게
+              console.log(
+                "[proxyReq]",
+                req.method,
+                req.url,
+                "->",
+                options.target + (proxyReq as any).path
+              );
+            });
+            proxy.on("proxyRes", (proxyRes, req) => {
+              console.log(
+                "[proxyRes]",
+                req.method,
+                req.url,
+                proxyRes.statusCode
+              );
+            });
+          },
+        },
+      },
+    },
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 검색 결과 개수 불일치 문제 해결
- [x] 토큰 재발급 및 재로그인 관련 로직 수정

## 📄 Description

- 검색 결과 표시 시에 공개 + 작성 완료 상태인 글만 보이도록 수정
- 토큰 갱신 실패 시에 로그인 페이지로 라우팅 -> 로그인 성공 시 바로 이전 화면으로 다시 이동할 수 있도록 함
- `auth/refresh` 호출 시 refreshToken이 Request Cookie로 전달되지 않아 404 에러가 뜸 -> Vite 프록시 설정 -> Request Cookie에 refreshToken 포함되는 것 확인했지만 500 에러 뜸 => 백엔드 쪽에도 얘기해서 뭐가 문제인지 확인해봐야 할 것 같습니다..!

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 검색 결과 헤더에 실제 화면에 표시된 항목 수(displayTotal)를 정확히 표시합니다.
  * 결과 카드의 클릭 가능 여부를 상태에 따라 제어하고, 비활성화 표기와 함께 상세 페이지로 이동을 지원합니다.
* 버그 수정
  * 비공개·작성 중 항목이 검색 결과에 표시되거나 클릭되지 않도록 필터를 강화했습니다(공개·완료만 표시).
  * 로그인 필요 시 인증 페이지로의 리다이렉션 안정성이 향상되었습니다(중복 네비게이션 방지).
* 잡일(개발용)
  * 개발 모드에서 API 인스턴스 디버깅 노출 및 로컬 개발용 프록시 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->