### PR TITLE
FEAT: 커뮤니티 관련 변경사항 업데이트

### DIFF
--- a/src/api/community.api.ts
+++ b/src/api/community.api.ts
@@ -38,6 +38,17 @@ export const getCommunityList = (
     })
   );
 
+// 커뮤니티 최근 열람 게시글 목록
+export const getCommunityRecentList = (page0 = 0, size = 12) =>
+  getAPIResponseData<GetCommunityListResponse>(
+    api.get<GetCommunityListResponse>("/community/recent", {
+      params: {
+        page: Math.max(1, page0 + 1),
+        size,
+      },
+    })
+  );
+
 // 커뮤니티 포스트 상세 조회
 export function getCommunityPostDetail(postId: number) {
   if (!inflightDetail.has(postId)) {

--- a/src/hooks/useCommunityCards.ts
+++ b/src/hooks/useCommunityCards.ts
@@ -131,7 +131,7 @@ export default function useCommunityCards(opts: Options = {}) {
       try {
         const resp = dedupe
           ? await fetchOnce(sourceKey, fetcher, sortBy, targetPage, pageSize)
-          : await getCommunityList(targetPage, pageSize, sortBy);
+          : await fetcher(targetPage, pageSize, sortBy);
 
         if (seqRef.current !== mySeq) return;
 

--- a/src/hooks/useCommunityCards.ts
+++ b/src/hooks/useCommunityCards.ts
@@ -18,6 +18,12 @@ type PageResp = {
   isLast?: boolean;
 };
 
+export type CommunityCardsFetcher = (
+  page: number,
+  size: number,
+  sortBy: CommunitySort
+) => Promise<PageResp>;
+
 interface Options {
   enabled?: boolean; // 기본 true
   pageSize?: number; // 기본 12
@@ -26,17 +32,29 @@ interface Options {
   rootMargin?: string; // 기본 "400px 0px"
   stopOnError?: boolean; // 기본 true
   cooldownMs?: number; // 기본 0
+  fetcher?: CommunityCardsFetcher; // 기본 getCommunityList
+  sourceKey?: string; // 캐시/리셋 구분용 키. 기본 "community"
 }
 
 // in-flight dedupe: (sort|page|size)
 const inflightPaged = new Map<string, Promise<PageResp>>();
-
-function keyFor(sort: CommunitySort, page: number, size: number) {
-  return `community|sort=${sort}|p=${page}|s=${size}`;
+function keyFor(
+  source: string,
+  sort: CommunitySort,
+  page: number,
+  size: number
+) {
+  return `${source}|sort=${sort}|p=${page}|s=${size}`;
 }
 
-async function fetchOnce(sort: CommunitySort, page: number, size: number) {
-  const key = keyFor(sort, page, size);
+async function fetchOnce(
+  source: string,
+  fetcher: CommunityCardsFetcher,
+  sort: CommunitySort,
+  page: number,
+  size: number
+) {
+  const key = keyFor(source, sort, page, size);
   if (!inflightPaged.has(key)) {
     const p = getCommunityList(page, size, sort).finally(() =>
       inflightPaged.delete(key)
@@ -55,9 +73,14 @@ export default function useCommunityCards(opts: Options = {}) {
     rootMargin = "400px 0px",
     stopOnError = true,
     cooldownMs = 0,
+    fetcher = (p, s, sort) => getCommunityList(p, s, sort),
+    sourceKey = "community",
   } = opts;
 
-  const srcKey = useMemo(() => `community|sort=${sortBy}`, [sortBy]);
+  const srcKey = useMemo(
+    () => `${sourceKey}|sort=${sortBy}`,
+    [sourceKey, sortBy]
+  );
 
   const [cards, setCards] = useState<TroublogCardProps[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -107,7 +130,7 @@ export default function useCommunityCards(opts: Options = {}) {
       const mySeq = ++seqRef.current;
       try {
         const resp = dedupe
-          ? await fetchOnce(sortBy, targetPage, pageSize)
+          ? await fetchOnce(sourceKey, fetcher, sortBy, targetPage, pageSize)
           : await getCommunityList(targetPage, pageSize, sortBy);
 
         if (seqRef.current !== mySeq) return;
@@ -155,7 +178,7 @@ export default function useCommunityCards(opts: Options = {}) {
         if (seqRef.current === mySeq) setIsLoading(false);
       }
     },
-    [enabled, pageSize, sortBy, stopOnError]
+    [enabled, pageSize, sortBy, stopOnError, fetcher, sourceKey]
   );
 
   // 초기 로드 (sort 변경 시 리셋 후 p=0)

--- a/src/mappers/communityComment.mapper.ts
+++ b/src/mappers/communityComment.mapper.ts
@@ -27,8 +27,8 @@ export const toPostComment = (
   const base: PostCommentProps = {
     id: String(c.commentId),
     // 프로필/닉네임 정보가 응답에 없으므로 임시 대체
-    name: `사용자 ${c.userId}`,
-    profile: undefined,
+    name: c.name ?? "(알 수 없음)",
+    profile: c.profileImg ?? undefined,
     date: fmtYYMMDD(c.createdAt),
     content: c.content ?? "",
     isMine: isMine(c.userId, viewerId),

--- a/src/mappers/communityPostDetail.mapper.ts
+++ b/src/mappers/communityPostDetail.mapper.ts
@@ -38,7 +38,7 @@ export function toCommunityPostVM(
     importance: 0,
     questions: sorted.map((c, i) => c.subTitle || `섹션 ${i + 1}`),
     contents: sorted.map((c) => [c.body || ""]),
-    isLiked: false,
+    isLiked: src.liked ?? false,
     likeCounts: src.likeCount ?? 0,
     commentCounts: src.commentCount ?? 0,
     comments: [],

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -1,7 +1,10 @@
+import { getCommunityRecentList } from "@/api/community.api";
 import TroublogCard from "@/components/Card/TroublogCard";
 import GenericDropdown from "@/components/Menu/GenericDropdown";
 import { PATH } from "@/constants/paths";
-import useCommunityCards from "@/hooks/useCommunityCards";
+import useCommunityCards, {
+  type CommunityCardsFetcher,
+} from "@/hooks/useCommunityCards";
 import type { CommunitySort } from "@/types/community.model";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -24,13 +27,32 @@ export default function CommunityPage() {
     return "likes";
   }, [selectedSort]);
 
-  // 커뮤니티 목록 불러오기 (무한스크롤)
-  const { cards, isLoading, error, hasNext, sentinelRef } = useCommunityCards({
+  // 커뮤니티 목록 불러오기 (기본 목록)
+  const trouble = useCommunityCards({
+    enabled: selectedTab === "trouble",
     sortBy,
     pageSize: 12,
     infinite: true,
     rootMargin: "400px 0px",
+    sourceKey: "community", // 기본값이라 생략 가능
   });
+
+  // 최근 읽은 포스트 목록
+  const recentFetcher: CommunityCardsFetcher = (page, size) =>
+    getCommunityRecentList(page, size) as any; // sort 미사용
+
+  const recent = useCommunityCards({
+    enabled: selectedTab === "recent",
+    sortBy: "latest", // 정렬 옵션 미사용이지만 시그니처 맞춤
+    pageSize: 12,
+    infinite: true,
+    rootMargin: "400px 0px",
+    fetcher: recentFetcher,
+    sourceKey: "community_recent", // 캐시/리셋 구분용
+  });
+
+  // 활성 데이터셋 선택
+  const active = selectedTab === "trouble" ? trouble : recent;
 
   return (
     <div className="flex flex-col mt-[79px] mb-[104px] max-w-[1600px] w-full mx-auto px-4 gap-[50px]">
@@ -85,26 +107,24 @@ export default function CommunityPage() {
       </div>
 
       {/* 에러 */}
-      {error && (
-        <div className="text-red-600 text-body-16-regular">{error}</div>
+      {active.error && (
+        <div className="text-red-600 text-body-16-regular">{active.error}</div>
       )}
 
       {/* 트러블로그 카드 */}
       <div className="w-full mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-[24px] gap-y-[60px]">
-        {selectedTab === "trouble"
-          ? cards.map((card) => (
-              <div
-                key={card.id}
-                className="cursor-pointer"
-                onClick={() => navigate(PATH.COMMUNITY_POST(card.id))}
-              >
-                <TroublogCard {...card} />
-              </div>
-            ))
-          : null}
+        {active.cards.map((card) => (
+          <div
+            key={card.id}
+            className="cursor-pointer"
+            onClick={() => navigate(PATH.COMMUNITY_POST(card.id))}
+          >
+            <TroublogCard {...card} />
+          </div>
+        ))}
 
         {/* 로딩 스켈레톤 */}
-        {isLoading && (
+        {active.isLoading && (
           <>
             <div className="w-full h-[300px] bg-gray-100 rounded-2xl" />
             <div className="w-full h-[300px] bg-gray-100 rounded-2xl" />
@@ -113,8 +133,8 @@ export default function CommunityPage() {
         )}
 
         {/* 무한스크롤 센티널 */}
-        {selectedTab === "trouble" && hasNext && (
-          <div ref={sentinelRef} style={{ height: 1 }} />
+        {active.hasNext && (
+          <div ref={active.sentinelRef} style={{ height: 1 }} />
         )}
       </div>
     </div>

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -6,7 +6,7 @@ import useCommunityCards, {
   type CommunityCardsFetcher,
 } from "@/hooks/useCommunityCards";
 import type { CommunitySort } from "@/types/community.model";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function CommunityPage() {
@@ -38,8 +38,10 @@ export default function CommunityPage() {
   });
 
   // 최근 읽은 포스트 목록
-  const recentFetcher: CommunityCardsFetcher = (page, size) =>
-    getCommunityRecentList(page, size) as any; // sort 미사용
+  const recentFetcher = useCallback<CommunityCardsFetcher>(
+    (page, size) => getCommunityRecentList(page, size), // sort 미사용
+    []
+  );
 
   const recent = useCommunityCards({
     enabled: selectedTab === "recent",

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -51,8 +51,8 @@ export interface CommunityCommentServerItem {
   commentId: number;
   postId: number;
   userId: number;
-  name: string;
-  profileImg: string;
+  name: string | null;
+  profileImg: string | null;
   content: string;
   createdAt: string;
   parentCommentId: number | null;

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -38,7 +38,7 @@ export interface CommunityPostDetailServer {
   introduction: string | null;
   likeCount: number;
   commentCount: number;
-  liked: boolean;
+  liked?: boolean | null;
   completedAt: string;
   errorTag: string;
   postTags: string[];

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -51,6 +51,8 @@ export interface CommunityCommentServerItem {
   commentId: number;
   postId: number;
   userId: number;
+  name: string;
+  profileImg: string;
   content: string;
   createdAt: string;
   parentCommentId: number | null;

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -38,6 +38,7 @@ export interface CommunityPostDetailServer {
   introduction: string | null;
   likeCount: number;
   commentCount: number;
+  liked: boolean;
   completedAt: string;
   errorTag: string;
   postTags: string[];


### PR DESCRIPTION
## 🔥 Issues

- closed #77 

## ✅ What to do

- [x] 커뮤니티 포스트 상세 화면에서 현재 로그인한 사용자의 기존 좋아요 여부 반영해서 UI 표시
- [x] 커뮤니티 포스트 댓글에 사용자 이름, 프로필 이미지 실서버 데이터 반영
- [x] 커뮤니티 최근 읽은 포스트 목록 조회 API 연동

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - ‘최근’ 게시글 목록을 별도 소스로 제공하여 탭 전환 시 독립적인 로딩과 캐시 동작을 지원합니다.
  - 최근 목록 조회용 API가 추가되었습니다.

- 개선
  - 댓글에 서버 제공 작성자 이름과 프로필 이미지를 표시합니다(가능할 경우).
  - 탭별로 분리된 캐시/중복요청 방지로 무한스크롤과 목록 상태 유지가 더 안정적입니다.

- 버그 수정
  - 게시글 상세의 좋아요 상태가 서버 값을 정확히 반영하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->