### PR TITLE
FEAT: QA 결과 일부 반영

### DIFF
--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -68,17 +68,26 @@ export function connectAlertSSE(
     openWhenHidden: true,
 
     async onopen(res) {
-      const ok =
-        res.ok &&
-        (res.headers.get("content-type") || "").startsWith("text/event-stream");
-      if (!ok) {
-        const err = new Error(`SSE open failed: ${res.status}`);
-        h.onError?.(err);
+      // 302/401/403 등 비정상 상태는 즉시 중단
+      if (!res.ok) {
+        const status = res.status;
+        if (status === 401 || status === 403 || status === 302) {
+          h.onUnauthorized?.(status);
+        } else {
+          h.onError?.(new Error(`SSE open failed: ${status}`));
+        }
+        // 재연결 루프 차단
+        ctrl.abort();
+        throw new Error(`stop-retry:${status}`);
+      }
+
+      const ct = res.headers.get("content-type") || "";
+      if (!ct.startsWith("text/event-stream")) {
+        h.onError?.(new Error(`Bad Content-Type: ${ct}`));
         if (!autoReconnect) ctrl.abort();
-        throw err;
+        throw new Error(`bad-ctype:${ct}`);
       }
       h.onOpen?.();
-      return;
     },
 
     onmessage(ev) {

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from "react-router-dom";
 import CardFooterInfo from "./CardFooterInfo";
 import CardPreviewArea from "./CardPreviewArea";
 import CardTitleSection from "./CardTitleSection";
 import TagList from "./TagList";
 import type { StatusType, VisibilityType } from "@/types/project";
+import { PATH } from "@/constants/paths";
 
 export interface TroublogCardProps {
   id: number;
@@ -18,9 +20,11 @@ export interface TroublogCardProps {
   commentCount?: number;
   importance?: number;
   summaryType?: "자기소개서" | "면접대비" | "블로그" | "이슈관리";
+  onClick?: (id: number) => void;
 }
 
 export default function TroublogCard({
+  id,
   isMine,
   status,
   visibility,
@@ -33,9 +37,34 @@ export default function TroublogCard({
   commentCount,
   importance,
   summaryType,
+  onClick,
 }: TroublogCardProps) {
+  const navigate = useNavigate();
+
+  const handleRootClick = () => {
+    if (typeof onClick === "function") {
+      onClick(id);
+    } else {
+      navigate(PATH.COMMUNITY_POST(id));
+    }
+  };
+
+  const handleRootKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleRootClick();
+    }
+  };
+
   return (
-    <div className="w-full max-w-[384px] h-[300px] sm:h-[330px] shrink-0 rounded-2xl bg-white shadow-card">
+    <div
+      className="w-full max-w-[384px] h-[300px] sm:h-[330px] shrink-0 rounded-2xl bg-white shadow-card cursor-pointer transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary/50"
+      onClick={handleRootClick}
+      onKeyDown={handleRootKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`${title} 상세 페이지로 이동`}
+    >
       {/* 프리뷰 영역 */}
       <CardPreviewArea
         errorCategory={errorCategory}

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -22,7 +22,12 @@ type MyPageSideBarProps =
         created: number;
       };
     }
-  | { isMyPage: false; sortedTags: [string, number][] };
+  | {
+      isMyPage: false;
+      sortedTags: [string, number][];
+      selectedTag: string | null;
+      onSelectTag: (tag: string | null) => void;
+    };
 
 const MyPageSideBar = (props: MyPageSideBarProps) => {
   const navigate = useNavigate();
@@ -30,7 +35,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const { id } = useParams<{ id: string }>();
   const { selectedStatus, setSelectedStatus, resetSelectedStatus } =
     useMyPageStore();
-  const { selectedTag, setSelectedTag, resetSelectedTag } = useMyPageStore();
+  const { resetSelectedTag } = useMyPageStore();
 
   const [userInfo, setUserInfo] = useState<UserInfoData | null>(null);
   const [followLoading, setFollowLoading] = useState(false);
@@ -51,6 +56,16 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   useEffect(() => {
     refetch();
   }, [refetch]);
+
+  // 현재 경로가 메인 페이지가 아니면 태그 탭 자동 초기화
+  useEffect(() => {
+    const basePath = PATH.MYPAGE(id!);
+    const onMain = location.pathname === basePath;
+    if (!onMain) {
+      resetSelectedStatus();
+      resetSelectedTag();
+    }
+  }, [location.pathname, id, resetSelectedStatus, resetSelectedTag]);
 
   const handleNavigate =
     (subPath: string = "", clearStatus = false) =>
@@ -152,11 +167,11 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
             <p className="text-head-32-semibold">{userInfo?.nickname}</p>
 
             <div className="flex gap-1 text-body-20-regular text-gray4">
-              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWING)}>
+              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWING, true)}>
                 팔로잉 {userInfo?.followingNum}
               </button>
               <span>·</span>
-              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWER)}>
+              <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWER, true)}>
                 팔로워 {userInfo?.followerNum}
               </button>
             </div>
