### PR TITLE
FEAT: 알림 관련 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@tailwindcss/typography": "^0.5.16",
         "@uiw/react-md-editor": "^4.0.7",
         "axios": "^1.10.0",
@@ -1269,6 +1270,12 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postinstall": "msw init public --save --no-open || true"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@tailwindcss/typography": "^0.5.16",
     "@uiw/react-md-editor": "^4.0.7",
     "axios": "^1.10.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
-import "./App.css";
-import { router } from "./routes/Router";
+import "@/App.css";
+import AlertSSEProvider from "@/providers/AlertSSEProvider";
+import { router } from "@/routes/Router";
 import { RouterProvider } from "react-router-dom";
 
 function App() {
   return (
-    <>
+    <AlertSSEProvider>
       <RouterProvider router={router} />
-    </>
+    </AlertSSEProvider>
   );
 }
 

--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -1,14 +1,26 @@
-import type { AlertServerItem, AlertTypeParam } from "@/types/alert.model";
+import type {
+  AlertServerItem,
+  AlertTypeParam,
+  Handlers,
+} from "@/types/alert.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 import api from "./axios";
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+
+const inflightAlerts = new Map<string, Promise<AlertServerItem[]>>();
 
 // 알림 목록 조회
 export async function getAlerts(alertType?: AlertTypeParam) {
-  return getAPIResponseData<AlertServerItem[]>({
-    url: "/alert/list",
-    method: "GET",
-    params: alertType ? { alertType } : {},
-  });
+  const key = `alerts:list:${alertType ?? "all"}`;
+  if (!inflightAlerts.has(key)) {
+    const p = getAPIResponseData<AlertServerItem[]>({
+      url: "/alert/list",
+      method: "GET",
+      params: alertType ? { alertType } : {},
+    }).finally(() => setTimeout(() => inflightAlerts.delete(key), 0));
+    inflightAlerts.set(key, p);
+  }
+  return inflightAlerts.get(key)!;
 }
 
 // 알림 삭제
@@ -16,44 +28,77 @@ export async function deleteAlert(alertId: number) {
   await api.delete("/alert", { params: { alertId } });
 }
 
