### PR TITLE
FEAT: 포스트 수정 api 구현, 작성글 렌더링, 에디터 블록 스크롤 제거 

### DIFF
--- a/src/api/image.api.ts
+++ b/src/api/image.api.ts
@@ -11,6 +11,7 @@ export async function uploadImage(
   form.append("multipartFile", file, file.name);
 
   const res = await api.post<ApiEnvelope<string>>("/image", form, {
+    headers: { "Content-Type": "multipart/form-data" },
     onUploadProgress: (e) => {
       if (!onProgress || !e.total) return;
       onProgress(Math.round((e.loaded * 100) / e.total));

--- a/src/components/TemplateWrite/EditorBlock.tsx
+++ b/src/components/TemplateWrite/EditorBlock.tsx
@@ -2,7 +2,7 @@ import MDEditor from "@uiw/react-md-editor";
 import alertIcon from "@/assets/icons/alerticon.svg";
 import checkBoxIcon from "@/assets/icons/checkedbox.svg";
 import nonCheckBoxIcon from "@/assets/icons/noncheckedbox.svg";
-
+import { useLayoutEffect, useRef, useState, useEffect } from "react";
 export interface BlockData {
   id: number;
   content: string;
@@ -13,7 +13,7 @@ export interface BlockData {
   checklistTitle: string;
 }
 
-interface Props {
+type EditorBlockProps = {
   title: string;
   selectedErrorType: string | null;
   block: BlockData;
@@ -21,13 +21,15 @@ interface Props {
   onChange: (index: number, updated: Partial<BlockData>) => void;
   onToggleChecklist: (index: number, item: string, checked: boolean) => void;
   onAddBlock?: () => void;
-
   isActive: boolean;
   isLast: boolean;
   onEnd?: () => void;
   onShowSaveAlert?: () => void;
   onActivate: (index: number) => void;
-}
+};
+
+const MIN_H = 200;
+const MAX_H = 2000;
 
 const EditorBlock = ({
   block,
@@ -42,7 +44,45 @@ const EditorBlock = ({
   title,
   selectedErrorType,
   onShowSaveAlert,
-}: Props) => {
+}: EditorBlockProps) => {
+  const [editorHeight, setEditorHeight] = useState<number>(MIN_H);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  const autosizeToContent = () => {
+    const ta = wrapRef.current?.querySelector(
+      "textarea.w-md-editor-text-input"
+    ) as HTMLTextAreaElement | null;
+    if (!ta) return;
+    ta.style.height = "auto";
+    const needed = ta.scrollHeight;
+    const next = Math.max(MIN_H, Math.min(MAX_H, needed + 24));
+    setEditorHeight(next);
+  };
+
+  useLayoutEffect(() => {
+    autosizeToContent();
+    const t = setTimeout(autosizeToContent, 0);
+    return () => clearTimeout(t);
+  }, [block.content, isActive]);
+
+  const applyWrapperHeight = () => {
+    const h = wrapRef.current?.getBoundingClientRect().height;
+    if (!h) return;
+    setEditorHeight(Math.max(MIN_H, Math.min(MAX_H, Math.round(h))));
+  };
+
+  useEffect(() => {
+    const ta = wrapRef.current?.querySelector(
+      "textarea.w-md-editor-text-input"
+    ) as HTMLTextAreaElement | null;
+    if (!ta || !("ResizeObserver" in window)) return;
+    const ro = new ResizeObserver(() => {
+      requestAnimationFrame(autosizeToContent);
+    });
+    ro.observe(ta);
+    return () => ro.disconnect();
+  }, []);
+
   return (
     <div
       className="flex flex-row gap-[25px] pb-[25px]"
@@ -83,30 +123,36 @@ const EditorBlock = ({
         </div>
 
         <div data-color-mode="light">
-          <MDEditor
-            value={block.content}
-            onChange={(val) => onChange(index, { content: val || "" })}
-            height={240}
-            preview={isActive ? "edit" : "preview"}
-            style={{ width: "1200px" }}
-            autoFocus={isActive}
-          />
+          <div
+            ref={wrapRef}
+            className="resize-y overflow-visible rounded-[8px] border border-gray-200"
+            style={{ minHeight: MIN_H, maxHeight: MAX_H, height: editorHeight }}
+            onMouseUp={applyWrapperHeight}
+            onTouchEnd={applyWrapperHeight}
+          >
+            <MDEditor
+              value={block.content}
+              onChange={(val) => {
+                onChange(index, { content: val || "" });
+                setTimeout(autosizeToContent, 0);
+              }}
+              height={editorHeight}
+              preview={isActive ? "edit" : "preview"}
+              style={{ width: "1200px", border: "none" }}
+              autoFocus={isActive}
+            />
+          </div>
         </div>
       </div>
 
-      {/* 오른쪽 체크리스트 */}
       <div className="flex flex-col gap-2 mt-14">
         {block.checklistItems.length > 0 && (
           <h3 className="text-base font-semibold text-gray4 flex items-center gap-2">
-
             <img src={alertIcon} alt="alert icon" className="w-5 h-5" />
-
-          
             {block.checklistTitle}
           </h3>
         )}
-
-        {block.checklistItems.map((item) => (
+        {block.checklistItems.map((item: string) => (
           <label
             key={item}
             className="flex items-start gap-2 text-sm text-gray-700 cursor-pointer"
@@ -122,12 +168,10 @@ const EditorBlock = ({
                 ["--icon-unchecked" as any]: `url("${nonCheckBoxIcon}")`,
                 ["--icon-checked" as any]: `url("${checkBoxIcon}")`,
               }}
-              className="
-    inline-block w-5 h-5 bg-no-repeat bg-center bg-contain
-    [background-image:var(--icon-unchecked)]
-    peer-checked:[background-image:var(--icon-checked)]
-  "
-            ></span>
+              className="inline-block w-5 h-5 bg-no-repeat bg-center bg-contain
+                         [background-image:var(--icon-unchecked)]
+                         peer-checked:[background-image:var(--icon-checked)]"
+            />
             <span>{item}</span>
           </label>
         ))}
@@ -137,3 +181,4 @@ const EditorBlock = ({
 };
 
 export default EditorBlock;
+export type { EditorBlockProps };

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -14,7 +14,6 @@ export const PATH = {
   FOLLOWER: (id: string) => `/user/mypage/${id}/follower`,
   STATISTICS: (id: string) => `/user/mypage/${id}/statistics`,
   LIKES: (id: string) => `/user/mypage/${id}/likes`,
-
   PROJECT_DETAIL: (id: string) => `/user/project/${id}`,
   COMMUNITY: "/user/community",
   COMMUNITY_POST: (postId: number) => `/user/community/${postId}`,

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -27,6 +27,23 @@ export type BlockData = {
   isSaved: boolean;
 };
 
+type IncomingFreeformState = {
+  editorType?: "FREEFORM";
+  title?: string;
+  tags?: string[];
+  errorType?: string | null;
+  blocks?: BlockData[];
+  savePrefill?: {
+    importance?: number;
+    description?: string;
+    visibility?: "public" | "private";
+    projectId?: number | null;
+    projectName?: string;
+    thumbnail?: string | null;
+  };
+  projectId?: number;
+};
+
 const errorOptions = [
   "Build / Compile Error",
   "Runtime Error",
@@ -52,7 +69,6 @@ export default function FreeFormWritePage() {
     { id: Date.now(), title: "", content: "", isSaved: false },
   ]);
 
-  // 모달 & 알림 상태
   const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
   const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
     useState(false);
@@ -62,7 +78,6 @@ export default function FreeFormWritePage() {
   const [showSaveAlert, setShowSaveAlert] = useState(false);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
 
-  // 생성/요약 진행 상태
   const [previewMeta, setPreviewMeta] = useState<PostSavePayload | null>(null);
   const [createdPostId, setCreatedPostId] = useState<number | null>(null);
   const [summaryTaskId, setSummaryTaskId] = useState<string | null>(null);
@@ -83,11 +98,23 @@ export default function FreeFormWritePage() {
 
   const closingRef = useRef(false);
   const navigate = useNavigate();
-  const location = useLocation() as { state?: { projectId?: number } };
+  const location = useLocation() as { state?: IncomingFreeformState };
   const initialProjectId = location.state?.projectId;
   const { data: projectList, loading: projectsLoading } = useProjectList();
 
-  // 자유양식 -> 서버 DTO
+  // 프리필 반영
+  useEffect(() => {
+    if (
+      location.state?.editorType === "FREEFORM" &&
+      location.state.blocks?.length
+    ) {
+      setTitle(location.state.title ?? "");
+      setSelectedTags(location.state.tags ?? []);
+      setSelectedErrorType(location.state.errorType ?? null);
+      setBlocks(location.state.blocks);
+    }
+  }, [location.state]);
+
   const toContentDtoList = (items: BlockData[]): PostContentDto[] =>
     items
       .filter((b) => (b.content ?? "").trim().length > 0)
@@ -140,7 +167,6 @@ export default function FreeFormWritePage() {
     setIsTemplateSelectModalOpen(true);
   };
 
-  // 템플릿 선택 -> 문서 생성 + 요약 시작
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -186,7 +212,6 @@ export default function FreeFormWritePage() {
     }
   };
 
-  // 요약 상태
   useEffect(() => {
     if (!isLoadingModalOpen || !createdPostId || !summaryTaskId) return;
 
@@ -199,7 +224,7 @@ export default function FreeFormWritePage() {
         if (stopped) return;
         const p = Math.max(0, Math.min(100, data.progress ?? 0));
         setSummaryProgress(p);
-        if (data.status) setSummaryStatus(data.status as SummaryStatus);
+        if (data.status) setSummaryStatus(data.status as any);
         if (data.message) setStatusMessage(data.message);
         if (data.status === "COMPLETED" || p >= 100) {
           setSummaryProgress(100);
@@ -225,7 +250,6 @@ export default function FreeFormWritePage() {
     };
   }, [isLoadingModalOpen, createdPostId, summaryTaskId]);
 
-  // 미리보기
   const handleLater = () => {
     const filled = blocks.filter((b) => b.content?.trim().length > 0);
     const questions = filled.map((b) =>
@@ -235,10 +259,22 @@ export default function FreeFormWritePage() {
 
     navigate(PATH.PREVIEW, {
       state: {
+        editorType: "FREEFORM",
         title,
         tags: selectedTags,
         errorType: selectedErrorType,
         importance: previewMeta?.importance,
+        // save modal
+        savePrefill: previewMeta
+          ? {
+              importance: previewMeta.importance ?? 0,
+              description: previewMeta.description ?? "",
+              visibility: previewMeta.visibility ?? "public",
+              projectId: previewMeta.projectId ?? null,
+              projectName: previewMeta.projectName,
+              thumbnail: previewMeta.thumbnail ?? null,
+            }
+          : undefined,
         authorName: "나",
         authorProfile: null,
         authorBio: "",
@@ -249,7 +285,6 @@ export default function FreeFormWritePage() {
     });
   };
 
-  // 로딩 모달 닫기(요약 취소)
   const handleCloseLoading = async () => {
     if (closingRef.current) return;
     closingRef.current = true;
@@ -276,7 +311,6 @@ export default function FreeFormWritePage() {
       <HeaderWoSearch />
       <div className="flex justify-center px-[360px] pt-[68px] items-start">
         <div className="flex-1 flex w-[1200px] flex-col gap-3">
-          {/* Alerts */}
           {showAlert && (
             <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               제목과 에러 종류를 모두 입력해주세요.
@@ -298,7 +332,6 @@ export default function FreeFormWritePage() {
             </div>
           )}
 
-          {/* 제목 + 태그 */}
           <div className="flex flex-col items-start gap-[40px]">
             <input
               type="text"
@@ -320,7 +353,6 @@ export default function FreeFormWritePage() {
             </div>
           </div>
 
-          {/* 블록들 */}
           {blocks.map((block, idx) => (
             <div key={block.id} className="max-w-[1200px]">
               <div className="w-full flex flex-row justify-center items-end h-[60px] mb-3">
@@ -333,7 +365,6 @@ export default function FreeFormWritePage() {
                   placeholder="소제목을 입력하세요"
                   className="w-[1070px] p-2 border-none rounded font-bold text-black text-[24px]"
                 />
-                {/* Save / End (첫 블록에만 End 노출) */}
                 <div className="flex items-end justify-center gap-2">
                   <button
                     onClick={() => {
@@ -365,7 +396,6 @@ export default function FreeFormWritePage() {
             </div>
           ))}
 
-          {/* 블록 추가 */}
           <button
             onClick={handleAddBlock}
             disabled={blocks.length >= 10}
@@ -374,7 +404,6 @@ export default function FreeFormWritePage() {
             + 블록 추가하기 ({blocks.length}/10)
           </button>
 
-          {/* 모달들 */}
           {isPostSaveModalOpen && (
             <PostSaveModal
               onClose={() => setIsPostSaveModalOpen(false)}
@@ -383,6 +412,16 @@ export default function FreeFormWritePage() {
               loadingProjects={projectsLoading}
               defaultProjectId={initialProjectId}
               selectedTags={selectedTags}
+              // 수정 반영
+              initialImportance={location.state?.savePrefill?.importance}
+              initialDescription={location.state?.savePrefill?.description}
+              initialVisibility={location.state?.savePrefill?.visibility}
+              initialProjectId={
+                location.state?.savePrefill?.projectId ??
+                initialProjectId ??
+                null
+              }
+              initialThumbnail={location.state?.savePrefill?.thumbnail ?? null}
             />
           )}
 

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -96,6 +96,8 @@ export default function FreeFormWritePage() {
   );
   const [statusMessage, setStatusMessage] = useState<string>("");
 
+  const [nextAction, setNextAction] = useState<"SUMMARY" | "SAVE" | null>(null);
+
   const closingRef = useRef(false);
   const navigate = useNavigate();
   const location = useLocation() as { state?: IncomingFreeformState };
@@ -126,9 +128,6 @@ export default function FreeFormWritePage() {
         summaryType: "NONE",
       }));
 
-  const toGuideContent = (text: string) =>
-    (text ?? "").split(/\n{2,}/).map((s) => s.trim());
-
   const handleAddBlock = () => {
     if (blocks.length >= 10) return;
     setBlocks((prev) => [
@@ -147,6 +146,57 @@ export default function FreeFormWritePage() {
     );
   };
 
+  const buildCreateForm = (
+    postStatus: "COMPLETED" | "DRAFT",
+    meta: PostSavePayload | null = previewMeta
+  ): PostForm => ({
+    title,
+    introduction: meta?.description ?? "",
+    postTags: selectedTags?.filter(Boolean) ?? [],
+    isVisible: (meta?.visibility ?? "public") === "public",
+    isSummaryCreated: false,
+    postStatus,
+    starRating: String(meta?.importance ?? 0),
+    thumbnailImageUrl: meta?.thumbnail ?? undefined,
+    projectId: Number(meta?.projectId ?? 0),
+    errorTag: selectedErrorType ?? "",
+    contents: toContentDtoList(blocks),
+  });
+
+  const saveOriginalOnly = async (
+    meta: PostSavePayload | null = previewMeta
+  ) => {
+    if (!meta?.projectId) {
+      setIsPostSaveModalOpen(true);
+      return;
+    }
+    try {
+      const req = toCreatePostRequest(buildCreateForm("COMPLETED", meta));
+      console.debug("[createPost] payload", req);
+      await createPost(req);
+      navigate(PATH.PROJECT_DETAIL(String(meta.projectId)), {
+        state: { projectName: meta.projectName },
+      });
+    } catch (err: any) {
+      const status = err?.response?.status;
+      const data = err?.response?.data;
+      console.error("createPost error", status, data, err);
+
+      if (status === 401) {
+        setStatusMessage("로그인이 만료되었어요. 다시 로그인해주세요.");
+        navigate(PATH.LOGIN);
+        return;
+      }
+
+      const msg =
+        (typeof data === "string" && data) ||
+        data?.message ||
+        data?.error ||
+        "원본 저장에 실패했어요. 잠시 후 다시 시도해주세요.";
+      setStatusMessage(msg);
+    }
+  };
+
   const handleEnd = () => {
     if (!title.trim() || !selectedErrorType) {
       setShowAlert(true);
@@ -158,12 +208,54 @@ export default function FreeFormWritePage() {
       setTimeout(() => setShowBlockAlert(false), 3000);
       return;
     }
+    setNextAction("SUMMARY");
     setIsPostSaveModalOpen(true);
   };
 
-  const handleNextInPostSaveModal = (payload: PostSavePayload) => {
+  const handleGlobalSave = async () => {
+    if (!title.trim() || !selectedErrorType) {
+      setShowAlert(true);
+      setTimeout(() => setShowAlert(false), 3000);
+      return;
+    }
+    if (!blocks[0]?.content.trim()) {
+      setShowBlockAlert(true);
+      setTimeout(() => setShowBlockAlert(false), 3000);
+      return;
+    }
+
+    setBlocks((prev) => prev.map((b) => ({ ...b, isSaved: true })));
+    setShowSaveAlert(true);
+    setTimeout(() => setShowSaveAlert(false), 3000);
+
+    setNextAction("SAVE");
+
+    if (!previewMeta?.projectId) {
+      setIsPostSaveModalOpen(true);
+      return;
+    }
+
+    try {
+      await saveOriginalOnly(previewMeta);
+    } catch (e) {
+      console.error(e);
+      setStatusMessage("원본 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+    }
+  };
+
+  const handleNextInPostSaveModal = async (payload: PostSavePayload) => {
     setPreviewMeta(payload);
     setIsPostSaveModalOpen(false);
+
+    if (nextAction === "SAVE") {
+      try {
+        await saveOriginalOnly(payload);
+      } catch (e) {
+        console.error(e);
+        setStatusMessage("원본 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+      }
+      return;
+    }
     setIsTemplateSelectModalOpen(true);
   };
 
@@ -179,21 +271,7 @@ export default function FreeFormWritePage() {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      const form: PostForm = {
-        title,
-        introduction: previewMeta?.description ?? "",
-        postTags: selectedTags,
-        isVisible: (previewMeta?.visibility ?? "public") === "public",
-        isSummaryCreated: false,
-        postStatus: "DRAFT",
-        starRating: String(previewMeta?.importance ?? "0"),
-        thumbnailImageUrl: previewMeta?.thumbnail ?? undefined,
-        projectId: previewMeta?.projectId ?? 0,
-        errorTag: selectedErrorType ?? "",
-        contents: toContentDtoList(blocks),
-      };
-
-      const req = toCreatePostRequest(form);
+      const req = toCreatePostRequest(buildCreateForm("DRAFT"));
       const created = await createPost(req);
       const postId = created.id;
       setCreatedPostId(postId);
@@ -250,39 +328,28 @@ export default function FreeFormWritePage() {
     };
   }, [isLoadingModalOpen, createdPostId, summaryTaskId]);
 
-  const handleLater = () => {
-    const filled = blocks.filter((b) => b.content?.trim().length > 0);
-    const questions = filled.map((b) =>
-      b.title?.trim() ? b.title.trim() : "(제목 없음)"
-    );
-    const contents = filled.map((b) => toGuideContent(b.content));
+  const handleLater = async () => {
+    if (
+      !title.trim() ||
+      !selectedErrorType ||
+      !blocks[0]?.content.trim() ||
+      !previewMeta?.projectId
+    ) {
+      setShowAlert(true);
+      setTimeout(() => setShowAlert(false), 3000);
+      return;
+    }
 
-    navigate(PATH.PREVIEW, {
-      state: {
-        editorType: "FREEFORM",
-        title,
-        tags: selectedTags,
-        errorType: selectedErrorType,
-        importance: previewMeta?.importance,
-        // save modal
-        savePrefill: previewMeta
-          ? {
-              importance: previewMeta.importance ?? 0,
-              description: previewMeta.description ?? "",
-              visibility: previewMeta.visibility ?? "public",
-              projectId: previewMeta.projectId ?? null,
-              projectName: previewMeta.projectName,
-              thumbnail: previewMeta.thumbnail ?? null,
-            }
-          : undefined,
-        authorName: "나",
-        authorProfile: null,
-        authorBio: "",
-        date: new Date().toISOString().slice(2, 10).replace(/-/g, "."),
-        questions,
-        contents,
-      },
-    });
+    try {
+      const req = toCreatePostRequest(buildCreateForm("COMPLETED"));
+      await createPost(req);
+      navigate(PATH.PROJECT_DETAIL(String(previewMeta.projectId)), {
+        state: { projectName: previewMeta.projectName },
+      });
+    } catch (e) {
+      console.error(e);
+      setStatusMessage("원본 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+    }
   };
 
   const handleCloseLoading = async () => {
@@ -311,6 +378,7 @@ export default function FreeFormWritePage() {
       <HeaderWoSearch />
       <div className="flex justify-center px-[360px] pt-[68px] items-start">
         <div className="flex-1 flex w-[1200px] flex-col gap-3">
+          {/* Alerts */}
           {showAlert && (
             <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               제목과 에러 종류를 모두 입력해주세요.
@@ -332,6 +400,7 @@ export default function FreeFormWritePage() {
             </div>
           )}
 
+          {/* 제목/태그 + 상단 액션바 */}
           <div className="flex flex-col items-start gap-[40px]">
             <input
               type="text"
@@ -340,22 +409,39 @@ export default function FreeFormWritePage() {
               placeholder="제목을 입력하세요."
               className="text-[36px] md:text-[48px] font-bold text-black outline-none w-full leading-tight"
             />
-            <div className="flex gap-[36px] items-center">
-              <DropDownButton
-                options={errorOptions}
-                placeholder="에러 종류를 선택하세요"
-                width="w-[340px]"
-                onSelect={(selectedError) =>
-                  setSelectedErrorType(selectedError)
-                }
-              />
-              <CategoryTag value={selectedTags} onChange={setSelectedTags} />
+            <div className="flex w-[1200px] justify-between">
+              <div className="flex gap-[36px] items-center">
+                <DropDownButton
+                  options={errorOptions}
+                  placeholder="에러 종류를 선택하세요"
+                  width="w-[340px]"
+                  onSelect={(selectedError) =>
+                    setSelectedErrorType(selectedError)
+                  }
+                />
+                <CategoryTag value={selectedTags} onChange={setSelectedTags} />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleGlobalSave}
+                  className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={handleEnd}
+                  className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600"
+                >
+                  End
+                </button>
+              </div>
             </div>
           </div>
 
-          {blocks.map((block, idx) => (
+          {/* 블록 리스트 */}
+          {blocks.map((block) => (
             <div key={block.id} className="max-w-[1200px]">
-              <div className="w-full flex flex-row justify-center items-end h-[60px] mb-3">
+              <div className="w-full flex items-end h-[60px] mb-2">
                 <input
                   type="text"
                   value={block.title}
@@ -363,30 +449,12 @@ export default function FreeFormWritePage() {
                     handleChangeBlock(block.id, "title", e.target.value)
                   }
                   placeholder="소제목을 입력하세요"
-                  className="w-[1070px] p-2 border-none rounded font-bold text-black text-[24px]"
+                  className="flex-1 px-0 py-2 border-none rounded font-bold text-black text-[24px]"
                 />
-                <div className="flex items-end justify-center gap-2">
-                  <button
-                    onClick={() => {
-                      setShowSaveAlert(true);
-                      setTimeout(() => setShowSaveAlert(false), 3000);
-                    }}
-                    className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100"
-                  >
-                    Save
-                  </button>
-                  {idx === 0 && (
-                    <button
-                      onClick={handleEnd}
-                      className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600"
-                    >
-                      End
-                    </button>
-                  )}
-                </div>
               </div>
 
               <MDEditor
+                className="mt-2"
                 value={block.content}
                 onChange={(val) =>
                   handleChangeBlock(block.id, "content", val || "")
@@ -404,6 +472,7 @@ export default function FreeFormWritePage() {
             + 블록 추가하기 ({blocks.length}/10)
           </button>
 
+          {/* 모달들 */}
           {isPostSaveModalOpen && (
             <PostSaveModal
               onClose={() => setIsPostSaveModalOpen(false)}
@@ -412,7 +481,6 @@ export default function FreeFormWritePage() {
               loadingProjects={projectsLoading}
               defaultProjectId={initialProjectId}
               selectedTags={selectedTags}
-              // 수정 반영
               initialImportance={location.state?.savePrefill?.importance}
               initialDescription={location.state?.savePrefill?.description}
               initialVisibility={location.state?.savePrefill?.visibility}

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -115,7 +115,6 @@ export default function PostSaveModal({
       visibility: selectedVisibility,
       projectId: selectedProjectId ?? null,
       projectName,
-      summaryType,
     });
   };
 

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -19,9 +19,9 @@ export type PostSavePayload = {
   thumbnail: string | null;
   description: string;
   visibility: Visibility;
-  projectId: number;
+  projectId: number | null;
   projectName?: string;
-  summaryType: SummaryTypeParam;
+  summaryType?: SummaryTypeParam;
 };
 
 type ProjectOption = { id: number; name: string };
@@ -33,6 +33,12 @@ export default function PostSaveModal({
   defaultProjectId,
   loadingProjects = false,
   selectedTags = [],
+
+  initialImportance,
+  initialDescription,
+  initialVisibility,
+  initialProjectId,
+  initialThumbnail,
 }: {
   onClose: () => void;
   onNext: (payload: PostSavePayload) => void;
@@ -40,23 +46,50 @@ export default function PostSaveModal({
   defaultProjectId?: number;
   loadingProjects?: boolean;
   selectedTags?: string[];
+  initialImportance?: number;
+  initialDescription?: string;
+  initialVisibility?: Visibility;
+  initialProjectId?: number | null;
+  initialThumbnail?: string | null;
 }) {
-  const [thumbnail, setThumbnail] = useState<string | null>(null);
-  const [importance, setImportance] = useState(0);
-  const [description, setDescription] = useState("");
-  const [selectedVisibility, setSelectedVisibility] =
-    useState<Visibility>("public");
+  const [thumbnail, setThumbnail] = useState<string | null>(
+    initialThumbnail ?? null
+  );
+  const [importance, setImportance] = useState<number>(initialImportance ?? 0);
+  const [description, setDescription] = useState<string>(
+    initialDescription ?? ""
+  );
+  const [selectedVisibility, setSelectedVisibility] = useState<Visibility>(
+    initialVisibility ?? "public"
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [hoverIndex, setHoverIndex] = useState(0);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
-    defaultProjectId ?? null
+    initialProjectId ?? defaultProjectId ?? null
   );
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
+
   const projectName =
     projects.find((p) => p.id === selectedProjectId)?.name ?? "";
-
   const projectNames = projects.map((p) => p.name);
   const nameToId = new Map(projects.map((p) => [p.name, p.id]));
+
+  useEffect(() => {
+    if (initialImportance != null) setImportance(initialImportance);
+  }, [initialImportance]);
+  useEffect(() => {
+    if (initialDescription != null) setDescription(initialDescription);
+  }, [initialDescription]);
+  useEffect(() => {
+    if (initialVisibility) setSelectedVisibility(initialVisibility);
+  }, [initialVisibility]);
+  useEffect(() => {
+    const pid = initialProjectId ?? defaultProjectId ?? null;
+    setSelectedProjectId(pid);
+  }, [initialProjectId, defaultProjectId]);
+  useEffect(() => {
+    if (initialThumbnail !== undefined) setThumbnail(initialThumbnail);
+  }, [initialThumbnail]);
 
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -68,27 +101,21 @@ export default function PostSaveModal({
     }
   };
 
-  const handleUploadClick = () => {
-    fileInputRef.current?.click();
-  };
+  const handleUploadClick = () => fileInputRef.current?.click();
 
   const handleNextClick = () => {
     setHasTriedSubmit(true);
-
-    if (importance === 0) return; //홈화면 프로젝트생성 연동후 !selectedProjectId || 추가
-
+    if (importance === 0) return;
     onNext({
       importance,
       thumbnail,
       description,
       visibility: selectedVisibility,
-      projectId: selectedProjectId,
+      projectId: selectedProjectId ?? null,
       projectName,
     });
   };
-  useEffect(() => {
-    if (defaultProjectId != null) setSelectedProjectId(defaultProjectId);
-  }, [defaultProjectId]);
+
   useEffect(() => {
     return () => {
       if (thumbnail && thumbnail.startsWith("blob:")) {
@@ -96,6 +123,7 @@ export default function PostSaveModal({
       }
     };
   }, [thumbnail]);
+
   const previewTags: string[] = useMemo(
     () => (selectedTags ?? []).slice(0, 3),
     [selectedTags]
@@ -115,6 +143,7 @@ export default function PostSaveModal({
           <img src={exitIcon} alt="닫기" className="w-full h-full" />
         </button>
       </div>
+
       <div className="flex flex-col gap-[10px]">
         <div className="items-center gap-[40px]">
           {/* 썸네일 + 별점 */}
@@ -192,11 +221,11 @@ export default function PostSaveModal({
             </div>
           </div>
 
-          {/*썸네일 아래 모든 컴포넌트(버튼 제외)*/}
+          {/* 아래 영역 */}
           <div className="flex-col items-center gap-[16px] w-[728px] pt-[40px] ">
             {/* (에러타입+tag) + 소개 */}
             <div className="flex flex-row gap-[26px]">
-              {/*에러 +태그 */}
+              {/* 에러 + 태그 (프리뷰용) */}
               <div className="flex-col items-start gap-[16px]">
                 <div className="flex flex-col w-[351px] justify-center items-start h-[78px] gap-[8px] pr-[26px] shrink-0">
                   <span className="text-head-20-semibold text-black ">
@@ -209,11 +238,10 @@ export default function PostSaveModal({
                   </div>
                 </div>
                 {/* 태그 */}
-                <div className="flex w-[351px] flex-col pt-[26px] ">
+                <div className="flex w=[351px] flex-col pt-[26px] ">
                   <span className="text-head-20-semibold text-black">
                     카테고리 태그
                   </span>
-
                   <div className="grid gap-[8px] h-[46px] shrink-0">
                     <div className="flex items-center gap-[12px] self-stretch shrink-0">
                       {previewTags.length > 0 ? (
@@ -226,15 +254,8 @@ export default function PostSaveModal({
                               #{tag}
                             </div>
                           ))}
-
                           {extraCount > 0 && (
-                            <div
-                              className="flex h-[32px] py-[7px] px-[10px] justify-center items-center gap-[2px] bg-gray-100 text-gray-600 rounded-full text-sm"
-                              title={selectedTags
-                                .slice(3)
-                                .map((t) => `#${t}`)
-                                .join(", ")}
-                            >
+                            <div className="flex h-[32px] py-[7px] px-[10px] justify-center items-center gap-[2px] bg-gray-100 text-gray-600 rounded-full text-sm">
                               +{extraCount}
                             </div>
                           )}
@@ -248,6 +269,7 @@ export default function PostSaveModal({
                   </div>
                 </div>
               </div>
+              {/* 소개 */}
               <div className="flex flex-col w-[351px] gap-[8px]">
                 <span className="text-head-20-semibold text-black">
                   포스트 소개
@@ -267,22 +289,20 @@ export default function PostSaveModal({
               </div>
             </div>
 
-            {/* 공개 설정 + 폴더 경로 */}
+            {/* 공개 설정 + 프로젝트 */}
             <div className="flex w-[728px] flex-row gap-[26px] ">
               <div className="flex flex-col w-[351px] gap-[8px]">
                 <span className="text-head-20-semibold text-gray7">
                   공개 설정
                 </span>
                 <div className="flex gap-3">
-                  {/* 전체 공개 */}
                   <button
                     type="button"
-                    className={`flex w-[168px] h-[46px] items-center justify-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition
-      ${
-        selectedVisibility === "public"
-          ? "border-purple-500  text-purple-500 bg-opacity-10"
-          : "border-gray2"
-      }`}
+                    className={`flex w-[168px] h-[46px] items-center justify-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition ${
+                      selectedVisibility === "public"
+                        ? "border-purple-500  text-purple-500 bg-opacity-10"
+                        : "border-gray2"
+                    }`}
                     onClick={() => setSelectedVisibility("public")}
                   >
                     <img
@@ -303,15 +323,13 @@ export default function PostSaveModal({
                     </span>
                   </button>
 
-                  {/* 비공개 */}
                   <button
                     type="button"
-                    className={`flex w-[168px] h-[46px] items-center justify-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition
-    ${
-      selectedVisibility === "private"
-        ? "border-purple-500 text-purple-500 bg-opacity-10"
-        : "border-gray2"
-    }`}
+                    className={`flex w-[168px] h-[46px] items-center justify-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition ${
+                      selectedVisibility === "private"
+                        ? "border-purple-500 text-purple-500 bg-opacity-10"
+                        : "border-gray2"
+                    }`}
                     onClick={() => setSelectedVisibility("private")}
                   >
                     <img

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -224,11 +224,11 @@ export default function PostSaveModal({
           </div>
 
           {/* 아래 영역 */}
-          <div className="flex-col items-center gap-[16px] w-[728px] pt-[40px] ">
+          <div className="flex flex-col items-center gap-[16px] w-[728px] pt-[40px] ">
             {/* (에러타입+tag) + 소개 */}
             <div className="flex flex-row gap-[26px]">
               {/* 에러 + 태그 (프리뷰용) */}
-              <div className="flex-col items-start gap-[16px]">
+              <div className="flex flex-col items-start gap-[16px]">
                 <div className="flex flex-col w-[351px] justify-center items-start h-[78px] gap-[8px] pr-[26px] shrink-0">
                   <span className="text-head-20-semibold text-black ">
                     에러타입
@@ -240,7 +240,7 @@ export default function PostSaveModal({
                   </div>
                 </div>
                 {/* 태그 */}
-                <div className="flex w=[351px] flex-col pt-[26px] ">
+                <div className="flex w-[351px] flex-col pt-[26px] ">
                   <span className="text-head-20-semibold text-black">
                     카테고리 태그
                   </span>

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -12,6 +12,8 @@ import privateIcon from "@/assets/icons/privateicon.svg";
 import purplePrivateIcon from "@/assets/icons/purpleprivateicon.svg";
 import type { SummaryTypeParam } from "@/models/post.model";
 
+import { uploadImage } from "@/api/image.api";
+
 type Visibility = "public" | "private";
 
 export type PostSavePayload = {
@@ -33,7 +35,6 @@ export default function PostSaveModal({
   defaultProjectId,
   loadingProjects = false,
   selectedTags = [],
-
   initialImportance,
   initialDescription,
   initialVisibility,
@@ -54,7 +55,7 @@ export default function PostSaveModal({
 }) {
   const [thumbnail, setThumbnail] = useState<string | null>(
     initialThumbnail ?? null
-  );
+  ); // 서버 URL
   const [importance, setImportance] = useState<number>(initialImportance ?? 0);
   const [description, setDescription] = useState<string>(
     initialDescription ?? ""
@@ -62,12 +63,18 @@ export default function PostSaveModal({
   const [selectedVisibility, setSelectedVisibility] = useState<Visibility>(
     initialVisibility ?? "public"
   );
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [hoverIndex, setHoverIndex] = useState(0);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
     initialProjectId ?? defaultProjectId ?? null
   );
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
+
+  // 업로드 상태
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [tempPreview, setTempPreview] = useState<string | null>(null); // 로컬 미리보기
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const MAX_MB = 8;
 
   const projectName =
     projects.find((p) => p.id === selectedProjectId)?.name ?? "";
@@ -77,34 +84,95 @@ export default function PostSaveModal({
   useEffect(() => {
     if (initialImportance != null) setImportance(initialImportance);
   }, [initialImportance]);
+
   useEffect(() => {
     if (initialDescription != null) setDescription(initialDescription);
   }, [initialDescription]);
+
   useEffect(() => {
     if (initialVisibility) setSelectedVisibility(initialVisibility);
   }, [initialVisibility]);
+
   useEffect(() => {
     const pid = initialProjectId ?? defaultProjectId ?? null;
     setSelectedProjectId(pid);
   }, [initialProjectId, defaultProjectId]);
+
   useEffect(() => {
     if (initialThumbnail !== undefined) setThumbnail(initialThumbnail);
   }, [initialThumbnail]);
 
-  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      if (thumbnail && thumbnail.startsWith("blob:")) {
-        URL.revokeObjectURL(thumbnail);
-      }
-      setThumbnail(URL.createObjectURL(file));
-    }
-  };
+  useEffect(() => {
+    return () => {
+      if (tempPreview) URL.revokeObjectURL(tempPreview);
+    };
+  }, [tempPreview]);
+
+  const previewTags: string[] = useMemo(
+    () => (selectedTags ?? []).slice(0, 3),
+    [selectedTags]
+  );
+  const extraCount = Math.max(0, (selectedTags?.length ?? 0) - 3);
 
   const handleUploadClick = () => fileInputRef.current?.click();
 
+  const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // 기본 검증
+    if (!file.type.startsWith("image/")) {
+      alert("이미지 파일만 업로드할 수 있어요.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+    if (file.size > MAX_MB * 1024 * 1024) {
+      alert(`파일 용량이 너무 커요. 최대 ${MAX_MB}MB까지 가능합니다.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    // 로컬 프리뷰
+    if (tempPreview) URL.revokeObjectURL(tempPreview);
+    const localUrl = URL.createObjectURL(file);
+    setTempPreview(localUrl);
+
+    // 서버 업로드
+    try {
+      setIsUploading(true);
+      setUploadProgress(0);
+
+      const serverUrl = await uploadImage(file, (p) => setUploadProgress(p));
+
+      setThumbnail(serverUrl);
+      if (localUrl) URL.revokeObjectURL(localUrl);
+      setTempPreview(null);
+    } catch (err: any) {
+      console.error(err);
+      alert(err?.message ?? "이미지 업로드에 실패했습니다.");
+      setThumbnail(null);
+    } finally {
+      setIsUploading(false);
+      setUploadProgress(0);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleRemoveImage = () => {
+    if (tempPreview) {
+      URL.revokeObjectURL(tempPreview);
+      setTempPreview(null);
+    }
+    setThumbnail(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
   const handleNextClick = () => {
     setHasTriedSubmit(true);
+    if (isUploading) {
+      alert("이미지 업로드가 끝난 후 저장할 수 있어요.");
+      return;
+    }
     if (importance === 0) return;
     if (selectedProjectId == null) return;
 
@@ -117,20 +185,6 @@ export default function PostSaveModal({
       projectName,
     });
   };
-
-  useEffect(() => {
-    return () => {
-      if (thumbnail && thumbnail.startsWith("blob:")) {
-        URL.revokeObjectURL(thumbnail);
-      }
-    };
-  }, [thumbnail]);
-
-  const previewTags: string[] = useMemo(
-    () => (selectedTags ?? []).slice(0, 3),
-    [selectedTags]
-  );
-  const extraCount = Math.max(0, (selectedTags?.length ?? 0) - 3);
 
   return (
     <BaseModal
@@ -151,36 +205,50 @@ export default function PostSaveModal({
           {/* 썸네일 + 별점 */}
           <div className="inline-flex items-center pt-[33px] pr-[65px] gap-[108px]">
             {/* 썸네일 */}
-            <div className=" relative flex w-[351px] h-[154px] overflow-hidden justify-center items-center border-dashed border-[2px] border-gray1 bg-[#FCFCFC] rounded-[16px]">
-              {thumbnail ? (
-                <>
-                  <img
-                    src={thumbnail}
-                    alt="썸네일"
-                    className="absolute inset-0 w-full h-full object-cover"
-                  />
-                  <button
-                    onClick={() => setThumbnail(null)}
-                    className="absolute bottom-[18px] z-10 px-[23px] pt-[10px] pb-[11px] bg-white border-[1.5px] border-gray1 rounded-[8px]"
-                  >
-                    썸네일 삭제
-                  </button>
-                </>
+            <div className="relative flex w-[351px] h-[154px] overflow-hidden justify-center items-center border-dashed border-[2px] border-gray1 bg-[#FCFCFC] rounded-[16px]">
+              {tempPreview || thumbnail ? (
+                <img
+                  src={tempPreview ?? thumbnail!}
+                  alt="썸네일"
+                  className="absolute inset-0 w-full h-full object-cover"
+                />
               ) : (
-                <>
-                  <div className="flex w-[111px] flex-col items-center gap-[23px]">
-                    <img src={addImageIcon} className="w-[52px] h-[52px]" />
-                    <button
-                      onClick={handleUploadClick}
-                      className=" flex w-[111px] h-[38px] self-stretch justify-center items-center bg-white border-[1.5px] border-gray1 rounded-[8px]"
-                    >
-                      <span className="text-sm font-normal text-black">
-                        썸네일 업로드
-                      </span>
-                    </button>
-                  </div>
-                </>
+                <div className="flex w-[111px] flex-col items-center gap-[23px]">
+                  <img src={addImageIcon} className="w-[52px] h-[52px]" />
+                  <button
+                    onClick={handleUploadClick}
+                    className="flex w-[111px] h-[38px] self-stretch justify-center items-center bg-white border-[1.5px] border-gray1 rounded-[8px]"
+                  >
+                    <span className="text-sm font-normal text-black">
+                      썸네일 업로드
+                    </span>
+                  </button>
+                </div>
               )}
+
+              {/* 진행률 오버레이 */}
+              {isUploading && (
+                <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center gap-2">
+                  <div className="w-[70%] h-2 bg-white/40 rounded">
+                    <div
+                      className="h-2 bg-white rounded"
+                      style={{ width: `${uploadProgress}%` }}
+                    />
+                  </div>
+                  <span className="text-white text-sm">{uploadProgress}%</span>
+                </div>
+              )}
+
+              {/* 삭제 버튼 */}
+              {!isUploading && (thumbnail || tempPreview) && (
+                <button
+                  onClick={handleRemoveImage}
+                  className="absolute bottom-[18px] z-10 px-[23px] pt-[10px] pb-[11px] bg-white border-[1.5px] border-gray1 rounded-[8px]"
+                >
+                  썸네일 삭제
+                </button>
+              )}
+
               <input
                 type="file"
                 accept="image/*"
@@ -206,15 +274,11 @@ export default function PostSaveModal({
                   <button
                     key={i}
                     onClick={() => setImportance(i)}
-                    onMouseEnter={() => setHoverIndex(i)}
-                    onMouseLeave={() => setHoverIndex(0)}
+                    onMouseEnter={() => {}}
+                    onMouseLeave={() => {}}
                   >
                     <img
-                      src={
-                        i <= (hoverIndex || importance)
-                          ? starFilledIcon
-                          : starUnfilledIcon
-                      }
+                      src={i <= importance ? starFilledIcon : starUnfilledIcon}
                       className="w-[32px] h-[32px]"
                     />
                   </button>
@@ -233,7 +297,7 @@ export default function PostSaveModal({
                   <span className="text-head-20-semibold text-black ">
                     에러타입
                   </span>
-                  <div className="grid w-[345px] h-[46px] px-[15px] py-[14px] border rounded border-purple-300 bg-white ">
+                  <div className="grid w/[345px] w-[345px] h-[46px] px-[15px] py-[14px] border rounded border-purple-300 bg-white ">
                     <span className="flex flex-1 self-stretch font-normal text-sm text-purple-700">
                       Build / Compile
                     </span>
@@ -272,7 +336,7 @@ export default function PostSaveModal({
                 </div>
               </div>
               {/* 소개 */}
-              <div className="flex flex-col w-[351px] gap-[8px]">
+              <div className="flex flex-col w/[351px] w-[351px] gap-[8px]">
                 <span className="text-head-20-semibold text-black">
                   포스트 소개
                 </span>
@@ -282,7 +346,7 @@ export default function PostSaveModal({
                     onChange={(e) => setDescription(e.target.value)}
                     maxLength={200}
                     placeholder="포스트를 짧게 소개해주세요."
-                    className="w-[351px]  h-[119px] resize-none px-[12px] py-[8px] border border-gray1 rounded-[8px] text-body-14-regular"
+                    className="w-[351px] h-[119px] resize-none px-[12px] py-[8px] border border-gray1 rounded-[8px] text-body-14-regular"
                   />
                   <div className="text-right text-caption-12-regular text-gray2 mt-[4px]">
                     {description.length}/200
@@ -302,7 +366,7 @@ export default function PostSaveModal({
                     type="button"
                     className={`flex w-[168px] h-[46px] items-center justify-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition ${
                       selectedVisibility === "public"
-                        ? "border-purple-500  text-purple-500 bg-opacity-10"
+                        ? "border-purple-500 text-purple-500 bg-opacity-10"
                         : "border-gray2"
                     }`}
                     onClick={() => setSelectedVisibility("public")}
@@ -393,7 +457,7 @@ export default function PostSaveModal({
         {/* 버튼 */}
         <div className="flex justify-end gap-[16px] pt-[12px] pb-[32px]">
           <CancelButton onClick={onClose} />
-          <SaveButton onClick={handleNextClick} />
+          <SaveButton onClick={handleNextClick} disabled={isUploading} />
         </div>
       </div>
     </BaseModal>

--- a/src/pages/TempWrite/PreviewPage.tsx
+++ b/src/pages/TempWrite/PreviewPage.tsx
@@ -23,6 +23,7 @@ type ImageItem = { type: "image"; src: string; alt?: string };
 type GuideContent = string | ImageItem;
 
 interface PreviewState {
+  editorType?: "FREEFORM" | "TEMPLATE";
   guide?: { question: string; content: GuideContent[] };
   errorType?: string | null;
   title?: string;
@@ -40,6 +41,15 @@ interface PreviewState {
   likeCounts?: number;
   commentCounts?: number;
   comments?: PostCommentProps[];
+
+  savePrefill?: {
+    importance?: number;
+    description?: string;
+    visibility?: "public" | "private";
+    projectId?: number | null;
+    projectName?: string;
+    thumbnail?: string | null;
+  };
 }
 
 export interface CommunityPostDetailProps {
@@ -77,7 +87,6 @@ export default function PreviewPage() {
   );
 
   const hasAnySection = questions.length > 0 && contents.length > 0;
-
   const safeDate = data.date ?? formatDate(new Date());
 
   const seedComments = (data.comments ?? []).map((c) => ({
@@ -90,7 +99,7 @@ export default function PreviewPage() {
     title: data.title ?? "제목(프리뷰)",
     tags: data.tags ?? [],
     date: safeDate,
-    isMine: !!data.isMine,
+    isMine: data.isMine ?? true,
     authorProfile: data.authorProfile,
     authorName: data.authorName ?? "작성자",
     authorFollowers: data.authorFollowers ?? 0,
@@ -98,7 +107,7 @@ export default function PreviewPage() {
     importance: data.importance ?? 0,
     questions,
     contents: contents as CommunityPostDetailProps["contents"],
-    isLiked: !!data.isLiked,
+    isLiked: data.isLiked ?? false,
     likeCounts: data.likeCounts ?? 0,
     commentCounts:
       typeof data.commentCounts === "number"
@@ -133,11 +142,9 @@ export default function PreviewPage() {
       prev.map((c) => (c.id === id ? { ...c, content: newContent } : c))
     );
   };
-
   const handleDelete = (id: string) => {
     setComments((prev) => prev.filter((c) => c.id !== id && c.parentId !== id));
   };
-
   const handleReply = (parentId: string, replyContent: string) => {
     const newReply: PostCommentProps = {
       id: `${Date.now()}-r`,
@@ -150,7 +157,6 @@ export default function PreviewPage() {
     };
     setComments((prev) => [...prev, newReply]);
   };
-
   const handleCreateComment = () => {
     const content = commentInput.trim();
     if (!content) return;
@@ -165,6 +171,47 @@ export default function PreviewPage() {
     setComments((prev) => [newComment, ...prev]);
     setCommentInput("");
   };
+
+  // 수정 이동
+  const toMarkdownFromGuide = (
+    items: (string | { type: "image"; src: string; alt?: string })[]
+  ) =>
+    items
+      .map((it) =>
+        typeof it === "string" ? it : `![${it.alt ?? ""}](${it.src})`
+      )
+      .join("\n\n");
+
+  const buildFreeformPrefill = (post: CommunityPostDetailProps) => ({
+    editorType: "FREEFORM" as const,
+    title: post.title,
+    tags: post.tags,
+    errorType: post.errorType,
+    savePrefill: data.savePrefill,
+    blocks: post.questions.map((q, i) => ({
+      id: Date.now() + i,
+      title: q,
+      content: toMarkdownFromGuide(post.contents[i] ?? []),
+      isSaved: true,
+    })),
+  });
+
+  const buildTemplatePrefill = (post: CommunityPostDetailProps) => ({
+    editorType: "TEMPLATE" as const,
+    title: post.title,
+    tags: post.tags,
+    errorType: post.errorType,
+    savePrefill: data.savePrefill,
+    blocks: post.questions.map((q, i) => ({
+      id: Date.now() + i,
+      content: toMarkdownFromGuide(post.contents[i] ?? []),
+      checklist: [],
+      checklistItems: [],
+      checklistTitle: "",
+      question: q,
+      isSaved: true,
+    })),
+  });
 
   const handleProfileClick = () => {
     navigate(PATH.MYPAGE("1"));
@@ -186,9 +233,7 @@ export default function PreviewPage() {
       sectionRefs.current.forEach((ref, idx) => {
         if (ref) {
           const top = ref.getBoundingClientRect().top + window.scrollY;
-          if (scrollY >= top - 250) {
-            current = idx;
-          }
+          if (scrollY >= top - 250) current = idx;
         }
       });
       setCurrentSection(current);
@@ -200,10 +245,7 @@ export default function PreviewPage() {
   const scrollToSection = (idx: number) => {
     const target = sectionRefs.current[idx];
     if (target) {
-      window.scrollTo({
-        top: target.offsetTop - 180,
-        behavior: "smooth",
-      });
+      window.scrollTo({ top: target.offsetTop - 180, behavior: "smooth" });
     }
   };
 
@@ -217,7 +259,7 @@ export default function PreviewPage() {
           </p>
           <button
             className="px-4 py-2 bg-purple-500 text-white rounded-xl"
-            onClick={() => navigate("/")}
+            onClick={() => navigate(PATH.ROOT)}
           >
             작성하러 가기
           </button>
@@ -245,15 +287,14 @@ export default function PreviewPage() {
             ))}
           </nav>
         </div>
+
         <div className="flex flex-col">
-          {/* 포스트 영역 */}
-          <div className="flex flex-col items-start max-w-[1200px] ml-[360px] mr-[36px] gap-[56px] mb={[224]}">
-            {/* 상단 영역 */}
+          <div className="flex flex-col items-start max-w-[1200px] ml-[360px] mr-[36px] gap-[56px] mb-[224px]">
+            {/* 상단 */}
             <div className="flex w-full pt-[180px] pb-[18px] items-center border-b border-gray1">
               <div className="flex flex-col items-start gap-[44px]">
                 <div className="flex flex-col items-start gap-[53px]">
                   <div className="flex flex-col items-start gap-[10px]">
-                    {/* 에러 종류 & 케밥 */}
                     <div className="flex w-[1200px] justify-between items-start">
                       <span className="text-head-20-semibold">
                         {basePost.errorType}
@@ -270,15 +311,22 @@ export default function PreviewPage() {
                                   label: "포스트 수정",
                                   onClick: () => {
                                     setShowMenu(false);
-                                    console.log("포스트 수정 동작 실행");
+                                    const editorType =
+                                      data.editorType ?? "FREEFORM";
+                                    if (editorType === "TEMPLATE") {
+                                      navigate(PATH.TEMP_WRITING, {
+                                        state: buildTemplatePrefill(basePost),
+                                      });
+                                    } else {
+                                      navigate(PATH.FREEFORM_WRITING, {
+                                        state: buildFreeformPrefill(basePost),
+                                      });
+                                    }
                                   },
                                 },
                                 {
                                   label: "삭제",
-                                  onClick: () => {
-                                    setShowMenu(false);
-                                    console.log("삭제 동작 실행");
-                                  },
+                                  onClick: () => setShowMenu(false),
                                 },
                               ]}
                               position={{ top: "0.1rem", left: "1.5rem" }}
@@ -287,12 +335,9 @@ export default function PreviewPage() {
                         </div>
                       )}
                     </div>
-
-                    {/* 포스트 제목 */}
                     <div className="text-head-48">{basePost.title}</div>
                   </div>
 
-                  {/* 태그 & 작성일 */}
                   {(basePost.tags.length || basePost.date) && (
                     <div className="flex items-center gap-[16px]">
                       {basePost.tags.length ? (
@@ -310,9 +355,7 @@ export default function PreviewPage() {
                   )}
                 </div>
 
-                {/* 작성자 정보 & 중요도 */}
                 <div className="flex w-full items-center justify-between">
-                  {/* 작성자 정보 */}
                   <div
                     className="flex items-center gap-[20px] cursor-pointer"
                     onClick={handleProfileClick}
@@ -329,8 +372,6 @@ export default function PreviewPage() {
                       {basePost.authorName}
                     </div>
                   </div>
-
-                  {/* 중요도 */}
                   <div className="flex items-center gap-[8px]">
                     <img
                       src={starIcon}
@@ -345,14 +386,11 @@ export default function PreviewPage() {
               </div>
             </div>
 
-            {/* 하단 영역 */}
+            {/* 본문 */}
             <div className="flex w-full flex-col items-start gap-[8px]">
-              {/* 메인 */}
               <div className="flex flex-col items-start gap-[36px] self-stretch">
-                {/* 포스트 내용 & 작성자 카드 */}
                 <div className="flex flex-col items-start self-stretch">
                   <div className="flex flex-col items-start gap-[48px] self-stretch">
-                    {/* 포스트 내용 */}
                     <div className="flex flex-col items-start gap-[48px] self-stretch">
                       {basePost.questions.map((q, idx) => (
                         <div
@@ -367,53 +405,12 @@ export default function PreviewPage() {
                         </div>
                       ))}
                     </div>
-
-                    {/* 작성자 정보 카드 */}
-                    {(basePost.authorName ||
-                      basePost.authorProfile ||
-                      basePost.authorBio) && (
-                      <div className="flex py-[32px] px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[36px] bg-[#F2F2F2]">
-                        <div className="flex justify-between items-center self-stretch">
-                          <div className="flex items-center gap-[28px]">
-                            <img
-                              src={basePost.authorProfile || imageIcon}
-                              onError={(e) => {
-                                e.currentTarget.src = imageIcon;
-                              }}
-                              alt="profile"
-                              className="w-[131px] h-[131px] rounded-full object-cover"
-                            />
-                            <div className="flex flex-col items-start gap-[13px]">
-                              <div className="flex flex-col items-start gap-[2px]">
-                                <div className="text-head-24-bold">
-                                  {basePost.authorName}
-                                </div>
-                                <div className="text-body-16-regular">
-                                  {basePost.authorFollowers}팔로워
-                                </div>
-                              </div>
-                              {basePost.authorBio && (
-                                <div className="text-body-18-regular">
-                                  {basePost.authorBio}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-
-                          {/* 팔로우 버튼 (프리뷰용 더미) */}
-                          <button className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white cursor-pointer">
-                            팔로우
-                          </button>
-                        </div>
-                      </div>
-                    )}
                   </div>
                 </div>
 
                 {/* 좋아요, 공유 */}
                 <div className="flex pt+[52px] pb-[20px] items-center self-stretch border-b border-gray1">
                   <div className="flex items-center gap-[20px]">
-                    {/* 좋아요 */}
                     <div
                       className="flex items-center gap-[8px] cursor-pointer"
                       onClick={handleToggleLike}
@@ -427,8 +424,6 @@ export default function PreviewPage() {
                         {likeCounts}
                       </div>
                     </div>
-
-                    {/* 공유 버튼 (프리뷰용 더미) */}
                     <img
                       src={shareIcon}
                       alt="share"
@@ -437,7 +432,7 @@ export default function PreviewPage() {
                   </div>
                 </div>
 
-                {/* 댓글 작성 */}
+                {/* 댓글 */}
                 <div className="flex flex-col items-end gap-[12px] self-stretch">
                   <div className="flex flex-col items-start gap-[36px] self-stretch">
                     <div className="text-head-32-semibold">
@@ -479,7 +474,6 @@ export default function PreviewPage() {
                           handleReply(parent.id, replyContent)
                         }
                       />
-                      {/* 답글 목록 */}
                       {comments
                         .filter((c) => c.parentId === parent.id)
                         .map((reply) => (
@@ -506,7 +500,6 @@ export default function PreviewPage() {
   );
 }
 
-// -------- utils
 function formatDate(date: Date) {
   const yy = String(date.getFullYear()).slice(2);
   const mm = String(date.getMonth() + 1).padStart(2, "0");

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -180,10 +180,6 @@ const TempWritePage = () => {
     setTimeout(() => setShowSaveAlert(false), 3000);
   };
 
-  function toGuideContent(text: string) {
-    return (text ?? "").split(/\n{2,}/).map((s) => s.trim());
-  }
-
   const handleNextInPostSaveModal = (payload: PostSavePayload) => {
     setPreviewMeta(payload);
     setIsPostSaveModalOpen(false);
@@ -202,21 +198,8 @@ const TempWritePage = () => {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      const form: PostForm = {
-        title,
-        introduction: previewMeta?.description ?? "",
-        postTags: selectedTags,
-        isVisible: (previewMeta?.visibility ?? "public") === "public",
-        isSummaryCreated: false,
-        postStatus: "DRAFT",
-        starRating: String(previewMeta?.importance ?? "0"),
-        thumbnailImageUrl: previewMeta?.thumbnail ?? undefined,
-        projectId: previewMeta?.projectId ?? 0,
-        errorTag: selectedErrorType ?? "",
-        contents: toContentDtoList(blocks),
-      };
-
-      const req = toCreatePostRequest(form);
+      // 요약을 돌릴 거라 임시로 DRAFT로 생성
+      const req = toCreatePostRequest(buildCreateForm("DRAFT"));
       const created = await createPost(req);
       const postId = created.id;
       setCreatedPostId(postId);
@@ -273,37 +256,28 @@ const TempWritePage = () => {
     };
   }, [isLoadingModalOpen, createdPostId, summaryTaskId]);
 
-  const handleLater = () => {
-    const filledBlocks = blocks.filter((b) => b.content?.trim().length > 0);
-    const questions = filledBlocks.map((b) => b.question);
-    const contents = filledBlocks.map((b) => toGuideContent(b.content));
+  const handleLater = async () => {
+    if (
+      !title.trim() ||
+      !selectedErrorType ||
+      !blocks[0]?.content.trim() ||
+      !previewMeta?.projectId
+    ) {
+      setShowAlert(true);
+      setTimeout(() => setShowAlert(false), 3000);
+      return;
+    }
 
-    navigate(PATH.PREVIEW, {
-      state: {
-        editorType: "TEMPLATE",
-        title,
-        tags: selectedTags,
-        errorType: selectedErrorType,
-        importance: previewMeta?.importance,
-        // save modal 프리필
-        savePrefill: previewMeta
-          ? {
-              importance: previewMeta.importance ?? 0,
-              description: previewMeta.description ?? "",
-              visibility: previewMeta.visibility ?? "public",
-              projectId: previewMeta.projectId ?? null,
-              projectName: previewMeta.projectName,
-              thumbnail: previewMeta.thumbnail ?? null,
-            }
-          : undefined,
-        authorName: "나",
-        authorProfile: null,
-        authorBio: "",
-        date: new Date().toISOString().slice(2, 10).replace(/-/g, "."),
-        questions,
-        contents,
-      },
-    });
+    try {
+      const req = toCreatePostRequest(buildCreateForm("COMPLETED"));
+      await createPost(req);
+      navigate(PATH.PROJECT_DETAIL(String(previewMeta.projectId)), {
+        state: { projectName: previewMeta.projectName },
+      });
+    } catch (e) {
+      console.error(e);
+      setStatusMessage("원본 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+    }
   };
 
   const handleCloseLoading = async () => {
@@ -325,6 +299,23 @@ const TempWritePage = () => {
     } finally {
       closingRef.current = false;
     }
+  };
+
+  const buildCreateForm = (postStatus: "COMPLETED" | "DRAFT") => {
+    const form: PostForm = {
+      title,
+      introduction: previewMeta?.description ?? "",
+      postTags: selectedTags,
+      isVisible: (previewMeta?.visibility ?? "public") === "public",
+      isSummaryCreated: false,
+      postStatus,
+      starRating: String(previewMeta?.importance ?? 0),
+      thumbnailImageUrl: previewMeta?.thumbnail ?? undefined,
+      projectId: previewMeta?.projectId ?? 0,
+      errorTag: selectedErrorType ?? "",
+      contents: toContentDtoList(blocks),
+    };
+    return form;
   };
 
   return (

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useState, useRef } from "react";
 import HeaderWoSearch from "@/components/Header/HeaderWoSearch";
-import DropDownButton from "../../components/Button/DropDownButton";
-import CategoryTag from "../../components/TemplateWrite/CategoryTag";
+import DropDownButton from "@/components/Button/DropDownButton";
+import CategoryTag from "@/components/TemplateWrite/CategoryTag";
 import EditorBlock, {
   type BlockData,
-} from "../../components/TemplateWrite/EditorBlock";
-import { questionData } from "../../components/TemplateWrite/questionTemplate";
-import PostSaveModal from "./PostSaveModal";
+} from "@/components/TemplateWrite/EditorBlock";
+import { questionData } from "@/components/TemplateWrite/questionTemplate";
+import PostSaveModal, { type PostSavePayload } from "./PostSaveModal";
 import PostLoadingModal from "./PostLoadingModal";
 import TemplateSelectModal from "./TemplateSelectModal";
 import { useNavigate, useLocation } from "react-router-dom";
 import { PATH } from "@/constants/paths";
-import type { PostSavePayload } from "./PostSaveModal";
 import { toCreatePostRequest, type PostForm } from "@/mappers/postMapper";
 import type { PostContentDto, SummaryTypeParam } from "@/models/post.model";
 import { useProjectList } from "@/hooks/useProjectList";
@@ -21,6 +20,23 @@ import {
   getSummaryStatus,
   cancelSummary,
 } from "@/api/post.api";
+
+type IncomingTemplateState = {
+  editorType?: "TEMPLATE";
+  title?: string;
+  tags?: string[];
+  errorType?: string | null;
+  blocks?: BlockData[];
+  savePrefill?: {
+    importance?: number;
+    description?: string;
+    visibility?: "public" | "private";
+    projectId?: number | null;
+    projectName?: string;
+    thumbnail?: string | null;
+  };
+  projectId?: number;
+};
 
 const TempWritePage = () => {
   const [title, setTitle] = useState("");
@@ -37,6 +53,8 @@ const TempWritePage = () => {
   const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
   const [showSaveAlert, setShowSaveAlert] = useState(false);
+  const [showCancelAlert, setShowCancelAlert] = useState(false);
+
   const navigate = useNavigate();
   const [previewMeta, setPreviewMeta] = useState<PostSavePayload | null>(null);
   const { data: projectList, loading: projectsLoading } = useProjectList();
@@ -45,8 +63,8 @@ const TempWritePage = () => {
   const [summaryProgress, setSummaryProgress] = useState(0);
   const [templateLabel, setTemplateLabel] = useState<string>("");
   const closingRef = useRef(false);
-  const [showCancelAlert, setShowCancelAlert] = useState(false);
-  const location = useLocation() as { state?: { projectId?: number } };
+
+  const location = useLocation() as { state?: IncomingTemplateState };
   const initialProjectId = location.state?.projectId;
 
   type SummaryStatus =
@@ -56,14 +74,13 @@ const TempWritePage = () => {
     | "ANALYZING"
     | "POSTPROCESSING"
     | "COMPLETED";
-
   const [summaryStatus, setSummaryStatus] = useState<SummaryStatus | null>(
     null
   );
   const [statusMessage, setStatusMessage] = useState<string>("");
 
-  const toContentDtoList = (blocks: BlockData[]): PostContentDto[] =>
-    blocks
+  const toContentDtoList = (bs: BlockData[]): PostContentDto[] =>
+    bs
       .filter((b) => (b.content ?? "").trim().length > 0)
       .map((b, i) => ({
         subTitle: b.question,
@@ -73,9 +90,23 @@ const TempWritePage = () => {
         summaryType: "NONE",
       }));
 
-  // 첫번째 블록 생성
+  // 프리필 반영
   useEffect(() => {
-    if (blocks.length === 0 && questionData.length > 0) {
+    if (location.state?.editorType === "TEMPLATE") {
+      if (location.state.title) setTitle(location.state.title);
+      if (location.state.tags) setSelectedTags(location.state.tags);
+      if (location.state.errorType !== undefined)
+        setSelectedErrorType(location.state.errorType ?? null);
+      if (location.state.blocks?.length) setBlocks(location.state.blocks);
+    }
+  }, [location.state]);
+
+  // 첫 블록 생성 (프리필 없을 때만)
+  useEffect(() => {
+    const hasPrefill = !!(
+      location.state?.editorType === "TEMPLATE" && location.state.blocks?.length
+    );
+    if (!hasPrefill && blocks.length === 0 && questionData.length > 0) {
       const firstBlock: BlockData = {
         id: Date.now(),
         content: "",
@@ -87,9 +118,8 @@ const TempWritePage = () => {
       };
       setBlocks([firstBlock]);
     }
-  }, [blocks]);
+  }, [blocks.length, location.state]);
 
-  // 블록 내용 변경
   const handleChangeBlockContent = (
     index: number,
     updated: Partial<BlockData>
@@ -101,7 +131,6 @@ const TempWritePage = () => {
     });
   };
 
-  // 체크리스트 토글
   const handleToggleChecklist = (
     index: number,
     item: string,
@@ -110,23 +139,17 @@ const TempWritePage = () => {
     setBlocks((prev) => {
       const newBlocks = [...prev];
       const checklist = new Set(newBlocks[index].checklist);
-      if (checked) {
-        checklist.add(item);
-      } else {
-        checklist.delete(item);
-      }
-
+      if (checked) checklist.add(item);
+      else checklist.delete(item);
       newBlocks[index].checklist = Array.from(checklist);
       return newBlocks;
     });
   };
 
-  // 블록 추가
   const handleAddBlock = () => {
     setBlocks((prev) => {
       const nextStep = prev.length;
       if (nextStep >= questionData.length) return prev;
-
       const stepData = questionData[nextStep];
       const newBlock: BlockData = {
         id: Date.now(),
@@ -137,21 +160,14 @@ const TempWritePage = () => {
         question: stepData.question,
         isSaved: false,
       };
-
       const newBlocks = [...prev, newBlock];
       setActiveIndex(newBlocks.length - 1);
       return newBlocks;
     });
   };
 
-  //  End 버튼
   const handleEnd = () => {
-    if (!title.trim() || !selectedErrorType) {
-      setShowAlert(true);
-      setTimeout(() => setShowAlert(false), 3000);
-      return;
-    }
-    if (!blocks[0]?.content.trim()) {
+    if (!title.trim() || !selectedErrorType || !blocks[0]?.content.trim()) {
       setShowAlert(true);
       setTimeout(() => setShowAlert(false), 3000);
       return;
@@ -164,31 +180,16 @@ const TempWritePage = () => {
     setTimeout(() => setShowSaveAlert(false), 3000);
   };
 
-  const errorOptions = [
-    "Build / Compile Error",
-    "Runtime Error",
-    "Dependency / Version Error",
-    "Network / API Error",
-    "Authentication / Authorization Error",
-    "Database Error",
-    "UI / Rendering Error",
-    "Configuration Error",
-    "Timeout / Error Handling",
-    "Third-Party Library Error",
-    "Others",
-  ];
-
   function toGuideContent(text: string) {
-    const paragraphs = (text ?? "").split(/\n{2,}/).map((s) => s.trim());
-    return paragraphs;
+    return (text ?? "").split(/\n{2,}/).map((s) => s.trim());
   }
+
   const handleNextInPostSaveModal = (payload: PostSavePayload) => {
     setPreviewMeta(payload);
     setIsPostSaveModalOpen(false);
     setIsTemplateSelectModalOpen(true);
   };
 
-  // 템플릿 선택 후 요약 시작
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -201,7 +202,6 @@ const TempWritePage = () => {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      // 1) 본문을 요청 DTO로 변환
       const form: PostForm = {
         title,
         introduction: previewMeta?.description ?? "",
@@ -216,21 +216,15 @@ const TempWritePage = () => {
         contents: toContentDtoList(blocks),
       };
 
-      // 2) 문서 생성
       const req = toCreatePostRequest(form);
       const created = await createPost(req);
       const postId = created.id;
       setCreatedPostId(postId);
 
-      // 3) 요약 작업 시작
       const start = await startSummary(postId, { type });
       setSummaryTaskId(start.taskId);
     } catch (e) {
       console.error(e);
-      // 이후 모달 반영후 지우기
-      // setIsTemplateSelectModalOpen(true);
-      // setIsLoadingModalOpen(false);
-      // 실패 시 상태 복구
       setIsLoadingModalOpen(false);
       setIsTemplateSelectModalOpen(true);
       setSummaryTaskId(null);
@@ -240,6 +234,7 @@ const TempWritePage = () => {
       setStatusMessage("요약 시작에 실패했어요. 잠시 후 다시 시도해주세요.");
     }
   };
+
   useEffect(() => {
     if (!isLoadingModalOpen || !createdPostId || !summaryTaskId) return;
 
@@ -251,11 +246,9 @@ const TempWritePage = () => {
         const data = await getSummaryStatus(createdPostId, summaryTaskId);
         const p = Math.max(0, Math.min(100, data.progress ?? 0));
         if (stopped) return;
-
         setSummaryProgress(p);
-        if (data.status) setSummaryStatus(data.status as SummaryStatus);
+        if (data.status) setSummaryStatus(data.status as any);
         if (data.message) setStatusMessage(data.message);
-
         if (data.status === "COMPLETED" || p >= 100) {
           setSummaryProgress(100);
           if (timer !== null) {
@@ -282,35 +275,41 @@ const TempWritePage = () => {
 
   const handleLater = () => {
     const filledBlocks = blocks.filter((b) => b.content?.trim().length > 0);
-
     const questions = filledBlocks.map((b) => b.question);
     const contents = filledBlocks.map((b) => toGuideContent(b.content));
 
     navigate(PATH.PREVIEW, {
       state: {
+        editorType: "TEMPLATE",
         title,
         tags: selectedTags,
         errorType: selectedErrorType,
-
         importance: previewMeta?.importance,
+        // save modal 프리필
+        savePrefill: previewMeta
+          ? {
+              importance: previewMeta.importance ?? 0,
+              description: previewMeta.description ?? "",
+              visibility: previewMeta.visibility ?? "public",
+              projectId: previewMeta.projectId ?? null,
+              projectName: previewMeta.projectName,
+              thumbnail: previewMeta.thumbnail ?? null,
+            }
+          : undefined,
         authorName: "나",
         authorProfile: null,
         authorBio: "",
         date: new Date().toISOString().slice(2, 10).replace(/-/g, "."),
-
         questions,
         contents,
       },
     });
   };
 
-  // 로딩 모달 요약 중단
   const handleCloseLoading = async () => {
     if (closingRef.current) return;
     closingRef.current = true;
-
     try {
-      // 진행 중이면 서버 취소 요청
       if (summaryProgress < 100 && createdPostId && summaryTaskId) {
         try {
           await cancelSummary(createdPostId, summaryTaskId);
@@ -318,11 +317,9 @@ const TempWritePage = () => {
           console.error("요약 작업 취소 실패:", e);
         }
       }
-
       setIsLoadingModalOpen(false);
       setSummaryTaskId(null);
       setSummaryProgress(0);
-
       setShowCancelAlert(true);
       setTimeout(() => setShowCancelAlert(false), 3000);
     } finally {
@@ -335,7 +332,6 @@ const TempWritePage = () => {
       <HeaderWoSearch />
       <div className="flex justify-center px-[225px] pt-[68px] items-start">
         <div className="flex-1 flex w-[1500px] flex-col gap-[36px]">
-          {/* Alert */}
           {showAlert && (
             <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
               제목, 에러 종류, 첫 번째 블록 내용을 모두 입력해주세요.
@@ -352,7 +348,6 @@ const TempWritePage = () => {
             </div>
           )}
 
-          {/*  제목 + 태그 */}
           <div className="flex flex-col items-start gap-[40px]">
             <input
               type="text"
@@ -363,7 +358,19 @@ const TempWritePage = () => {
             />
             <div className="flex gap-[36px] items-center">
               <DropDownButton
-                options={errorOptions}
+                options={[
+                  "Build / Compile Error",
+                  "Runtime Error",
+                  "Dependency / Version Error",
+                  "Network / API Error",
+                  "Authentication / Authorization Error",
+                  "Database Error",
+                  "UI / Rendering Error",
+                  "Configuration Error",
+                  "Timeout / Error Handling",
+                  "Third-Party Library Error",
+                  "Others",
+                ]}
                 placeholder="에러 종류를 선택하세요"
                 width="w-[340px] h-[36px]"
                 onSelect={(selectedError) =>
@@ -374,10 +381,9 @@ const TempWritePage = () => {
             </div>
           </div>
 
-          {/* 블록 렌더링 (역순 표시) */}
           <div>
             {[...blocks].reverse().map((block, index) => {
-              const originalIndex = blocks.length - 1 - index; // 실제 index
+              const originalIndex = blocks.length - 1 - index;
               return (
                 <EditorBlock
                   key={block.id}
@@ -398,7 +404,6 @@ const TempWritePage = () => {
             })}
           </div>
 
-          {/* 모달들 */}
           {isPostSaveModalOpen && (
             <PostSaveModal
               onClose={() => setIsPostSaveModalOpen(false)}
@@ -407,8 +412,19 @@ const TempWritePage = () => {
               loadingProjects={projectsLoading}
               defaultProjectId={initialProjectId}
               selectedTags={selectedTags}
+              // 수정 프리필 반영
+              initialImportance={location.state?.savePrefill?.importance}
+              initialDescription={location.state?.savePrefill?.description}
+              initialVisibility={location.state?.savePrefill?.visibility}
+              initialProjectId={
+                location.state?.savePrefill?.projectId ??
+                initialProjectId ??
+                null
+              }
+              initialThumbnail={location.state?.savePrefill?.thumbnail ?? null}
             />
           )}
+
           {isTemplateSelectModalOpen && (
             <TemplateSelectModal
               onConfirm={(type, label) => handleConfirmTemplate(type, label)}


### PR DESCRIPTION
## 🔥 Issues

#60

## ✅ What to do

- [ ]  포스트 수정 ui 수정, api 구현
- [ ] 작성한 글 렌더링 오류 
- [ ] 에디터 블록 스크롤 대신 확장되게 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 마크다운 에디터 자동 높이 조절 및 리사이즈 지원 추가
  - 위치 기반 사전채움(prefill)으로 자유/템플릿 편집 진입 지원
  - 상단 공용 액션바(저장/완료) 및 전역 저장/완료 흐름 도입
  - 저장 모달에 초기값(중요도/소개/공개범위/프로젝트/썸네일) 프리필 및 이미지 업로드/진행률 지원

- **Improvements**
  - 완료/요약 흐름 및 유효성 검증 강화(End 버튼 검증 포함)
  - 미리보기 → 편집 시 콘텐츠를 마크다운으로 변환해 블록 구성
  - 체크리스트 렌더링 및 에디터 UI 구조 개선

- **Chores**
  - 경로 상수 공백 정리 및 임포트 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->