@@ -275,32 +290,51 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
           </button>
         </div>
       ) : (
-        <div className="flex flex-col items-start gap-[12px] self-stretch">
-          <div className="w-full">
-            <div className="flex flex-col items-start gap-[12px]">
-              <span className="text-head-20-semibold">태그 분석</span>
-              <div className="w-full h-[1px] bg-[#939393]" />
-            </div>
-            <div className="flex flex-col items-start gap-[10px] pt-[12px]">
-              {props.sortedTags.map(([tag, count]) => {
-                const isSelected = tag === selectedTag;
-                return (
-                  <button
-                    key={tag}
-                    onClick={() => setSelectedTag(isSelected ? null : tag)}
-                    className={`transition-colors ${
-                      isSelected
-                        ? "text-body-16-semibold"
-                        : "text-body-16-regular text-gray3"
-                    }`}
-                  >
-                    {tag} ({count})
-                  </button>
-                );
-              })}
+        <>
+          {/* 태그 분석 (다른 사용자) */}
+          <div className="flex flex-col items-start gap-[12px] self-stretch">
+            <div className="w-full">
+              <div className="flex flex-col items-start gap-[12px]">
+                <span className="text-head-20-semibold">태그 분석</span>
+                <div className="w-full h-[1px] bg-[#939393]" />
+              </div>
+
+              <div className="flex flex-col items-start gap-[10px] pt-[12px]">
+                {/* 전체 보기 */}
+                <button
+                  type="button"
+                  onClick={() => props.onSelectTag(null)}
+                  className={`text-left ${
+                    props.selectedTag === null
+                      ? "font-semibold text-black"
+                      : "text-gray-500"
+                  }`}
+                >
+                  전체 보기
+                </button>
+
+                {/* 태그 리스트 */}
+                {props.sortedTags.map(([tag, count]) => {
+                  const isSelected = props.selectedTag === tag;
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => props.onSelectTag(isSelected ? null : tag)}
+                      className={`transition-colors ${
+                        isSelected
+                          ? "text-body-16-semibold"
+                          : "text-body-16-regular text-gray3"
+                      }`}
+                    >
+                      {tag} ({count})
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -1,12 +1,15 @@
 import MyPageSideBar from "@/components/MyPage/MyPageSidebar";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import useTroubleCards from "@/hooks/useTroubleCards";
 import { useMemo, useState } from "react";
 import { useViewerId } from "@/store/auth";
+import { PATH } from "@/constants/paths";
 
 const MyPageLayout = () => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const viewerId = useViewerId();
   const myUserIdStr = viewerId != null ? String(viewerId) : null;
@@ -23,13 +26,35 @@ const MyPageLayout = () => {
     return Number.isFinite(n) ? n : NaN;
   }, [id]);
 
+  // URL에서 tag 쿼리 읽기 (없으면 null)
+  const selectedTag = useMemo(() => {
+    const sp = new URLSearchParams(location.search);
+    const t = sp.get("tag");
+    return t && t.trim() ? t : null;
+  }, [location.search]);
+
+  // 서브메뉴(팔로잉/팔로워 등) 어디에서든 태그 클릭 시 메인 마이페이지로 이동
+  const handleSelectTag = (tag: string | null) => {
+    if (!id) return;
+    const url = tag
+      ? `${PATH.MYPAGE(id)}?tag=${encodeURIComponent(tag)}`
+      : PATH.MYPAGE(id);
+    navigate(url);
+    // 상단으로 스크롤
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   // 훅에 넘길 source를 미리 계산
   const source = useMemo(
     () =>
       isMyPage
-        ? ({ type: "all" } as const)
-        : ({ type: "user", userId: userIdNum } as const),
-    [isMyPage, userIdNum]
+        ? ({ type: "all", tag: selectedTag ?? undefined } as const)
+        : ({
+            type: "user",
+            userId: userIdNum,
+            tag: selectedTag ?? undefined,
+          } as const),
+    [isMyPage, userIdNum, selectedTag]
   );
 
   // user 페이지인데 id가 유효하지 않으면 로딩을 막아두기
@@ -42,6 +67,14 @@ const MyPageLayout = () => {
       sortBy,
       enabled,
     });
+
+  // 클라이언트 필터 적용
+  const visibleCards = useMemo(() => {
+    if (!selectedTag) return cards;
+    return cards.filter((c) =>
+      Array.isArray(c.tags) ? c.tags.includes(selectedTag) : false
+    );
+  }, [cards, selectedTag]);
 
   // 작성 상태별 트러블슈팅 개수 계산
   const counts = useMemo(() => {
@@ -57,7 +90,6 @@ const MyPageLayout = () => {
   // 다른 사용자의 마이페이지용 태그 분석
   const sortedTags = useMemo<[string, number][]>(() => {
     if (cards.length === 0) return [];
-
     const counter = new Map<string, number>();
     for (const c of cards) {
       if (!Array.isArray(c.tags)) continue;
@@ -67,8 +99,6 @@ const MyPageLayout = () => {
         counter.set(tag, (counter.get(tag) ?? 0) + 1);
       }
     }
-
-    // count 내림차순, count 같으면 이름 오름차순
     return Array.from(counter.entries()).sort(
       (a, b) => b[1] - a[1] || a[0].localeCompare(b[0])
     );
@@ -79,14 +109,19 @@ const MyPageLayout = () => {
       <MyPageSideBar
         {...(isMyPage
           ? { isMyPage: true as const, counts }
-          : { isMyPage: false as const, sortedTags })}
+          : {
+              isMyPage: false as const,
+              sortedTags,
+              selectedTag,
+              onSelectTag: handleSelectTag,
+            })}
       />
 
       <div className="flex flex-col items-start">
         <Outlet
           context={{
             isMyPage,
-            cards,
+            cards: visibleCards,
             isLoading,
             error,
             hasNext,
@@ -94,6 +129,7 @@ const MyPageLayout = () => {
             reload,
             sortBy,
             setSortBy,
+            selectedTag,
           }}
         />
       </div>

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -480,15 +480,29 @@ export default function FreeFormWritePage() {
               loadingProjects={projectsLoading}
               defaultProjectId={initialProjectId}
               selectedTags={selectedTags}
-              initialImportance={location.state?.savePrefill?.importance}
-              initialDescription={location.state?.savePrefill?.description}
-              initialVisibility={location.state?.savePrefill?.visibility}
+              initialImportance={
+                previewMeta?.importance ??
+                location.state?.savePrefill?.importance
+              }
+              initialDescription={
+                previewMeta?.description ??
+                location.state?.savePrefill?.description
+              }
+              initialVisibility={
+                previewMeta?.visibility ??
+                location.state?.savePrefill?.visibility
+              }
               initialProjectId={
+                previewMeta?.projectId ??
                 location.state?.savePrefill?.projectId ??
                 initialProjectId ??
                 null
               }
-              initialThumbnail={location.state?.savePrefill?.thumbnail ?? null}
+              initialThumbnail={
+                previewMeta?.thumbnail ??
+                location.state?.savePrefill?.thumbnail ??
+                null
+              }
             />
           )}
 
@@ -497,6 +511,10 @@ export default function FreeFormWritePage() {
               onConfirm={(type, label) => handleConfirmTemplate(type, label)}
               onClose={() => setIsTemplateSelectModalOpen(false)}
               onLater={handleLater}
+              onPrev={() => {
+                setIsTemplateSelectModalOpen(false);
+                setIsPostSaveModalOpen(true);
+              }}
             />
           )}
 

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -45,17 +45,16 @@ type IncomingFreeformState = {
 };
 
 const errorOptions = [
-  "Build / Compile Error",
+  "Build/Compile Error",
   "Runtime Error",
-  "Dependency / Version Error",
-  "Network / API Error",
-  "Authentication / Authorization Error",
+  "Dependency/Version Error",
+  "Network/API Error",
+  "Authentication/Authorization Error",
   "Database Error",
-  "UI / Rendering Error",
+  "UI/Rendering Error",
   "Configuration Error",
-  "Timeout / Error Handling",
+  "Timeout/Error Handling",
   "Third-Party Library Error",
-  "Others",
 ];
 
 export default function FreeFormWritePage() {

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -403,15 +403,29 @@ const TempWritePage = () => {
               defaultProjectId={initialProjectId}
               selectedTags={selectedTags}
               // 수정 프리필 반영
-              initialImportance={location.state?.savePrefill?.importance}
-              initialDescription={location.state?.savePrefill?.description}
-              initialVisibility={location.state?.savePrefill?.visibility}
+              initialImportance={
+                previewMeta?.importance ??
+                location.state?.savePrefill?.importance
+              }
+              initialDescription={
+                previewMeta?.description ??
+                location.state?.savePrefill?.description
+              }
+              initialVisibility={
+                previewMeta?.visibility ??
+                location.state?.savePrefill?.visibility
+              }
               initialProjectId={
+                previewMeta?.projectId ??
                 location.state?.savePrefill?.projectId ??
                 initialProjectId ??
                 null
               }
-              initialThumbnail={location.state?.savePrefill?.thumbnail ?? null}
+              initialThumbnail={
+                previewMeta?.thumbnail ??
+                location.state?.savePrefill?.thumbnail ??
+                null
+              }
             />
           )}
 
@@ -420,6 +434,10 @@ const TempWritePage = () => {
               onConfirm={(type, label) => handleConfirmTemplate(type, label)}
               onClose={() => setIsTemplateSelectModalOpen(false)}
               onLater={handleLater}
+              onPrev={() => {
+                setIsTemplateSelectModalOpen(false);
+                setIsPostSaveModalOpen(true);
+              }}
             />
           )}
 

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -350,17 +350,16 @@ const TempWritePage = () => {
             <div className="flex gap-[36px] items-center">
               <DropDownButton
                 options={[
-                  "Build / Compile Error",
+                  "Build/Compile Error",
                   "Runtime Error",
-                  "Dependency / Version Error",
-                  "Network / API Error",
-                  "Authentication / Authorization Error",
+                  "Dependency/Version Error",
+                  "Network/API Error",
+                  "Authentication/Authorization Error",
                   "Database Error",
-                  "UI / Rendering Error",
+                  "UI/Rendering Error",
                   "Configuration Error",
-                  "Timeout / Error Handling",
+                  "Timeout/Error Handling",
                   "Third-Party Library Error",
-                  "Others",
                 ]}
                 placeholder="에러 종류를 선택하세요"
                 width="w-[340px] h-[36px]"

--- a/src/pages/TempWrite/TemplateSelectModal.tsx
+++ b/src/pages/TempWrite/TemplateSelectModal.tsx
@@ -17,10 +17,12 @@ export default function TemplateSelectModal({
   onClose,
   onConfirm,
   onLater,
+  onPrev,
 }: {
   onClose: () => void;
   onConfirm: (type: SummaryTypeParam, label: string) => void;
   onLater: () => void;
+  onPrev?: () => void;
 }) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [hasTriedSubmit, setHasTriedSubmit] = useState(false);
@@ -93,6 +95,7 @@ export default function TemplateSelectModal({
 
         {/* 버튼 */}
         <div className="flex justify-end gap-[16px] pt-[12px] pb-[32px]">
+          {onPrev && <CancelButton onClick={onPrev} label="이전" />}
           <CancelButton onClick={onLater} label="다음에" />
           <SaveButton onClick={handleConfirm} label="요약" />
         </div>

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -1,6 +1,16 @@
 import { type PropsWithChildren, useEffect, useRef } from "react";
 import { connectAlertSSE } from "@/api/alert.api";
 import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
+import api from "@/api/axios";
+
+async function tryRefreshOnce() {
+  try {
+    await api.get("/auth/refresh");
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const isLoggedIn = useIsLoggedIn();
@@ -12,6 +22,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const stopRef = useRef(false);
   const prevViewerRef = useRef<number | null>(null);
   const connectTimerRef = useRef<number | null>(null);
+  const refreshingRef = useRef(false);
 
   const autoReconnect = true;
   const retryMs = Number(import.meta.env.VITE_SSE_RETRY_MS ?? 3000);
@@ -19,7 +30,8 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     if (!hydrated) return;
 
-    if (!isLoggedIn) {
+    const token = localStorage.getItem("accessToken") ?? "";
+    if (!isLoggedIn || !token) {
       stopRef.current = true;
       esCloseRef.current?.();
       esCloseRef.current = null;
@@ -46,7 +58,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
     prevViewerRef.current = viewerId ?? null;
 
     const start = () => {
-      const token = localStorage.getItem("accessToken") ?? "";
+      const curToken = localStorage.getItem("accessToken") ?? "";
       const envType =
         localStorage.getItem("EnvType") ??
         (import.meta as any)?.env?.VITE_ENV_TYPE ??
@@ -59,8 +71,28 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
             // TODO: 알림 스토어 반영
           },
           onError: (e) => console.warn("[SSE] error", e),
+          onUnauthorized: async () => {
+            // 401/403/302 → 재연결 루프 STOP 후 토큰 갱신 1회 시도
+            if (refreshingRef.current) return;
+            refreshingRef.current = true;
+
+            const ok = await tryRefreshOnce();
+            refreshingRef.current = false;
+
+            if (stopRef.current) return;
+            if (!ok) {
+              // 갱신 실패 → 연결 유지하지 않음 (사용자가 재로그인하면 effect가 다시 트리거)
+              return;
+            }
+            // 갱신 성공 → 새 토큰으로 재연결
+            esCloseRef.current?.();
+            esCloseRef.current = null;
+            connectedRef.current = false;
+            // 약간의 딜레이 후 재시도(토큰 저장/동기화 여유)
+            connectTimerRef.current = window.setTimeout(start, 200);
+          },
         },
-        { token, envType, autoReconnect, retryMs }
+        { token: curToken, envType, autoReconnect, retryMs }
       );
 
       esCloseRef.current = () => {

--- a/src/types/alert.model.ts
+++ b/src/types/alert.model.ts
@@ -4,6 +4,7 @@ export type Handlers = {
   onOpen?: () => void;
   onMessage?: (data: any) => void;
   onError?: (err: any) => void;
+  onUnauthorized?: (status: number) => void;
 };
 
 export interface AlertServerItem {


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ]  한 일

## 📄 Description

- 다른 사용자의 페이지 태그 분석 전체 보기 탭 추가
- SSE 무한 연결 재시도 차단
- 트러블슈팅 문서 상세 조회 임시로 연결 및 에러 태그 오타 수정
- 요약 모달창에 이전 버튼 추가

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카드 클릭 동작을 커스터마이즈 가능(옵션 onClick)하며 키보드 접근성(Enter/Space) 추가.
  - 템플릿 선택 단계에 “이전” 버튼 도입으로 모달 간 뒤로가기 지원.
  - 마이페이지에서 URL 쿼리(tag) 기반 태그 필터링 및 스크롤 상단 이동.

- 개선
  - 작성/템플릿 페이지 옵션 라벨 통일(슬래시 공백 제거) 및 “Others” 제거.
  - 저장 모달 사전입력값이 미리보기 정보 우선 사용(중요도/설명/공개범위/프로젝트/썸네일).
  - 마이페이지 사이드바 태그 선택 제어 개선 및 탐색 시 상태 초기화.
  - 알림 실시간 연결의 인증 만료 시 1회 자동 재인증 시도로 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->