-// SSE 연결 (실시간 알림)
-export function connectAlertSSE(opts: {
-  tokenParamName?: string; // 서버가 허용한다면 쿼리로 토큰 전달
-  tokenValue?: string | null;
-  onMessage?: (payload: unknown) => void;
-  onOpen?: (e: Event) => void;
-  onError?: (e: Event) => void;
-}) {
-  const { tokenParamName, tokenValue, onMessage, onOpen, onError } = opts || {};
+// 공통 헤더 구성: Authorization + EnvType
+function buildSSEHeaders(opts?: { token?: string; envType?: string }) {
+  const token = opts?.token ?? localStorage.getItem("accessToken") ?? "";
 
-  // axios baseURL 고려 (same origin 아닐 때 절대경로)
-  const base = (api.defaults.baseURL ?? "").replace(/\/+$/, "");
-  const path = "/alert/connect";
-  const qs =
-    tokenParamName && tokenValue
-      ? `?${encodeURIComponent(tokenParamName)}=${encodeURIComponent(
-          tokenValue
-        )}`
-      : "";
-  const url = base ? `${base}${path}${qs}` : `${path}${qs}`;
+  const envType =
+    opts?.envType ??
+    localStorage.getItem("EnvType") ??
+    (import.meta as any)?.env?.VITE_ENV_TYPE ??
+    "LOCAL";
 
-  const es = new EventSource(url, { withCredentials: true });
-
-  es.onopen = (e) => onOpen?.(e);
-  es.onerror = (e) => onError?.(e);
-  es.onmessage = (evt) => {
-    // 서버가 {"timeout":0} 같은 keep-alive를 주면 파싱 후 필터링
-    try {
-      const data = JSON.parse(evt.data);
-      // timeout 패킷 등은 무시
-      if (data && typeof data === "object" && "timeout" in data) return;
-      onMessage?.(data);
-    } catch {
-      // JSON이 아니면 원문 전달 (필요시 파싱 로직 확장)
-      onMessage?.(evt.data);
-    }
+  const headers: Record<string, string> = {
+    Accept: "text/event-stream",
+    EnvType: envType,
   };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
 
-  // 정리 함수 반환
-  return () => es.close();
+// SSE 연결 (실시간 알림)
+export function connectAlertSSE(
+  h: Handlers = {},
+  opts?: {
+    token?: string;
+    envType?: string;
+    autoReconnect?: boolean;
+    retryMs?: number;
+  }
+) {
+  const { token, envType, autoReconnect = true } = opts ?? {};
+  const ctrl = new AbortController();
+  const headers = buildSSEHeaders({ token, envType });
+
+  fetchEventSource("/api/alert/connect", {
+    method: "GET",
+    headers,
+    credentials: "include",
+    signal: ctrl.signal,
+    openWhenHidden: true,
+
+    async onopen(res) {
+      const ok =
+        res.ok &&
+        (res.headers.get("content-type") || "").startsWith("text/event-stream");
+      if (!ok) {
+        const err = new Error(`SSE open failed: ${res.status}`);
+        h.onError?.(err);
+        if (!autoReconnect) ctrl.abort();
+        throw err;
+      }
+      h.onOpen?.();
+      return;
+    },
+
+    onmessage(ev) {
+      const d = ev.data;
+      if (typeof d === "string" && d.startsWith(":")) return;
+      try {
+        h.onMessage?.(JSON.parse(d));
+      } catch {
+        h.onMessage?.(d);
+      }
+    },
+
+    onerror(err) {
+      h.onError?.(err);
+      if (!autoReconnect) {
+        ctrl.abort();
+        return;
+      }
+    },
+  });
+
+  return () => ctrl.abort();
 }

--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -1,0 +1,59 @@
+import type { AlertServerItem, AlertTypeParam } from "@/types/alert.model";
+import getAPIResponseData from "@/utils/getAPIResponseData";
+import api from "./axios";
+
+// 알림 목록 조회
+export async function getAlerts(alertType?: AlertTypeParam) {
+  return getAPIResponseData<AlertServerItem[]>({
+    url: "/alert/list",
+    method: "GET",
+    params: alertType ? { alertType } : {},
+  });
+}
+
+// 알림 삭제
+export async function deleteAlert(alertId: number) {
+  await api.delete("/alert", { params: { alertId } });
+}
+
+// SSE 연결 (실시간 알림)
+export function connectAlertSSE(opts: {
+  tokenParamName?: string; // 서버가 허용한다면 쿼리로 토큰 전달
+  tokenValue?: string | null;
+  onMessage?: (payload: unknown) => void;
+  onOpen?: (e: Event) => void;
+  onError?: (e: Event) => void;
+}) {
+  const { tokenParamName, tokenValue, onMessage, onOpen, onError } = opts || {};
+
+  // axios baseURL 고려 (same origin 아닐 때 절대경로)
+  const base = (api.defaults.baseURL ?? "").replace(/\/+$/, "");
+  const path = "/alert/connect";
+  const qs =
+    tokenParamName && tokenValue
+      ? `?${encodeURIComponent(tokenParamName)}=${encodeURIComponent(
+          tokenValue
+        )}`
+      : "";
+  const url = base ? `${base}${path}${qs}` : `${path}${qs}`;
+
+  const es = new EventSource(url, { withCredentials: true });
+
+  es.onopen = (e) => onOpen?.(e);
+  es.onerror = (e) => onError?.(e);
+  es.onmessage = (evt) => {
+    // 서버가 {"timeout":0} 같은 keep-alive를 주면 파싱 후 필터링
+    try {
+      const data = JSON.parse(evt.data);
+      // timeout 패킷 등은 무시
+      if (data && typeof data === "object" && "timeout" in data) return;
+      onMessage?.(data);
+    } catch {
+      // JSON이 아니면 원문 전달 (필요시 파싱 로직 확장)
+      onMessage?.(evt.data);
+    }
+  };
+
+  // 정리 함수 반환
+  return () => es.close();
+}

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,6 +2,16 @@ import axios, { AxiosError } from "axios";
 import { router } from "@/routes/Router";
 import { PATH } from "@/constants/paths";
 
+export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").replace(
+  /\/+$/,
+  ""
+);
+if (!API_BASE_URL) {
+  console.warn(
+    "[API] VITE_API_BASE_URL가 비었습니다. SSE 등은 절대 URL을 만들 수 없습니다."
+  );
+}
+
 const RAW_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_BASE_URL ?? "";
 
@@ -22,7 +32,8 @@ const API_ORIGIN = getOriginSafely(COMPUTED_BASE_URL);
 const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
 
 const api = axios.create({
-  baseURL: COMPUTED_BASE_URL,
+  // baseURL: COMPUTED_BASE_URL,
+  baseURL: API_BASE_URL || undefined,
   timeout: 10000,
   withCredentials: true,
   headers: {

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
-import { mockNotifications } from "@/mocks/mockNotifications";
 import escapeIcon from "@/assets/icons/escape.svg";
+import useNotifications from "@/hooks/useNotifications";
 
 const tabs = ["전체", "트러블슈팅", "댓글", "좋아요"] as const;
 type TabType = (typeof tabs)[number];
@@ -16,12 +16,8 @@ export interface NotificationItem {
 
 export default function NotificationModal() {
   const [selectedTab, setSelectedTab] = useState<TabType>("전체");
+  const { items, loading, error, removeOne } = useNotifications(selectedTab);
   const navigate = useNavigate();
-
-  const filtered =
-    selectedTab === "전체"
-      ? mockNotifications
-      : mockNotifications.filter((n) => n.type === selectedTab);
 
   return (
     <div className="w-[600px] h-[262px] rounded-[20px] bg-white shadow-card p-0 overflow-hidden flex flex-col">
@@ -46,13 +42,21 @@ export default function NotificationModal() {
 
       {/* 알림 영역 */}
       <div className="flex-1 overflow-y-auto px-[38px] pb-[46px]">
-        {filtered.length === 0 ? (
+        {loading ? (
+          <div className="w-full h-full flex items-center justify-center text-head-20-semibold">
+            불러오는 중…
+          </div>
+        ) : error ? (
+          <div className="w-full h-full flex items-center justify-center text-head-20-semibold text-red-500">
+            {error}
+          </div>
+        ) : items.length === 0 ? (
           <div className="w-full h-full flex items-center justify-center text-head-20-semibold">
             받은 알림이 없어요.
           </div>
         ) : (
           <div className="flex flex-col gap-[24px]">
-            {filtered.map((item) => (
+            {items.map((item) => (
               <div
                 key={item.id}
                 className="flex justify-between items-start group"
@@ -71,6 +75,7 @@ export default function NotificationModal() {
                   src={escapeIcon}
                   alt="delete"
                   className="w-[24px] h-[24px] cursor-pointer shrink-0"
+                  onClick={() => removeOne(item.id)}
                 />
               </div>
             ))}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import { deleteAlert, getAlerts, connectAlertSSE } from "@/api/alert.api";
+import {
+  toNotificationItem,
+  type NotificationItem,
+  type TabType,
+} from "@/mappers/alert.mapper";
+import type { AlertServerItem, AlertTypeParam } from "@/types/alert.model";
+
+// 탭 -> 서버 쿼리 파라미터
+const tabToParam = (tab: TabType): AlertTypeParam | undefined => {
+  switch (tab) {
+    case "댓글":
+      return "comments";
+    case "좋아요":
+      return "likes";
+    case "트러블슈팅":
+      return "troubles";
+    default:
+      return undefined; // 전체
+  }
+};
+
+export default function useNotifications(selected: TabType) {
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 최신 탭을 SSE에서 참조하기 위한 ref
+  const selectedRef = useRef<TabType>(selected);
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
+  // 목록 불러오기
+  useEffect(() => {
+    let dead = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const param = tabToParam(selected);
+        const list = await getAlerts(param);
+        if (dead) return;
+        const mapped = (list ?? []).map((s) => toNotificationItem(s, selected));
+        setItems(mapped);
+      } catch (e: any) {
+        if (!dead) setError(e?.message ?? "알림을 불러오지 못했습니다.");
+      } finally {
+        if (!dead) setLoading(false);
+      }
+    })();
+    return () => {
+      dead = true;
+    };
+  }, [selected]);
+
+  // 삭제
+  const removeOne = async (id: number) => {
+    try {
+      await deleteAlert(id);
+      setItems((prev) => prev.filter((x) => x.id !== id));
+    } catch (e: any) {
+      // 필요시 토스트로 교체
+      alert(e?.message ?? "알림 삭제에 실패했습니다.");
+    }
+  };
+
+  // SSE 연결 (mount 시 1회)
+  useEffect(() => {
+    // 토큰이 필요하면 localStorage 등에서 꺼내 쿼리로 전달
+    const token = localStorage.getItem("accessToken");
+
+    const close = connectAlertSSE({
+      tokenParamName: token ? "token" : undefined, // 백엔드가 허용할 때만!
+      tokenValue: token ?? undefined,
+      onMessage: (payload) => {
+        // 서버 이벤트 페이로드를 서버 스키마에 맞게 해석
+        const sse = payload as Partial<AlertServerItem> | any;
+
+        // 유효한 알림인지 체크
+        if (!sse || typeof sse !== "object" || !("alertId" in sse)) return;
+
+        // 현재 탭에서 보이는 항목만 prepend (전체면 무조건)
+        const tab = selectedRef.current;
+        const item = toNotificationItem(sse as AlertServerItem);
+        const shouldShow =
+          tab === "전체" || tab === item.type || tabToParam(tab) === undefined;
+
+        setItems((prev) => (shouldShow ? [item, ...prev] : prev));
+      },
+      onError: () => {
+        // 끊겨도 브라우저가 자동 재시도; 필요시 상태표시만
+        // console.warn("SSE connection error", e);
+      },
+    });
+
+    return close; // unmount 시 연결 해제
+  }, []);
+
+  return { items, loading, error, removeOne };
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { deleteAlert, getAlerts, connectAlertSSE } from "@/api/alert.api";
+import { deleteAlert, getAlerts } from "@/api/alert.api";
 import {
   toNotificationItem,
   type NotificationItem,
   type TabType,
 } from "@/mappers/alert.mapper";
-import type { AlertServerItem, AlertTypeParam } from "@/types/alert.model";
+import type { AlertTypeParam } from "@/types/alert.model";
 
 // 탭 -> 서버 쿼리 파라미터
 const tabToParam = (tab: TabType): AlertTypeParam | undefined => {
@@ -61,42 +61,9 @@ export default function useNotifications(selected: TabType) {
       await deleteAlert(id);
       setItems((prev) => prev.filter((x) => x.id !== id));
     } catch (e: any) {
-      // 필요시 토스트로 교체
       alert(e?.message ?? "알림 삭제에 실패했습니다.");
     }
   };
-
-  // SSE 연결 (mount 시 1회)
-  useEffect(() => {
-    // 토큰이 필요하면 localStorage 등에서 꺼내 쿼리로 전달
-    const token = localStorage.getItem("accessToken");
-
-    const close = connectAlertSSE({
-      tokenParamName: token ? "token" : undefined, // 백엔드가 허용할 때만!
-      tokenValue: token ?? undefined,
-      onMessage: (payload) => {
-        // 서버 이벤트 페이로드를 서버 스키마에 맞게 해석
-        const sse = payload as Partial<AlertServerItem> | any;
-
-        // 유효한 알림인지 체크
-        if (!sse || typeof sse !== "object" || !("alertId" in sse)) return;
-
-        // 현재 탭에서 보이는 항목만 prepend (전체면 무조건)
-        const tab = selectedRef.current;
-        const item = toNotificationItem(sse as AlertServerItem);
-        const shouldShow =
-          tab === "전체" || tab === item.type || tabToParam(tab) === undefined;
-
-        setItems((prev) => (shouldShow ? [item, ...prev] : prev));
-      },
-      onError: () => {
-        // 끊겨도 브라우저가 자동 재시도; 필요시 상태표시만
-        // console.warn("SSE connection error", e);
-      },
-    });
-
-    return close; // unmount 시 연결 해제
-  }, []);
 
   return { items, loading, error, removeOne };
 }

--- a/src/mappers/alert.mapper.ts
+++ b/src/mappers/alert.mapper.ts
@@ -1,0 +1,34 @@
+import type { AlertServerItem } from "@/types/alert.model";
+
+export type TabType = "전체" | "트러블슈팅" | "댓글" | "좋아요";
+
+export interface NotificationItem {
+  id: number;
+  type: TabType;
+  text: string;
+  link?: string;
+  isRead?: boolean;
+  title?: string;
+}
+
+// 서버 라벨(ko) -> 탭
+export function guessTabFromLabel(label?: string): TabType {
+  if (!label) return "전체";
+  if (label.includes("댓글")) return "댓글";
+  if (label.includes("좋아요")) return "좋아요";
+  if (label.includes("트러블") || label.includes("문서")) return "트러블슈팅";
+  return "전체";
+}
+
+export function toNotificationItem(
+  s: AlertServerItem,
+  fallbackTab: TabType = "전체"
+): NotificationItem {
+  return {
+    id: s.alertId,
+    type: guessTabFromLabel(s.alertType) || fallbackTab,
+    text: s.message ?? s.title ?? "",
+    isRead: s.isRead,
+    title: s.title,
+  };
+}

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -1,0 +1,110 @@
+import { type PropsWithChildren, useEffect, useRef } from "react";
+import { connectAlertSSE } from "@/api/alert.api";
+import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
+
+export default function AlertSSEProvider({ children }: PropsWithChildren) {
+  const isLoggedIn = useIsLoggedIn();
+  const viewerId = useViewerId();
+  const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
+
+  const esCloseRef = useRef<null | (() => void)>(null);
+  const connectedRef = useRef(false);
+  const stopRef = useRef(false);
+  const prevViewerRef = useRef<number | null>(null);
+  const connectTimerRef = useRef<number | null>(null);
+
+  const autoReconnect = true;
+  const retryMs = Number(import.meta.env.VITE_SSE_RETRY_MS ?? 3000);
+
+  useEffect(() => {
+    if (!hydrated) return;
+
+    if (!isLoggedIn) {
+      stopRef.current = true;
+      esCloseRef.current?.();
+      esCloseRef.current = null;
+      connectedRef.current = false;
+      prevViewerRef.current = null;
+      // 예약된 연결 시도도 취소
+      if (connectTimerRef.current != null) {
+        clearTimeout(connectTimerRef.current);
+        connectTimerRef.current = null;
+      }
+      return;
+    }
+
+    // 계정 전환 시 재연결
+    if (connectedRef.current && prevViewerRef.current !== viewerId) {
+      esCloseRef.current?.();
+      esCloseRef.current = null;
+      connectedRef.current = false;
+    }
+
+    if (connectedRef.current) return;
+
+    stopRef.current = false;
+    prevViewerRef.current = viewerId ?? null;
+
+    const start = () => {
+      const token = localStorage.getItem("accessToken") ?? "";
+      const envType =
+        localStorage.getItem("EnvType") ??
+        (import.meta as any)?.env?.VITE_ENV_TYPE ??
+        "LOCAL";
+
+      const close = connectAlertSSE(
+        {
+          onOpen: () => console.log("[SSE] connected"),
+          onMessage: () => {
+            // TODO: 알림 스토어 반영
+          },
+          onError: (e) => console.warn("[SSE] error", e),
+        },
+        { token, envType, autoReconnect, retryMs }
+      );
+
+      esCloseRef.current = () => {
+        close();
+        connectedRef.current = false;
+      };
+      connectedRef.current = true;
+    };
+
+    // StrictMode 2회 실행 방지: 첫 사이클은 예약-즉시-해제되어 네트워크 요청 X
+    connectTimerRef.current = window.setTimeout(start, 0);
+
+    // 포커스/온라인 복귀 시 재연결 보조 (dev에서도 활성화)
+    const onFocusOrOnline = () => {
+      if (stopRef.current) return;
+      if (!connectedRef.current) {
+        esCloseRef.current?.();
+        esCloseRef.current = null;
+        start();
+      }
+    };
+    const onBeforeUnload = () => esCloseRef.current?.();
+
+    window.addEventListener("focus", onFocusOrOnline);
+    window.addEventListener("online", onFocusOrOnline);
+    window.addEventListener("beforeunload", onBeforeUnload);
+
+    return () => {
+      stopRef.current = true;
+
+      if (connectTimerRef.current != null) {
+        clearTimeout(connectTimerRef.current);
+        connectTimerRef.current = null;
+      }
+
+      window.removeEventListener("focus", onFocusOrOnline);
+      window.removeEventListener("online", onFocusOrOnline);
+      window.removeEventListener("beforeunload", onBeforeUnload);
+
+      esCloseRef.current?.();
+      esCloseRef.current = null;
+      connectedRef.current = false;
+    };
+  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs]);
+
+  return <>{children}</>;
+}

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -7,27 +7,38 @@ export type Viewer = {
 
 type AuthState = {
   user: Viewer | null;
+  hydrated: boolean;
   setUser: (u: Viewer) => void;
   clearUser: () => void;
+  setHydrated: (v: boolean) => void;
 };
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,
+      hydrated: false,
       setUser: (u) => set({ user: u }),
       clearUser: () => set({ user: null }),
+      setHydrated: (v) => set({ hydrated: v }),
     }),
     {
-      name: "auth", // localStorage 키(자동 저장)
+      name: "auth",
       storage: createJSONStorage(() => localStorage),
-      partialize: (s) => ({ user: s.user }), // 필요한 것만 저장
+      partialize: (s) => ({ user: s.user }),
+      onRehydrateStorage: () => (state) => {
+        // rehydrate가 끝남을 표시
+        state?.setHydrated(true);
+      },
     }
   )
 );
 
 // 컴포넌트에서 사용
 export const useViewerId = () => useAuthStore((s) => s.user?.userId ?? null);
+export const useIsLoggedIn = () => useAuthStore((s) => s.user !== null);
+export const useAuthHydrated = () => useAuthStore((s) => s.hydrated);
 
 // 훅 못 쓰는 유틸/서비스 파일에서 사용
 export const getViewerId = () => useAuthStore.getState().user?.userId ?? null;
+export const getIsLoggedIn = () => useAuthStore.getState().user !== null;

--- a/src/types/alert.model.ts
+++ b/src/types/alert.model.ts
@@ -1,0 +1,10 @@
+export type AlertTypeParam = "comments" | "likes" | "troubles";
+
+export interface AlertServerItem {
+  alertId: number;
+  title: string;
+  message: string;
+  alertType: string;
+  isRead: boolean;
+  userId: number;
+}

--- a/src/types/alert.model.ts
+++ b/src/types/alert.model.ts
@@ -1,5 +1,11 @@
 export type AlertTypeParam = "comments" | "likes" | "troubles";
 
+export type Handlers = {
+  onOpen?: () => void;
+  onMessage?: (data: any) => void;
+  onError?: (err: any) => void;
+};
+
 export interface AlertServerItem {
   alertId: number;
   title: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,11 @@
   resolved "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz"
   integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
 
+"@microsoft/fetch-event-source@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz"
+  integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
+
 "@mswjs/interceptors@^0.39.1":
   version "0.39.5"
   resolved "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.5.tgz"


### PR DESCRIPTION
## 🔥 Issues

- closed #69 

## ✅ What to do

- [x] SSE 연결 API 연동
- [x] 알림 목록 조회 API 연동
- [x] 알림 삭제 API 연동

## 📄 Description

- `AlertSSEProvider`로 앱 전체 감싸서 사용자가 로그인 및 사이트 접속 시에 실시간 알림을 받아올 수 있도록 함

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 알림 모달이 실제 데이터와 연동되어 탭별 알림을 조회합니다.
  - 알림 삭제 기능이 추가되어 개별 알림을 제거할 수 있습니다.
  - 로딩/에러/빈 상태가 UI에 표시됩니다.
  - 앱 전역에 실시간 알림 수신을 위한 SSE 프로바이더가 도입되었습니다.
  - 로그인 상태와 스토어 하이드레이션을 감지해 안정적으로 연결을 관리합니다.
  - API 기본 URL 처리 로직이 개선되어 절대/상대 경로 구성이 유연해졌습니다.

- Chores
  - 실시간 이벤트 수신을 위한 의존성 추가: @microsoft/fetch-event-source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->