### PR TITLE
FEAT: 팔로잉/팔로워 API, UI 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -140,15 +140,15 @@ const Header = () => {
   };
 
   return (
-    <div className="flex w-full py-[25px] px-[88px] gap-[10px] justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
+    <div className="flex w-full py-[25px] px-[88px] gap-12 justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
       <img
         src={logo}
         alt="logo"
         className="w-[70px] h-[51px] cursor-pointer"
         onClick={() => navigate(PATH.HOME)}
       />
-      <div className="flex gap-[72px] items-center">
-        <div className="flex w-[1200px] h-12 p-2 justify-between items-center gap-1 rounded-md border border-gray1">
+      <div className="flex w-full gap-12 items-center">
+        <div className="flex w-full h-12 p-2 justify-between items-center gap-1 rounded-md border border-gray1">
           <input
             className="text-body-14-regular w-full"
             placeholder={placeholder}

--- a/src/components/MyPage/FollowingBtn.tsx
+++ b/src/components/MyPage/FollowingBtn.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import userIcon from "@/assets/icons/user.svg";
 
 interface FollowingProps {
   userId: number;
@@ -24,7 +25,11 @@ const FollowingBtn = ({
         className="flex items-center gap-3"
         onClick={() => nav(`/user/mypage/${userId}`)}
       >
-        <img src={profileUrl} alt="user" className="w-[52px] h-[52px]" />
+        <img
+          src={profileUrl || userIcon}
+          alt="user"
+          className="w-[52px] h-[52px]"
+        />
 
         <div className="flex w-[143px] flex-col items-start gap-0.5">
           <p className="font-sans text-2xl font-bold leading-normal">

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import FollowButton from "@/components/Button/FollowButton";
 import { useMyPageStore } from "@/store/useMyPageStore";
 import type { StatusType } from "@/types/project";
@@ -9,7 +9,7 @@ import userIcon from "@/assets/icons/user.svg";
 import circleYIcon from "@/assets/icons/circle_y.svg";
 import circleGIcon from "@/assets/icons/circle_g.svg";
 import circleBIcon from "@/assets/icons/circle_b.svg";
-import { getUserInfo, postFollow } from "@/api/user.api";
+import { getUserInfo, postFollow, postUnfollow } from "@/api/user.api";
 import type { UserInfoData } from "@/models/user.model";
 
 type MyPageSideBarProps =
@@ -22,10 +22,7 @@ type MyPageSideBarProps =
         created: number;
       };
     }
-  | {
-      isMyPage: false;
-      sortedTags: [string, number][];
-    };
+  | { isMyPage: false; sortedTags: [string, number][] };
 
 const MyPageSideBar = (props: MyPageSideBarProps) => {
   const navigate = useNavigate();
@@ -36,23 +33,24 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const { selectedTag, setSelectedTag, resetSelectedTag } = useMyPageStore();
 
   const [userInfo, setUserInfo] = useState<UserInfoData | null>(null);
+  const [followLoading, setFollowLoading] = useState(false);
 
   const basePath = PATH.MYPAGE(id!);
   const isOnMainPage = location.pathname === basePath;
 
-  useEffect(() => {
+  const refetch = useCallback(async () => {
     if (!id) return;
-    const fetchUserInfo = async () => {
-      try {
-        const data = await getUserInfo(Number(id));
-        setUserInfo(data);
-        console.log(userInfo);
-      } catch (error) {
-        console.error("사용자 정보 불러오기 실패:", error);
-      }
-    };
-    fetchUserInfo();
+    try {
+      const data = await getUserInfo(Number(id));
+      setUserInfo(data);
+    } catch (error) {
+      console.error("사용자 정보 불러오기 실패:", error);
+    }
   }, [id]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
 
   const handleNavigate =
     (subPath: string = "", clearStatus = false) =>
@@ -72,19 +70,71 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const getMenuButtonClass = (match: boolean) =>
     `${match ? "text-black" : "text-gray3"} text-head-20-semibold`;
 
-  const handleTagClick = (tag: string) => {
-    if (selectedTag === tag) {
-      setSelectedTag(null);
-    } else {
-      setSelectedTag(tag);
+  // 팔로우
+  const handleFollow = async (targetId: number) => {
+    if (!userInfo || followLoading) return;
+    setFollowLoading(true);
+
+    setUserInfo((prev) =>
+      prev
+        ? {
+            ...prev,
+            isFollowed: true,
+            followerNum: (prev.followerNum ?? 0) + 1, // 상대방의 팔로워 수 증가
+          }
+        : prev
+    );
+
+    try {
+      await postFollow(targetId);
+      await refetch();
+    } catch (e) {
+      console.error("팔로우 실패", e);
+      setUserInfo((prev) =>
+        prev
+          ? {
+              ...prev,
+              isFollowed: false,
+              followerNum: Math.max(0, (prev.followerNum ?? 1) - 1),
+            }
+          : prev
+      );
+    } finally {
+      setFollowLoading(false);
     }
   };
 
-  const handleFollowClick = async (id: number) => {
+  // 언팔로우
+  const handleUnfollow = async (targetId: number) => {
+    if (!userInfo || followLoading) return;
+    setFollowLoading(true);
+    setUserInfo((prev) =>
+      prev
+        ? {
+            ...prev,
+            isFollowed: false,
+            followerNum: Math.max(0, (prev.followerNum ?? 1) - 1),
+          }
+        : prev
+    );
+
     try {
-      await postFollow(id);
+      await postUnfollow(targetId);
+      await refetch();
     } catch (e) {
-      console.error("팔로우 실패", e);
+      console.error("언팔로우 실패", e);
+      // 롤백
+      setUserInfo((prev) =>
+        prev
+          ? {
+              ...prev,
+              isFollowed: true,
+              followerNum: (prev.followerNum ?? 0) + 1,
+            }
+          : prev
+      );
+    } finally {
+      setFollowLoading(false);
     }
   };
 
@@ -119,22 +169,27 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
                 colorClass="bg-primary"
                 onClick={handleNavigate(MYPAGE_SUBPATH.EDIT_PROFILE)}
               />
+            ) : userInfo?.isFollowed ? (
+              <FollowButton
+                label="팔로잉"
+                colorClass="bg-subColor1"
+                onClick={() => handleUnfollow(Number(id))}
+              />
             ) : (
               <FollowButton
                 label="팔로우"
                 colorClass="bg-primary"
-                onClick={() => handleFollowClick(Number(id))}
+                onClick={() => handleFollow(Number(id))}
               />
             )}
           </div>
         </div>
       </div>
 
-      {/* 하단 메뉴 */}
+      {/* 하단 메뉴*/}
       {props.isMyPage ? (
         <div className="flex flex-col items-start gap-9 self-stretch text-gray3 text-head-20-semibold">
           <div className="w-full">
-            {/* 헤더 텍스트 */}
             <div
               className={`pb-2 border-b ${
                 isOnMainPage && selectedStatus
@@ -144,8 +199,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
             >
               내 트러블 슈팅
             </div>
-
-            {/* 트러블슈팅 필터 버튼들 */}
             <div className="flex flex-col items-start gap-[13px] pt-2 text-body-16-regular text-gray3">
               <button
                 onClick={() => {
@@ -204,7 +257,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
             </div>
           </div>
 
-          {/* 일반 메뉴 버튼들 */}
           <button
             onClick={handleNavigate(MYPAGE_SUBPATH.STATISTICS, true)}
             className={getMenuButtonClass(
@@ -225,21 +277,17 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       ) : (
         <div className="flex flex-col items-start gap-[12px] self-stretch">
           <div className="w-full">
-            {/* 헤더 텍스트 */}
-
             <div className="flex flex-col items-start gap-[12px]">
               <span className="text-head-20-semibold">태그 분석</span>
               <div className="w-full h-[1px] bg-[#939393]" />
             </div>
-
-            {/* 태그 목록 */}
             <div className="flex flex-col items-start gap-[10px] pt-[12px]">
               {props.sortedTags.map(([tag, count]) => {
                 const isSelected = tag === selectedTag;
                 return (
                   <button
                     key={tag}
-                    onClick={() => handleTagClick(tag)}
+                    onClick={() => setSelectedTag(isSelected ? null : tag)}
                     className={`transition-colors ${
                       isSelected
                         ? "text-body-16-semibold"

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -22,6 +22,7 @@ export interface UserInfoData {
   bio: string;
   followerNum: number;
   followingNum: number;
+  isFollowed: boolean;
 }
 
 export interface FollowingData {

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -151,15 +151,15 @@ const EditProfile = () => {
   };
 
   return (
-    <div className="flex justify-center min-h-screen">
-      <div className="flex flex-col items-end gap-14">
-        <div className="flex items-start gap-[68px] pt-20">
+    <div className="flex justify-center min-h-screen pb-6">
+      <div className="flex flex-col items-end gap-14 w-3/4">
+        <div className="flex items-start gap-16 pt-20 w-full">
           {/* 왼쪽 */}
           <div className="flex flex-col items-center gap-12 self-stretch">
             <img
               src={profileImage}
               alt="user"
-              className="w-[288px] h-[288px] object-cover rounded-full"
+              className="w-72 h-72 object-cover rounded-full"
             />
 
             <input
@@ -185,7 +185,7 @@ const EditProfile = () => {
           </div>
 
           {/* 오른쪽 */}
-          <div className="flex flex-col items-start gap-12 w-[948px]">
+          <div className="flex flex-col items-start gap-12 w-3/4">
             <p className="text-head-48 pb-2">프로필 수정</p>
             <MyInput
               label="닉네임"


### PR DESCRIPTION
## 🔥 Issues

#39 

## ✅ What to do

- [x] 팔로잉/팔로워 버튼 구현
- [x] 팔로잉 여부 추가
- [x] 헤더 반응형 수정
- [x] 내정보 반응형 수정

## 🛠️ Improvements to Make

반응형 아직 다 못해서 나중에 시간나면 천천히 수정할 예정.
내 정보 수정은 이미지 처리 완료 후 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 프로필 이미지가 없는 경우 기본 아이콘을 자동 표시합니다.
  - 마이페이지에서 팔로우/언팔로우가 즉시 반영되며 중복 클릭이 방지됩니다.
  - 사용자 정보에 팔로우 상태가 반영되어 버튼 상태가 일관되게 표시됩니다.
- 스타일
  - 헤더의 가로 간격과 너비를 조정해 공간 활용과 일관성을 개선했습니다.
  - 프로필 편집 페이지 레이아웃을 반응형으로 개선하고 섹션 간 격자를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->