### PR TITLE
FIX: 커뮤니티 게시글 목록 불러올 때 fetcher 사용 안되는 오류 해결

### DIFF
--- a/src/hooks/useCommunityCards.ts
+++ b/src/hooks/useCommunityCards.ts
@@ -56,7 +56,7 @@ async function fetchOnce(
 ) {
   const key = keyFor(source, sort, page, size);
   if (!inflightPaged.has(key)) {
-    const p = getCommunityList(page, size, sort).finally(() =>
+    const p = fetcher(page, size, sort).finally(() =>
       inflightPaged.delete(key)
     );
     inflightPaged.set(key, p);


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] `fetchOnce` 메서드 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - 커뮤니티 목록 로딩 로직에 커스텀 데이터 페처 주입을 지원하도록 내부 구조를 개선했습니다. 기본 설정에서는 기존 동작과 동일하며, UI와 사용자 흐름에는 변화가 없습니다. 성능과 안정성은 기존 수준을 유지하고, 네트워크 요청 중복 방지 동작도 동일합니다. 개발·배포 환경에 따라 맞춤형 호출기를 사용할 수 있어 통합 시나리오 확장에 도움이 됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->