### PR TITLE
FEAT: QA 결과 반영 (기능 관련)

### DIFF
--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -91,12 +91,20 @@ export function connectAlertSSE(
     },
 
     onmessage(ev) {
+      // 서버가 이벤트 이름을 준다면 'alert'만 처리
+      if (ev.event && ev.event !== "alert") return;
+
       const d = ev.data;
+      // 서버/프록시 keepalive 주석 라인 무시
       if (typeof d === "string" && d.startsWith(":")) return;
+      if (!d) return;
+
+      // 알림 payload만 파싱 시도
       try {
-        h.onMessage?.(JSON.parse(d));
+        const parsed = JSON.parse(d);
+        h.onMessage?.(parsed);
       } catch {
-        h.onMessage?.(d);
+        // 비-JSON은 무시 (예: "SSE 연결 성공")
       }
     },
 

--- a/src/api/post.api.ts
+++ b/src/api/post.api.ts
@@ -48,7 +48,7 @@ export const editPost = (postId: number, body: EditPostRequest) =>
 // 원본 문서 삭제
 export const deletePost = (postId: number) =>
   getAPIResponseData<void>({
-    url: `/troubles/${postId}/hard`,
+    url: `/troubles/${postId}`,
     method: "DELETE",
   });
 

--- a/src/api/trouble.api.ts
+++ b/src/api/trouble.api.ts
@@ -25,7 +25,7 @@ const inflightCommunity = new Map<
 export const getTroubleList = (
   page = 1,
   size = 10,
-  sortBy: "latest" | "likes" = "latest"
+  sortBy: "latest" | "importance" = "latest"
 ) =>
   getAPIResponseData<GetTroubleListResponse>(
     api.get<GetTroubleListResponse>("/troubles/my/list", {
@@ -66,15 +66,10 @@ export async function searchMyTroubles(params: {
 }
 
 // 특정 사용자 트러블슈팅 목록 조회 (카드)
-export const getUserTroubleList = (
-  userId: number,
-  page = 1,
-  size = 10,
-  sortBy: "latest" | "likes" = "latest"
-) =>
+export const getUserTroubleList = (userId: number, page = 1, size = 10) =>
   getAPIResponseData<GetTroubleListResponse>(
     api.get<GetTroubleListResponse>(`/troubles/users/${userId}/list`, {
-      params: { page, size, sortBy },
+      params: { page, size },
     })
   );
 

--- a/src/api/trouble.api.ts
+++ b/src/api/trouble.api.ts
@@ -5,14 +5,20 @@ import type {
 } from "@/types/trouble.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 import api from "./axios";
-import type { MyTroublesServerPage } from "@/types/troubles.server";
+
+// 엔드포인트별 검색 응답 타입으로 분리
+import type {
+  MyTroubleSearchPage,
+  UserTroubleSearchPage,
+  CommunityTroubleSearchPage,
+} from "@/types/troubles.server";
 
 // 키별 디듀프(StrictMode 이펙트 2회 방지)
-const inflight = new Map<string, Promise<MyTroublesServerPage | null>>();
-const inflightUser = new Map<string, Promise<MyTroublesServerPage | null>>();
+const inflightMy = new Map<string, Promise<MyTroubleSearchPage | null>>();
+const inflightUser = new Map<string, Promise<UserTroubleSearchPage | null>>();
 const inflightCommunity = new Map<
   string,
-  Promise<MyTroublesServerPage | null>
+  Promise<CommunityTroubleSearchPage | null>
 >();
 
 /// 전체 트러블슈팅 목록 조회
@@ -38,28 +44,28 @@ export const getProjectTroubleList = (
     params: query, // { status: 'COMPLETED'|'SUMMARIZED', ...선택 }
   });
 
-// 사용자의 트러블슈팅 문서 기반 검색
+// 내 트러블슈팅 검색
 export async function searchMyTroubles(params: {
   keyword: string;
   page?: number;
   size?: number;
-}): Promise<MyTroublesServerPage | null> {
+}): Promise<MyTroubleSearchPage | null> {
   const { keyword, page = 1, size = 10 } = params;
   const p = Math.max(1, page);
 
   const key = `my::${keyword}::${p}::${size}`;
-  if (!inflight.has(key)) {
-    const promise = getAPIResponseData<MyTroublesServerPage | null>({
-      url: "/troubles/my/search",
+  if (!inflightMy.has(key)) {
+    const promise = getAPIResponseData<MyTroubleSearchPage | null>({
+      url: "troubles/my/search",
       method: "GET",
       params: { keyword, page: p, size },
-    }).finally(() => setTimeout(() => inflight.delete(key), 0));
-    inflight.set(key, promise);
+    }).finally(() => setTimeout(() => inflightMy.delete(key), 0));
+    inflightMy.set(key, promise);
   }
-  return inflight.get(key)!;
+  return inflightMy.get(key)!;
 }
 
-// 특정 사용자의 트러블슈팅 목록 조회
+// 특정 사용자 트러블슈팅 목록 조회 (카드)
 export const getUserTroubleList = (
   userId: number,
   page = 1,
@@ -72,20 +78,20 @@ export const getUserTroubleList = (
     })
   );
 
-// 특정 사용자의 트러블슈팅 문서 기반 검색
+// 특정 사용자 트러블슈팅 검색
 export async function searchUserTroubles(params: {
   userId: number;
   keyword: string;
   page?: number;
   size?: number;
-}): Promise<MyTroublesServerPage | null> {
+}): Promise<UserTroubleSearchPage | null> {
   const { userId, keyword, page = 1, size = 10 } = params;
   const p = Math.max(1, page);
 
   const key = `user:${userId}::${keyword}::${p}::${size}`;
   if (!inflightUser.has(key)) {
-    const promise = getAPIResponseData<MyTroublesServerPage | null>({
-      url: `/troubles/users/${userId}/search`,
+    const promise = getAPIResponseData<UserTroubleSearchPage | null>({
+      url: `/troubles/users/${userId}`,
       method: "GET",
       params: { keyword, page: p, size },
     }).finally(() => setTimeout(() => inflightUser.delete(key), 0));
@@ -94,18 +100,18 @@ export async function searchUserTroubles(params: {
   return inflightUser.get(key)!;
 }
 
-// 공개 커뮤니티 검색 (제목/본문/태그)
+// 커뮤니티 검색
 export async function searchCommunityTroubles(params: {
   keyword: string;
   page?: number;
   size?: number;
-}): Promise<MyTroublesServerPage | null> {
+}): Promise<CommunityTroubleSearchPage | null> {
   const { keyword, page = 1, size = 10 } = params;
-  const p = Math.max(1, page); // ← 서버는 1부터
+  const p = Math.max(1, page);
 
   const key = `community::${keyword}::${p}::${size}`;
   if (!inflightCommunity.has(key)) {
-    const promise = getAPIResponseData<MyTroublesServerPage | null>({
+    const promise = getAPIResponseData<CommunityTroubleSearchPage | null>({
       url: "/community/search",
       method: "GET",
       params: { keyword, page: p, size },

--- a/src/components/Card/CardHeaderRight.tsx
+++ b/src/components/Card/CardHeaderRight.tsx
@@ -20,12 +20,19 @@ export default function CardHeaderRight({
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
+  // 카드 클릭으로 전파되지 않도록 막는 핸들러
+  const stopCardClick = {
+    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+    onKeyDown: (e: React.KeyboardEvent) => e.stopPropagation(),
+  };
+
   if (!isMine) {
     return (
       <img
         src={authorProfileImageUrl || image}
         alt="작성자 프로필"
         className="w-[28px] h-[28px] sm:w-[36px] sm:h-[36px] rounded-full"
+        onClick={(e) => e.stopPropagation()}
       />
     );
   }
@@ -34,22 +41,26 @@ export default function CardHeaderRight({
     <div className="relative flex items-center gap-1 sm:gap-2" ref={menuRef}>
       <StatusDot status={status} />
       {status !== "inProgress" && (
-        <>
-          <KebabMenuButton onClick={() => setShowMenu(!showMenu)} />
+        <div className="relative" {...stopCardClick}>
+          <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
+
           {showMenu && (
-            <KebabDropdown
-              options={[
-                {
-                  label: "삭제",
-                  onClick: () => {
-                    setShowMenu(false);
-                    console.log("삭제 동작 실행");
+            // 아이템 클릭 시 카드 onClick 방지
+            <div {...stopCardClick}>
+              <KebabDropdown
+                options={[
+                  {
+                    label: "삭제",
+                    onClick: () => {
+                      setShowMenu(false);
+                      console.log("삭제 동작 실행");
+                    },
                   },
-                },
-              ]}
-            />
+                ]}
+              />
+            </div>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/components/Card/CardHeaderRight.tsx
+++ b/src/components/Card/CardHeaderRight.tsx
@@ -11,6 +11,8 @@ interface CardHeaderRightProps {
   status: StatusType;
   authorProfileImageUrl?: string;
   onAvatarClick?: () => void;
+  onDelete?: () => void;
+  deleting?: boolean;
 }
 
 export default function CardHeaderRight({
@@ -18,6 +20,8 @@ export default function CardHeaderRight({
   status,
   authorProfileImageUrl,
   onAvatarClick,
+  onDelete,
+  deleting = false,
 }: CardHeaderRightProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
@@ -62,10 +66,11 @@ export default function CardHeaderRight({
               <KebabDropdown
                 options={[
                   {
-                    label: "삭제",
+                    label: deleting ? "삭제 중..." : "삭제",
                     onClick: () => {
-                      setShowMenu(false);
-                      console.log("삭제 동작 실행");
+                      if (!deleting) {
+                        onDelete?.();
+                      }
                     },
                   },
                 ]}

--- a/src/components/Card/CardHeaderRight.tsx
+++ b/src/components/Card/CardHeaderRight.tsx
@@ -10,12 +10,14 @@ interface CardHeaderRightProps {
   isMine: boolean;
   status: StatusType;
   authorProfileImageUrl?: string;
+  onAvatarClick?: () => void;
 }
 
 export default function CardHeaderRight({
   isMine,
   status,
   authorProfileImageUrl,
+  onAvatarClick,
 }: CardHeaderRightProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
@@ -32,7 +34,17 @@ export default function CardHeaderRight({
         src={authorProfileImageUrl || image}
         alt="작성자 프로필"
         className="w-[28px] h-[28px] sm:w-[36px] sm:h-[36px] rounded-full"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onAvatarClick?.();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onAvatarClick?.();
+          }
+        }}
       />
     );
   }

--- a/src/components/Card/CardPreviewArea.tsx
+++ b/src/components/Card/CardPreviewArea.tsx
@@ -7,6 +7,8 @@ interface CardPreviewAreaProps {
   status: StatusType;
   authorProfileImageUrl?: string;
   onAvatarClick?: () => void;
+  onRequestDelete?: () => void;
+  deleting?: boolean;
 }
 
 export default function CardPreviewArea({
@@ -15,6 +17,8 @@ export default function CardPreviewArea({
   status,
   authorProfileImageUrl,
   onAvatarClick,
+  onRequestDelete,
+  deleting,
 }: CardPreviewAreaProps) {
   return (
     <div
@@ -29,6 +33,8 @@ export default function CardPreviewArea({
           status={status}
           authorProfileImageUrl={authorProfileImageUrl}
           onAvatarClick={onAvatarClick}
+          onDelete={onRequestDelete}
+          deleting={deleting}
         />
       </div>
     </div>

--- a/src/components/Card/CardPreviewArea.tsx
+++ b/src/components/Card/CardPreviewArea.tsx
@@ -6,6 +6,7 @@ interface CardPreviewAreaProps {
   isMine: boolean;
   status: StatusType;
   authorProfileImageUrl?: string;
+  onAvatarClick?: () => void;
 }
 
 export default function CardPreviewArea({
@@ -13,6 +14,7 @@ export default function CardPreviewArea({
   isMine,
   status,
   authorProfileImageUrl,
+  onAvatarClick,
 }: CardPreviewAreaProps) {
   return (
     <div
@@ -26,6 +28,7 @@ export default function CardPreviewArea({
           isMine={isMine}
           status={status}
           authorProfileImageUrl={authorProfileImageUrl}
+          onAvatarClick={onAvatarClick}
         />
       </div>
     </div>

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -16,11 +16,13 @@ export interface TroublogCardProps {
   createdAt: string;
   tags: string[];
   authorProfileImageUrl?: string;
+  authorId?: number;
   likeCount?: number;
   commentCount?: number;
   importance?: number;
   summaryType?: "자기소개서" | "면접대비" | "블로그" | "이슈관리";
   onClick?: (id: number) => void;
+  onAvatarClick?: () => void;
 }
 
 export default function TroublogCard({
@@ -38,6 +40,7 @@ export default function TroublogCard({
   importance,
   summaryType,
   onClick,
+  onAvatarClick,
 }: TroublogCardProps) {
   const navigate = useNavigate();
 
@@ -71,6 +74,7 @@ export default function TroublogCard({
         isMine={isMine}
         status={status}
         authorProfileImageUrl={authorProfileImageUrl}
+        onAvatarClick={onAvatarClick}
       />
 
       {/* 제목, 날짜, 태그 영역 */}

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -5,6 +5,8 @@ import CardTitleSection from "./CardTitleSection";
 import TagList from "./TagList";
 import type { StatusType, VisibilityType } from "@/types/project";
 import { PATH } from "@/constants/paths";
+import { useCallback, useState } from "react";
+import { deletePost } from "@/api/post.api";
 
 export interface TroublogCardProps {
   id: number;
@@ -23,6 +25,7 @@ export interface TroublogCardProps {
   summaryType?: "자기소개서" | "면접대비" | "블로그" | "이슈관리";
   onClick?: (id: number) => void;
   onAvatarClick?: () => void;
+  onDeleted?: (id: number) => void;
 }
 
 export default function TroublogCard({
@@ -41,8 +44,10 @@ export default function TroublogCard({
   summaryType,
   onClick,
   onAvatarClick,
+  onDeleted,
 }: TroublogCardProps) {
   const navigate = useNavigate();
+  const [deleting, setDeleting] = useState(false);
 
   const handleRootClick = () => {
     if (typeof onClick === "function") {
@@ -58,6 +63,31 @@ export default function TroublogCard({
       handleRootClick();
     }
   };
+
+  // 케밥 > 삭제
+  const handleRequestDelete = useCallback(async () => {
+    if (!isMine) return;
+    if (
+      !window.confirm(
+        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setDeleting(true);
+      await deletePost(id);
+      onDeleted?.(id); // 부모에 알림(목록 갱신)
+    } catch (err: any) {
+      console.error(err);
+      alert(
+        err?.response?.data?.message ??
+          "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }, [id, isMine, onDeleted]);
 
   return (
     <div
@@ -75,6 +105,8 @@ export default function TroublogCard({
         status={status}
         authorProfileImageUrl={authorProfileImageUrl}
         onAvatarClick={onAvatarClick}
+        onRequestDelete={handleRequestDelete}
+        deleting={deleting}
       />
 
       {/* 제목, 날짜, 태그 영역 */}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -11,6 +11,7 @@ import NotificationModal from "../Modal/NotificationModal";
 import { PATH } from "@/constants/paths";
 import logo from "@/assets/icons/logo.svg";
 import { useViewerId } from "@/store/auth";
+import { useNotificationStore } from "@/store/notification";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -27,11 +28,15 @@ const Header = () => {
   const viewerId = useViewerId();
   const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
+  const hasNew = useNotificationStore((s) => s.hasNew);
+  const clearNew = useNotificationStore((s) => s.clearNew);
+
   const handleMouseEnter = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
     setIsNotificationModalOpen(true);
+    if (hasNew) clearNew();
   };
 
   const handleMouseLeave = () => {
@@ -197,8 +202,8 @@ const Header = () => {
           >
             <BsFillBellFill
               size={40}
-              color="#525252"
-              className="cursor-pointer"
+              color={hasNew ? "#7C3AED" : "#525252"}
+              className="cursor-pointer transition-colors"
             />
             {isNotificationModalOpen && (
               <div className="absolute right-[-10px] top-full mt-[41.5px] z-10">

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,6 +21,7 @@ const Header = () => {
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
   const userDropdownRef = useClickOutside(() => setIsUserDropdownOpen(false));
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
   const viewerId = useViewerId();
@@ -158,9 +159,18 @@ const Header = () => {
         onClick={() => navigate(PATH.HOME)}
       />
       <div className="flex w-full gap-12 items-center">
-        <div className="flex w-full h-12 p-2 justify-between items-center gap-1 rounded-md border border-gray1">
+        <div
+          role="search"
+          onClick={() => inputRef.current?.focus()}
+          className="
+    group flex w-full h-12 p-2 justify-between items-center gap-1
+    rounded-md border border-gray1 transition
+    focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40
+  "
+        >
           <input
-            className="text-body-14-regular w-full"
+            ref={inputRef}
+            className="text-body-16-regular w-full h-full focus:outline-none"
             placeholder={placeholder}
             value={search}
             onChange={handleSearch}

--- a/src/components/Header/HeaderWoSearch.tsx
+++ b/src/components/Header/HeaderWoSearch.tsx
@@ -9,6 +9,7 @@ import useClickOutside from "@/hooks/useClickOutside";
 import NotificationModal from "../Modal/NotificationModal";
 import UserMenuDropdown from "../Menu/UserMenuDropdown";
 import { useViewerId } from "@/store/auth";
+import { useNotificationStore } from "@/store/notification";
 
 const HeaderWoSearch = () => {
   const navigate = useNavigate();
@@ -22,11 +23,17 @@ const HeaderWoSearch = () => {
   const viewerId = useViewerId();
   const myUserId = viewerId != null ? String(viewerId) : null;
 
+  const { hasNew, clearNew } = useNotificationStore((s) => ({
+    hasNew: s.hasNew,
+    clearNew: s.clearNew,
+  }));
+
   const handleMouseEnter = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
     setIsNotificationModalOpen(true);
+    clearNew();
   };
 
   const handleMouseLeave = () => {
@@ -67,8 +74,8 @@ const HeaderWoSearch = () => {
         >
           <BsFillBellFill
             size={40}
-            color="#525252"
-            className="cursor-pointer"
+            color={hasNew ? "#7C3AED" : "#525252"}
+            className="cursor-pointer transition-colors"
           />
           {isNotificationModalOpen && (
             <div className="absolute right-[-10px] top-full mt-[41.5px] z-10">

--- a/src/components/Menu/KebabMenuButton.tsx
+++ b/src/components/Menu/KebabMenuButton.tsx
@@ -8,7 +8,11 @@ export default function KebabMenuButton({ onClick }: KebabMenuButtonProps) {
   return (
     <button
       onClick={onClick}
-      className="w-[16px] h-[16px] sm:w-[18px] sm:h-[18px]"
+      className="
+        inline-flex items-center justify-center
+        -m-2 p-2                 
+        rounded-full hover:bg-gray-100
+      "
     >
       <img
         src={kebabIcon}

--- a/src/components/Menu/KebabMenuButton.tsx
+++ b/src/components/Menu/KebabMenuButton.tsx
@@ -1,23 +1,46 @@
+// KebabMenuButton.tsx
 import kebabIcon from "@/assets/icons/menu-kebab.svg";
+
+type HitArea = "compact" | "comfortable" | "spacious";
 
 interface KebabMenuButtonProps {
   onClick?: () => void;
+  iconSize?: number;
+  hitArea?: HitArea;
+  className?: string;
+  ariaLabel?: string;
 }
 
-export default function KebabMenuButton({ onClick }: KebabMenuButtonProps) {
+const hitAreaClass: Record<HitArea, string> = {
+  compact: "-m-1 p-1",
+  comfortable: "-m-2 p-2",
+  spacious: "-m-3 p-3",
+};
+
+export default function KebabMenuButton({
+  onClick,
+  iconSize = 18,
+  hitArea = "comfortable",
+  className = "",
+  ariaLabel = "케밥 메뉴",
+}: KebabMenuButtonProps) {
   return (
     <button
       onClick={onClick}
-      className="
-        inline-flex items-center justify-center
-        -m-2 p-2                 
-        rounded-full hover:bg-gray-100
-      "
+      aria-label={ariaLabel}
+      className={[
+        "inline-flex items-center justify-center rounded-full",
+        "hover:bg-gray-100",
+        hitAreaClass[hitArea],
+        className,
+      ].join(" ")}
     >
       <img
         src={kebabIcon}
-        alt="케밥 메뉴"
-        className="w-full h-full object-contain"
+        alt=""
+        aria-hidden="true"
+        style={{ width: iconSize, height: iconSize }}
+        className="shrink-0"
       />
     </button>
   );

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -62,7 +62,20 @@ export default function NotificationModal() {
                 className="flex justify-between items-start group"
               >
                 <div
-                  onClick={() => item.link && navigate(item.link)}
+                  onClick={() => {
+                    if (!item.link) return;
+                    try {
+                      const url = new URL(item.link);
+                      if (url.origin === window.location.origin) {
+                        navigate(url.pathname + url.search + url.hash);
+                      } else {
+                        window.location.href = item.link;
+                      }
+                    } catch {
+                      // 절대 URL 파싱 실패 → 내부 경로로 간주
+                      navigate(item.link);
+                    }
+                  }}
                   className={clsx(
                     "text-body-20-regular cursor-pointer transition-all",
                     item.link &&

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -70,7 +70,6 @@ const TroubleShootingCard = ({
 
   const navigate = useNavigate();
 
-  const shouldShowVisibilityIcon = status === "complete" && visibility;
   const shouldShowSummaryType = status === "created";
 
   const isClickable = typeof onClick === "function" && !disabled;
@@ -204,7 +203,7 @@ const TroubleShootingCard = ({
                       · {summaryType}
                     </div>
                   )}
-                  {shouldShowVisibilityIcon && visibility && (
+                  {visibility && isMine && (
                     <img
                       src={visibility === "public" ? publicIcon : privateIcon}
                       alt={visibility}
@@ -222,7 +221,7 @@ const TroubleShootingCard = ({
             <div className="flex flex-wrap items-center gap-[12px]">
               <TagList tags={tags} variant="mypage" />
               <div className="flex items-center gap-[12px]">
-                {!isSearchResult && importance !== undefined && (
+                {!isSearchResult && importance !== undefined && isMine && (
                   <>
                     <div className="flex items-center gap-[4px]">
                       <img

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -11,7 +11,7 @@ import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import commentIcon from "@/assets/icons/comment.svg";
 import { deletePost } from "@/api/post.api";
-import type { MyTroubleServerItem } from "@/types/troubles.server";
+import type { MyTroubleDetailItem } from "@/types/troubles.server";
 
 export interface TroubleShootingCardProps {
   id: string;
@@ -33,7 +33,7 @@ export interface TroubleShootingCardProps {
   onDeleted?: (postId: number) => void;
   onClick?: (postId: number) => void;
   disabled?: boolean;
-  raw?: MyTroubleServerItem;
+  raw?: MyTroubleDetailItem;
 }
 
 const TroubleShootingCard = ({

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -12,6 +12,8 @@ import heartIcon from "@/assets/icons/heart.svg";
 import commentIcon from "@/assets/icons/comment.svg";
 import { deletePost } from "@/api/post.api";
 import type { MyTroubleDetailItem } from "@/types/troubles.server";
+import { useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
 
 export interface TroubleShootingCardProps {
   id: string;
@@ -29,6 +31,8 @@ export interface TroubleShootingCardProps {
   likeCount?: number;
   commentCount?: number;
   authorName?: string;
+  authorProfileImageUrl?: string;
+  authorUserId?: number;
   isSearchResult?: boolean;
   onDeleted?: (postId: number) => void;
   onClick?: (postId: number) => void;
@@ -52,6 +56,8 @@ const TroubleShootingCard = ({
   likeCount,
   commentCount,
   authorName,
+  authorProfileImageUrl,
+  authorUserId,
   isSearchResult,
   onDeleted,
   onClick,
@@ -61,6 +67,8 @@ const TroubleShootingCard = ({
   const [deleting, setDeleting] = useState(false);
   const handleCloseMenu = useCallback(() => setShowMenu(false), []);
   const menuRef = useClickOutside(handleCloseMenu);
+
+  const navigate = useNavigate();
 
   const shouldShowVisibilityIcon = status === "complete" && visibility;
   const shouldShowSummaryType = status === "created";
@@ -106,6 +114,23 @@ const TroubleShootingCard = ({
     }
   };
 
+  const handleAuthorClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation();
+    if (!authorUserId) return;
+    navigate(PATH.MYPAGE(String(authorUserId)));
+  };
+
+  const handleAuthorKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (
+    e
+  ) => {
+    if (!authorUserId) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      navigate(PATH.MYPAGE(String(authorUserId)));
+    }
+  };
+
   return (
     <div
       className={`w-full py-[30px] flex flex-col items-start gap-[10px] border-b border-gray3 bg-white ${
@@ -124,8 +149,18 @@ const TroubleShootingCard = ({
       <div className="w-full flex flex-col">
         {/* 작성자 */}
         {isSearchResult && (
-          <div className="mb-[25px] flex items-center gap-[12px]">
-            <img src={imageIcon} alt="profile" className="w-[52px] h-[52px]" />
+          <div
+            className="mb-[25px] flex items-center gap-[12px] cursor-pointer" // ⬅️ 시각적 힌트
+            onClick={handleAuthorClick}
+            onKeyDown={handleAuthorKeyDown}
+            role={authorUserId ? "button" : undefined}
+            tabIndex={authorUserId ? 0 : undefined}
+          >
+            <img
+              src={authorProfileImageUrl ? authorProfileImageUrl : imageIcon}
+              alt="profile"
+              className="w-[52px] h-[52px]"
+            />
             <span className="text-head-24-bold">{authorName}</span>
           </div>
         )}

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -11,6 +11,7 @@ import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import commentIcon from "@/assets/icons/comment.svg";
 import { deletePost } from "@/api/post.api";
+import type { MyTroubleServerItem } from "@/types/troubles.server";
 
 export interface TroubleShootingCardProps {
   id: string;
@@ -32,6 +33,7 @@ export interface TroubleShootingCardProps {
   onDeleted?: (postId: number) => void;
   onClick?: (postId: number) => void;
   disabled?: boolean;
+  raw?: MyTroubleServerItem;
 }
 
 const TroubleShootingCard = ({

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -3,7 +3,9 @@ import SortButtonGroup from "../Project/SortButtonGroup";
 import TroubleShootingCard from "./TroubleShootingCard";
 import { mapToTroubleShootingCard } from "@/mappers/cardMapper";
 import { useMyPageStore } from "@/store/useMyPageStore";
-import { useOutletContext } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+import { useViewerId } from "@/store/auth";
 
 interface OutletContextType {
   isMyPage: boolean;
@@ -29,6 +31,8 @@ const TroubleShootingList = () => {
     setSortBy,
     reload,
   } = useOutletContext<OutletContextType>();
+  const navigate = useNavigate();
+  const viewerId = useViewerId();
 
   const selectedStatus = useMyPageStore((state) => state.selectedStatus);
   const selectedTag = useMyPageStore((state) => state.selectedTag);
@@ -83,6 +87,15 @@ const TroubleShootingList = () => {
             key={card.id}
             {...mapToTroubleShootingCard(card)}
             onDeleted={handleDeleted}
+            onClick={() => {
+              const qs = new URLSearchParams({ from: "mypage" });
+              if (isMyPage) {
+                qs.set("ownerId", String(viewerId));
+              }
+              navigate(`${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`, {
+                state: { from: "mypage" },
+              });
+            }}
           />
         ))}
 

--- a/src/components/Notification/NotificationToaster.tsx
+++ b/src/components/Notification/NotificationToaster.tsx
@@ -1,0 +1,77 @@
+// components/Notification/NotificationToaster.tsx
+import { useEffect, useRef } from "react";
+import { useNotificationStore } from "@/store/notification";
+import { useNavigate } from "react-router-dom";
+
+export default function NotificationToaster() {
+  const toasts = useNotificationStore((s) => s.toasts);
+  const popToast = useNotificationStore((s) => s.popToast);
+  const navigate = useNavigate();
+
+  // 이미 예약된 타이머 중복 방지 (리렌더 시 중복 등록을 막기 위해)
+  const scheduledRef = useRef<Record<number, number>>({});
+
+  useEffect(() => {
+    // 새로 생긴 토스트만 타이머 등록
+    for (const t of toasts) {
+      if (scheduledRef.current[t.id]) continue;
+      const tid = window.setTimeout(() => {
+        popToast(t.id);
+        delete scheduledRef.current[t.id];
+      }, 2500);
+      scheduledRef.current[t.id] = tid;
+    }
+
+    // 사라진 토스트의 타이머 정리
+    const liveIds = new Set(toasts.map((t) => t.id));
+    for (const id in scheduledRef.current) {
+      const num = Number(id);
+      if (!liveIds.has(num)) {
+        clearTimeout(scheduledRef.current[num]);
+        delete scheduledRef.current[num];
+      }
+    }
+
+    // 언마운트 안전 장치
+    return () => {
+      for (const id in scheduledRef.current) {
+        clearTimeout(scheduledRef.current[Number(id)]);
+      }
+      scheduledRef.current = {};
+    };
+  }, [toasts, popToast]);
+
+  const handleClick = (link?: string) => {
+    if (!link) return;
+    try {
+      const url = new URL(link);
+      if (url.origin === window.location.origin) {
+        navigate(url.pathname + url.search + url.hash);
+      } else {
+        window.location.href = link;
+      }
+    } catch {
+      // 절대 URL이 아니면 내부 경로로 가정
+      navigate(link);
+    }
+  };
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[9999] flex flex-col gap-2">
+      {toasts.map((t) => (
+        <button
+          key={t.id}
+          onClick={() => handleClick(t.link)}
+          className="px-4 py-2 rounded-full bg-black/90 text-white shadow-card hover:bg-black transition"
+          title={t.title}
+        >
+          <span className="font-semibold">{t.title}</span>
+          <span className="mx-2">·</span>
+          <span>{t.message}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -144,7 +144,11 @@ export default function ProjectFolderCard({
         e.stopPropagation();
       }}
     >
-      <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
+      <KebabMenuButton
+        onClick={() => setShowMenu((v) => !v)}
+        iconSize={16}
+        hitArea="comfortable"
+      />
       {showMenu && (
         <KebabDropdown
           options={[

--- a/src/hooks/useInfiniteCommunityTroubleSearch.ts
+++ b/src/hooks/useInfiniteCommunityTroubleSearch.ts
@@ -1,11 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useInfiniteMyTroubleSearch } from "./useInfiniteMyTroubleSearch";
 import { searchCommunityTroubles } from "@/api/trouble.api";
-import type { MyTroubleServerItem } from "@/types/troubles.server";
+import type { MyTroubleDetailItem } from "@/types/troubles.server";
 
 export function useInfiniteCommunityTroubleSearch(keyword: string, size = 10) {
   // 공개 + 완료만 (작성 중 제외)
-  const filterVisible = useCallback((x: MyTroubleServerItem) => {
+  const filterVisible = useCallback((x: MyTroubleDetailItem) => {
     const visible = x.isVisible === true; // 서버가 boolean로 내려줌
     const statusRaw = String(x.postStatus ?? "");
     const inProgress =

--- a/src/hooks/useInfiniteMyTroubleSearch.ts
+++ b/src/hooks/useInfiniteMyTroubleSearch.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { searchMyTroubles } from "@/api/trouble.api";
 import type {
-  MyTroublesServerPage,
-  MyTroubleServerItem,
+  MyTroubleSearchPage,
+  TroubleSearchCard,
 } from "@/types/troubles.server";
 import type { TroubleShootingCardProps } from "@/components/MyPage/TroubleShootingCard";
 import { toTroubleShootingCard } from "@/mappers/trouble.list-to-ts-card";
@@ -15,13 +15,13 @@ export interface UseInfiniteMyTroubleSearchOptions {
 
 type Fetcher = (args: {
   keyword: string;
-  page: number;
+  page: number; // 1-based 요청
   size: number;
-}) => Promise<MyTroublesServerPage | null>;
+}) => Promise<MyTroubleSearchPage | null>;
 
 interface Ext {
   fetcher?: Fetcher;
-  filterItem?: (x: MyTroubleServerItem) => boolean;
+  filterItem?: (x: TroubleSearchCard) => boolean; // 여기도 카드 타입으로
   enabled?: boolean;
 }
 
@@ -40,13 +40,14 @@ export function useInfiniteMyTroubleSearch(
     [options?.isMine, options?.authorName, options?.isSearchResult]
   );
 
+  // /my/search 반환 타입에 맞춘 Fetcher
   const fetcher: Fetcher = useMemo(
     () => ext?.fetcher ?? ((args) => searchMyTroubles(args)),
     [ext?.fetcher]
   );
   const enabled = ext?.enabled ?? true;
 
-  // filterItem은 ref에 담아 콜백 의존성 불변화
+  // filterItem은 ref로 유지
   const filterRef = useRef<Ext["filterItem"]>(ext?.filterItem);
   useEffect(() => {
     filterRef.current = ext?.filterItem;
@@ -57,13 +58,13 @@ export function useInfiniteMyTroubleSearch(
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 내부 page는 1-based
   const [page, setPage] = useState(1);
   const [hasNext, setHasNext] = useState(false);
   const [totalElements, setTotalElements] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
-  const [displayTotal, setDisplayTotal] = useState(0); // 화면 표시용 개수
+  const [displayTotal, setDisplayTotal] = useState(0);
 
-  // 중복 호출 방지 락
   const inflightRef = useRef(false);
   const lastKeyRef = useRef<string>("");
 
@@ -85,7 +86,7 @@ export function useInfiniteMyTroubleSearch(
       if (inflightRef.current) return;
 
       const key = `${keyword}::${p}::${size}`;
-      if (key === lastKeyRef.current) return; // 같은 요청 반복 방지
+      if (key === lastKeyRef.current) return;
       lastKeyRef.current = key;
 
       inflightRef.current = true;
@@ -95,19 +96,25 @@ export function useInfiniteMyTroubleSearch(
 
         const res = await fetcher({ keyword, page: Math.max(1, p), size });
 
-        const safe: MyTroublesServerPage = res ?? {
-          content: [],
-          hasNext: false,
-          totalPages: 0,
-          totalElements: 0,
-          page: p,
-          size,
-          isFirst: p === 1,
-          isLast: true,
+        // 서버가 0-based page를 줄 수 있으니 안전 보정
+        const safe: MyTroubleSearchPage = {
+          content: res?.content ?? [],
+          hasNext: !!res?.hasNext,
+          totalPages: res?.totalPages ?? 0,
+          totalElements: res?.totalElements ?? 0,
+          page:
+            typeof res?.page === "number"
+              ? res.page >= 0
+                ? res.page + 1
+                : Math.max(1, p)
+              : Math.max(1, p),
+          size: res?.size ?? size,
+          isFirst: res?.isFirst ?? p === 1,
+          isLast: res?.isLast ?? !res?.hasNext,
         };
 
-        // 필터링 (다른 사용자 검색에서 공개글만)
-        const raw = (safe.content as MyTroubleServerItem[]) ?? [];
+        // /my/search 아이템 타입 사용
+        const raw = (safe.content as TroubleSearchCard[]) ?? [];
         const filtered = filterRef.current
           ? raw.filter(filterRef.current)
           : raw;
@@ -120,12 +127,12 @@ export function useInfiniteMyTroubleSearch(
           for (const it of prev) map.set(it.id, it);
           for (const it of mapped) map.set(it.id, it);
           const arr = Array.from(map.values());
-          setDisplayTotal(arr.length); // 현재 화면에 보여질 총 개수
+          setDisplayTotal(arr.length);
           return arr;
         });
 
         setPage(safe.page);
-        setHasNext(safe.hasNext);
+        setHasNext(!!safe.hasNext);
         setTotalElements(safe.totalElements);
         setTotalPages(safe.totalPages);
       } catch (e) {
@@ -140,7 +147,6 @@ export function useInfiniteMyTroubleSearch(
     [opt, enabled, keyword, size, fetcher]
   );
 
-  // 키워드/사이즈/옵션 변경 시 초기 1페이지 로드
   useEffect(() => {
     if (!enabled || !keyword.trim()) {
       reset();

--- a/src/hooks/useInfiniteUserTroubleSearch.ts
+++ b/src/hooks/useInfiniteUserTroubleSearch.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useInfiniteMyTroubleSearch } from "./useInfiniteMyTroubleSearch";
 import { searchUserTroubles } from "@/api/trouble.api";
-import type { MyTroubleServerItem } from "@/types/troubles.server";
+import type { MyTroubleDetailItem } from "@/types/troubles.server";
 
 export function useInfiniteUserTroubleSearch(
   keyword: string,
@@ -9,7 +9,7 @@ export function useInfiniteUserTroubleSearch(
   size = 10
 ) {
   // 공개 + 완료만 (작성 중 제외)
-  const filterVisible = useCallback((x: MyTroubleServerItem) => {
+  const filterVisible = useCallback((x: MyTroubleDetailItem) => {
     const visible = x.isVisible === true; // 서버가 boolean로 내려줌
     const statusRaw = String(x.postStatus ?? "");
     const inProgress =

--- a/src/hooks/useTroubleCards.ts
+++ b/src/hooks/useTroubleCards.ts
@@ -15,7 +15,7 @@ import type {
 import { useViewerId } from "@/store/auth";
 
 // 내 전체 목록 정렬용 (서버 스펙)
-type SortParam = "latest" | "likes";
+type SortParam = "latest" | "importance";
 
 type Source =
   | { type: "all" }
@@ -85,7 +85,7 @@ async function fetchUserPagedOnce(
   const sk = `user:${userId}`;
   const key = makePagedKey(sk, page, size, sortBy);
   if (!inflightUserPaged.has(key)) {
-    const p = getUserTroubleList(userId, page, size, sortBy).finally(() =>
+    const p = getUserTroubleList(userId, page, size).finally(() =>
       inflightUserPaged.delete(key)
     );
     inflightUserPaged.set(key, p);
@@ -219,12 +219,7 @@ export default function useTroubleCards(source: Source, options: Options = {}) {
                 pageSize,
                 sortBy
               )
-            : await getUserTroubleList(
-                source.userId,
-                targetPage,
-                pageSize,
-                sortBy
-              );
+            : await getUserTroubleList(source.userId, targetPage, pageSize);
         } else {
           // all
           resp = dedupe

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,5 @@
 import Header from "@/components/Header/Header";
+import NotificationToaster from "@/components/Notification/NotificationToaster";
 import { Outlet } from "react-router-dom";
 
 export default function MainLayout() {
@@ -7,6 +8,7 @@ export default function MainLayout() {
       <Header />
       <main className="flex-1 max-w-screen-[1920px] px-4 sm:px-6 md:px-8">
         <Outlet />
+        <NotificationToaster />
       </main>
     </div>
   );

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -68,13 +68,24 @@ const MyPageLayout = () => {
       enabled,
     });
 
+  // 공개글 판정 (여러 형태 대비)
+  const isPublicCard = (c: any) =>
+    c?.isVisible === true ||
+    c?.visibility === "public" ||
+    c?.raw?.isVisible === true;
+
+  // 다른 사람 마이페이지면 공개글만 사용
+  const cardsForView = useMemo(() => {
+    return isMyPage ? cards : cards.filter(isPublicCard);
+  }, [cards, isMyPage]);
+
   // 클라이언트 필터 적용
   const visibleCards = useMemo(() => {
-    if (!selectedTag) return cards;
-    return cards.filter((c) =>
+    if (!selectedTag) return cardsForView;
+    return cardsForView.filter((c) =>
       Array.isArray(c.tags) ? c.tags.includes(selectedTag) : false
     );
-  }, [cards, selectedTag]);
+  }, [cardsForView, selectedTag]);
 
   // 작성 상태별 트러블슈팅 개수 계산
   const counts = useMemo(() => {
@@ -89,9 +100,9 @@ const MyPageLayout = () => {
 
   // 다른 사용자의 마이페이지용 태그 분석
   const sortedTags = useMemo<[string, number][]>(() => {
-    if (cards.length === 0) return [];
+    if (cardsForView.length === 0) return [];
     const counter = new Map<string, number>();
-    for (const c of cards) {
+    for (const c of cardsForView) {
       if (!Array.isArray(c.tags)) continue;
       for (const raw of c.tags) {
         const tag = String(raw ?? "").trim();
@@ -102,7 +113,7 @@ const MyPageLayout = () => {
     return Array.from(counter.entries()).sort(
       (a, b) => b[1] - a[1] || a[0].localeCompare(b[0])
     );
-  }, [cards]);
+  }, [cardsForView]);
 
   return (
     <div className="flex items-start gap-[68px] pt-20 justify-center">

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -18,7 +18,7 @@ const MyPageLayout = () => {
   const isMyPage = !!myUserId && id === myUserId;
 
   // 정렬 상태
-  const [sortBy, setSortBy] = useState<"latest" | "likes">("latest");
+  const [sortBy, setSortBy] = useState<"latest" | "importance">("latest");
 
   // userId 숫자 파싱 (없거나 잘못된 경우 NaN)
   const userIdNum = useMemo(() => {

--- a/src/mappers/alert.mapper.ts
+++ b/src/mappers/alert.mapper.ts
@@ -30,5 +30,6 @@ export function toNotificationItem(
     text: s.message ?? s.title ?? "",
     isRead: s.isRead,
     title: s.title,
+    link: s.targetUrl ?? undefined,
   };
 }

--- a/src/mappers/communityCard.mapper.ts
+++ b/src/mappers/communityCard.mapper.ts
@@ -11,6 +11,7 @@ export const toCommunityCard = (s: CommunityServerCard): TroublogCardProps => ({
   createdAt: s.completedAt ?? "",
   tags: s.postTags ?? [],
   authorProfileImageUrl: s.postCardUserInfoResDto?.profileImageUrl ?? undefined,
+  authorId: s.postCardUserInfoResDto.userId,
   likeCount: s.likeCount ?? 0,
   commentCount: s.commentCount ?? 0,
 });

--- a/src/mappers/communityCard.mapper.ts
+++ b/src/mappers/communityCard.mapper.ts
@@ -11,7 +11,7 @@ export const toCommunityCard = (s: CommunityServerCard): TroublogCardProps => ({
   createdAt: s.completedAt ?? "",
   tags: s.postTags ?? [],
   authorProfileImageUrl: s.postCardUserInfoResDto?.profileImageUrl ?? undefined,
-  authorId: s.postCardUserInfoResDto.userId,
+  authorId: s.postCardUserInfoResDto?.userId,
   likeCount: s.likeCount ?? 0,
   commentCount: s.commentCount ?? 0,
 });

--- a/src/mappers/myPostDetail.mapper.ts
+++ b/src/mappers/myPostDetail.mapper.ts
@@ -2,33 +2,46 @@ import type { CommunityPostDetailProps } from "@/pages/Community/CommunityPostDe
 
 // getPostDetail의 data 형태(래퍼 제거 후)
 export type PostDetailServer = {
+  userInfoResDto?: {
+    userId: number;
+    nickname: string;
+    profileUrl: string | null;
+    bio: string | null;
+    followerNum: number;
+    followingNum: number;
+    isFollowed: boolean;
+  } | null;
+
   id: number;
   title: string;
   introduction: string | null;
+
   likeCount: number;
   commentCount: number;
-  isVisible: boolean;
+  liked?: boolean | null;
+
   isSummaryCreated: boolean;
-  isDeleted: boolean;
   postStatus: string;
-  starRating: string | number;
-  checklistError: string[];
-  checklistReason: string[];
-  createdAt: string; // ISO
-  updatedAt: string; // ISO
-  deletedAt: string | null;
-  userId: number;
-  projectId: number;
+  starRating: number | string;
+  templateType?: "FREE_FORM" | "GUIDELINE" | string;
+
+  checklistError: number[];
+  checklistReason: number[];
+
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+
   errorTag: string;
   postTags: string[];
+
   contents: Array<{
     id: number;
     subTitle: string;
     body: string;
     sequence: number;
-    authorType: "USER_WRITTEN" | string;
-    summaryType: "NONE" | string;
   }>;
+
   thumbnailUrl?: string | null;
 };
 
@@ -73,7 +86,14 @@ export function toPostDetailVM(
   src: PostDetailServer,
   viewerId: number | string | null
 ): CommunityPostDetailProps {
-  const isMine = viewerId != null && String(src.userId) === String(viewerId);
+  const author = src.userInfoResDto ?? null;
+  const authorId = author?.userId;
+
+  const isMine =
+    viewerId != null &&
+    authorId != null &&
+    String(authorId) === String(viewerId);
+
   const sorted = [...(src.contents ?? [])].sort(
     (a, b) => (a?.sequence ?? 0) - (b?.sequence ?? 0)
   );
@@ -83,16 +103,20 @@ export function toPostDetailVM(
     title: src.title ?? "",
     tags: src.postTags ?? [],
     date: isoToYYMMDD(src.updatedAt || src.createdAt),
+
     isMine,
-    authorId: src.userId,
-    authorProfile: undefined,
-    authorName: "",
-    authorFollowers: 0,
-    authorBio: "",
+    authorId: authorId ?? 0,
+    authorProfile: author?.profileUrl ?? undefined,
+    authorName: author?.nickname ?? "",
+    authorFollowers: author?.followerNum ?? 0,
+    authorBio: author?.bio ?? "",
+
     importance: starToNumber(src.starRating),
+
     questions: sorted.map((c, i) => c?.subTitle || `섹션 ${i + 1}`),
     contents: sorted.map((c) => [c?.body || ""]),
-    isLiked: false,
+
+    isLiked: !!src.liked,
     likeCounts: src.likeCount ?? 0,
     commentCounts: src.commentCount ?? 0,
     comments: [],

--- a/src/mappers/myPostDetail.mapper.ts
+++ b/src/mappers/myPostDetail.mapper.ts
@@ -1,0 +1,100 @@
+import type { CommunityPostDetailProps } from "@/pages/Community/CommunityPostDetail";
+
+// getPostDetail의 data 형태(래퍼 제거 후)
+export type PostDetailServer = {
+  id: number;
+  title: string;
+  introduction: string | null;
+  likeCount: number;
+  commentCount: number;
+  isVisible: boolean;
+  isSummaryCreated: boolean;
+  isDeleted: boolean;
+  postStatus: string;
+  starRating: string | number;
+  checklistError: string[];
+  checklistReason: string[];
+  createdAt: string; // ISO
+  updatedAt: string; // ISO
+  deletedAt: string | null;
+  userId: number;
+  projectId: number;
+  errorTag: string;
+  postTags: string[];
+  contents: Array<{
+    id: number;
+    subTitle: string;
+    body: string;
+    sequence: number;
+    authorType: "USER_WRITTEN" | string;
+    summaryType: "NONE" | string;
+  }>;
+  thumbnailUrl?: string | null;
+};
+
+// ISO -> "YY.MM.DD"
+const isoToYYMMDD = (iso?: string) => {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const yy = String(d.getFullYear()).slice(-2);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yy}.${mm}.${dd}`;
+};
+
+// 별점 enum/숫자 -> 정수(0~5)
+const starToNumber = (v: string | number | undefined): number => {
+  if (typeof v === "number") return Math.max(0, Math.min(5, v));
+  switch (String(v || "").toUpperCase()) {
+    case "ONE_STAR":
+    case "ONE_STARS":
+    case "ONE":
+      return 1;
+    case "TWO_STARS":
+    case "TWO":
+      return 2;
+    case "THREE_STARS":
+    case "THREE":
+      return 3;
+    case "FOUR_STARS":
+    case "FOUR":
+      return 4;
+    case "FIVE_STARS":
+    case "FIVE":
+      return 5;
+    default:
+      return 0;
+  }
+};
+
+// getPostDetail(data) -> CommunityPostDetailProps
+export function toPostDetailVM(
+  src: PostDetailServer,
+  viewerId: number | string | null
+): CommunityPostDetailProps {
+  const isMine = viewerId != null && String(src.userId) === String(viewerId);
+  const sorted = [...(src.contents ?? [])].sort(
+    (a, b) => (a?.sequence ?? 0) - (b?.sequence ?? 0)
+  );
+
+  return {
+    errorType: src.errorTag ?? "",
+    title: src.title ?? "",
+    tags: src.postTags ?? [],
+    date: isoToYYMMDD(src.updatedAt || src.createdAt),
+    isMine,
+    authorId: src.userId,
+    authorProfile: undefined,
+    authorName: "",
+    authorFollowers: 0,
+    authorBio: "",
+    importance: starToNumber(src.starRating),
+    questions: sorted.map((c, i) => c?.subTitle || `섹션 ${i + 1}`),
+    contents: sorted.map((c) => [c?.body || ""]),
+    isLiked: false,
+    likeCounts: src.likeCount ?? 0,
+    commentCounts: src.commentCount ?? 0,
+    comments: [],
+  };
+}

--- a/src/mappers/postMapper.ts
+++ b/src/mappers/postMapper.ts
@@ -13,6 +13,7 @@ export interface PostForm {
   isSummaryCreated: boolean;
   postStatus: string;
   starRating: string;
+  templateType: string;
   thumbnailImageUrl?: string;
   projectId: number;
 
@@ -28,6 +29,7 @@ export const toCreatePostRequest = (form: PostForm): CreatePostRequest => ({
   isSummaryCreated: form.isSummaryCreated,
   postStatus: form.postStatus,
   starRating: form.starRating,
+  templateType: form.templateType,
   thumbnailImageUrl: form.thumbnailImageUrl,
   projectId: form.projectId,
   errorTagName: form.errorTag,
@@ -42,6 +44,7 @@ export const toEditPostRequest = (form: PostForm): EditPostRequest => ({
   isSummaryCreated: form.isSummaryCreated,
   postStatus: form.postStatus,
   starRating: form.starRating,
+  templateType: form.templateType,
   thumbnailImageUrl: form.thumbnailImageUrl,
   projectId: form.projectId,
   errorTagName: form.errorTag,
@@ -56,6 +59,7 @@ export const toPostForm = (res: ViewPostResponse): PostForm => ({
   isSummaryCreated: res.isSummaryCreated,
   postStatus: res.postStatus,
   starRating: res.starRating,
+  templateType: res.templateType,
   thumbnailImageUrl: res.thumbnailImageUrl,
   projectId: res.projectId,
   errorTag: res.errorTag,

--- a/src/mappers/trouble.list-to-ts-card.ts
+++ b/src/mappers/trouble.list-to-ts-card.ts
@@ -4,6 +4,7 @@ import type {
   MyTroubleDetailItem,
   CommunityTroubleSearchItem,
   TroubleSearchCard,
+  UserBrief,
 } from "@/types/troubles.server";
 import { formatYYMMDD } from "@/utils/troubleFormat";
 
@@ -55,13 +56,26 @@ const pickContent = (
   return "";
 };
 
+// 작성자(UserBrief) 우선 사용
+function extractUserBrief(
+  item: MyTroubleDetailItem | CommunityTroubleSearchItem | TroubleSearchCard
+): UserBrief | undefined {
+  if (has(item, "postCardUserInfoResDto")) {
+    return (item as any).postCardUserInfoResDto as UserBrief;
+  }
+  if (has(item, "userInfo")) {
+    return (item as any).userInfo as UserBrief;
+  }
+  return undefined;
+}
+
 export const toTroubleShootingCard = (
   item: MyTroubleDetailItem | CommunityTroubleSearchItem | TroubleSearchCard,
   opts?: { isMine?: boolean; authorName?: string; isSearchResult?: boolean }
 ): TroubleShootingCardProps => {
   const {
     isMine = true,
-    authorName = "나",
+    authorName: fallbackAuthorName = "나",
     isSearchResult = true,
   } = opts ?? {};
 
@@ -85,6 +99,13 @@ export const toTroubleShootingCard = (
       ? (item as any).contents?.[0]?.summaryType ?? undefined
       : undefined;
 
+  const brief = extractUserBrief(item);
+  const authorName = brief?.nickname ?? fallbackAuthorName;
+  const authorProfileImageUrl = brief?.profileImageUrl ?? undefined;
+  const authorUserId =
+    brief?.userId ??
+    (("userId" in (item as any) && (item as any).userId) || undefined);
+
   return {
     id: String((item as any).id),
     isMine,
@@ -103,6 +124,8 @@ export const toTroubleShootingCard = (
     likeCount: (item as any).likeCount ?? undefined,
     commentCount: (item as any).commentCount ?? undefined,
     authorName,
+    authorProfileImageUrl,
+    authorUserId,
     isSearchResult,
   } as TroubleShootingCardProps;
 };

--- a/src/mappers/trouble.list-to-ts-card.ts
+++ b/src/mappers/trouble.list-to-ts-card.ts
@@ -1,31 +1,35 @@
 import type { TroubleShootingCardProps } from "@/components/MyPage/TroubleShootingCard";
 import type { StatusType, VisibilityType } from "@/types/project";
-import type { MyTroubleServerItem } from "@/types/troubles.server";
+import type {
+  MyTroubleDetailItem,
+  CommunityTroubleSearchItem,
+  TroubleSearchCard,
+} from "@/types/troubles.server";
 import { formatYYMMDD } from "@/utils/troubleFormat";
 
-// 서버 상태 + 요약 생성 여부 -> 카드 StatusType
+// 타입 가드
+const has = (o: unknown, k: string) => !!o && typeof o === "object" && k in o;
+
 const toStatus = (
   postStatus?: string | null,
-  isSummaryCreated?: boolean | null
+  isSummaryCreated?: boolean | null,
+  completedAt?: string | null
 ): StatusType => {
   if (isSummaryCreated) return "created";
   const v = String(postStatus ?? "").trim();
   const U = v.toUpperCase();
-
   if (U === "COMPLETED" || v === "작성 완료") return "complete";
   if (
     U === "IN_PROGRESS" ||
-    U === "DRAFT" ||
+    U === "WRITING" ||
     v === "임시 저장" ||
     v === "작성 중"
   )
     return "inProgress";
-
-  // 모호하면 완료로
+  if (completedAt != null) return "complete";
   return "complete";
 };
 
-// boolean/string -> 카드 VisibilityType
 const toVisibility = (
   raw?: boolean | string | null
 ): VisibilityType | undefined => {
@@ -38,13 +42,21 @@ const toVisibility = (
   return undefined;
 };
 
-// 소개문 -> 첫 본문 -> 빈 문자열
-const pickContent = (x: MyTroubleServerItem): string =>
-  x.introduction ?? x.contents?.[0].body ?? "";
+const pickContent = (
+  item: MyTroubleDetailItem | CommunityTroubleSearchItem | TroubleSearchCard
+): string => {
+  if (has(item, "introduction") && (item as any).introduction) {
+    return (item as any).introduction as string;
+  }
+  if (has(item, "contents") && Array.isArray((item as any).contents)) {
+    const c0 = (item as any).contents?.[0];
+    if (c0?.body) return c0.body as string;
+  }
+  return "";
+};
 
-// 서버 아이템 -> TroubleShootingCardProps
 export const toTroubleShootingCard = (
-  item: MyTroubleServerItem,
+  item: MyTroubleDetailItem | CommunityTroubleSearchItem | TroubleSearchCard,
   opts?: { isMine?: boolean; authorName?: string; isSearchResult?: boolean }
 ): TroubleShootingCardProps => {
   const {
@@ -53,34 +65,44 @@ export const toTroubleShootingCard = (
     isSearchResult = true,
   } = opts ?? {};
 
-  const status = toStatus(item.postStatus, item.isSummaryCreated);
+  const status = toStatus(
+    has(item, "postStatus") ? (item as any).postStatus : null,
+    has(item, "isSummaryCreated") ? (item as any).isSummaryCreated : null,
+    has(item, "completedAt") ? (item as any).completedAt : null
+  );
+
+  const createdAt =
+    has(item, "createdAt") && (item as any).createdAt
+      ? formatYYMMDD((item as any).createdAt as string)
+      : has(item, "completedAt") && (item as any).completedAt
+      ? ((item as any).completedAt as string)
+      : "";
+
+  const summaryType =
+    status === "created" &&
+    has(item, "contents") &&
+    Array.isArray((item as any).contents)
+      ? (item as any).contents?.[0]?.summaryType ?? undefined
+      : undefined;
 
   return {
-    id: String(item.id),
+    id: String((item as any).id),
     isMine,
-    errorCategory: item.errorTag ?? "",
-    title: item.title ?? "",
+    errorCategory: (item as any).errorTag ?? "",
+    title: (item as any).title ?? "",
     content: pickContent(item),
-    tags: item.postTags ?? [],
-    importance: item.starRating ?? undefined,
-    createdAt: item.createdAt ? formatYYMMDD(item.createdAt) : "",
-    thumbnailUrl: item.thumbnailUrl ?? undefined,
-    visibility: toVisibility(item.isVisible),
-    summaryType:
-      status === "created"
-        ? item.contents?.[0]?.summaryType ?? undefined
-        : undefined,
+    tags: (item as any).postTags ?? [],
+    importance: (item as any).starRating ?? undefined,
+    createdAt,
+    thumbnailUrl: (item as any).thumbnailUrl ?? undefined,
+    visibility: has(item, "isVisible")
+      ? toVisibility((item as any).isVisible)
+      : undefined,
+    summaryType,
     status,
-    likeCount: item.likeCount ?? undefined,
-    commentCount: item.commentCount ?? undefined,
+    likeCount: (item as any).likeCount ?? undefined,
+    commentCount: (item as any).commentCount ?? undefined,
     authorName,
     isSearchResult,
-    raw: item,
-  };
+  } as TroubleShootingCardProps;
 };
-
-export const toTroubleShootingCards = (
-  items: MyTroubleServerItem[],
-  opts: { isMine?: boolean; authorName?: string; isSearchResult?: boolean }
-): TroubleShootingCardProps[] =>
-  (items ?? []).map((it) => toTroubleShootingCard(it, opts));

--- a/src/mappers/trouble.list-to-ts-card.ts
+++ b/src/mappers/trouble.list-to-ts-card.ts
@@ -75,6 +75,7 @@ export const toTroubleShootingCard = (
     commentCount: item.commentCount ?? undefined,
     authorName,
     isSearchResult,
+    raw: item,
   };
 };
 

--- a/src/mappers/trouble.server-to-list.ts
+++ b/src/mappers/trouble.server-to-list.ts
@@ -1,9 +1,9 @@
 import type { TroubleListItem } from "@/types/trouble.model";
-import type { MyTroubleServerItem } from "@/types/troubles.server";
+import type { MyTroubleDetailItem } from "@/types/troubles.server";
 
 // 서버 -> 공통 도메인 (TroubleListItem)
 export const serverToTroubleListItem = (
-  x: MyTroubleServerItem
+  x: MyTroubleDetailItem
 ): TroubleListItem => ({
   id: x.id,
   projectId: x.projectId ?? 0,

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -33,6 +33,7 @@ export interface PostBasicFields {
   isSummaryCreated: boolean;
   postStatus: string;
   starRating: string;
+  templateType: string;
   thumbnailImageUrl?: string;
 }
 
@@ -43,6 +44,7 @@ export interface PostServerMeta {
   createdAt: string;
   updatedAt: string;
   deletedAt: string | null;
+  completedAt: string | null;
   userId: number;
   projectId: number;
 }

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -122,9 +122,9 @@ export default function CommunityPage() {
               onClick={() => {
                 const qs = new URLSearchParams({ from: "community" });
                 if (card.authorId != null)
-                  qs.set("ownerId", String(card.authorId)); // ← 있을 때만
+                  qs.set("ownerId", String(card.authorId));
                 navigate(`${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`, {
-                  state: { from: "community", ownerId: card.authorId }, // ← 보조용 state
+                  state: { from: "community", ownerId: card.authorId },
                 });
               }}
               onAvatarClick={() => {

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -119,15 +119,17 @@ export default function CommunityPage() {
           <div key={card.id} className="cursor-pointer">
             <TroublogCard
               {...card}
-              onClick={(id) =>
-                navigate(PATH.COMMUNITY_POST(id), {
-                  state: { from: "community" },
-                })
-              }
+              onClick={() => {
+                const qs = new URLSearchParams({ from: "community" });
+                if (card.authorId != null)
+                  qs.set("ownerId", String(card.authorId)); // ← 있을 때만
+                navigate(`${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`, {
+                  state: { from: "community", ownerId: card.authorId }, // ← 보조용 state
+                });
+              }}
               onAvatarClick={() => {
-                if (card.authorId != null) {
+                if (card.authorId != null)
                   navigate(PATH.MYPAGE(String(card.authorId)));
-                }
               }}
             />
           </div>

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -116,13 +116,14 @@ export default function CommunityPage() {
       {/* 트러블로그 카드 */}
       <div className="w-full mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-[24px] gap-y-[60px]">
         {active.cards.map((card) => (
-          <div
-            key={card.id}
-            className="cursor-pointer"
-            onClick={() => navigate(PATH.COMMUNITY_POST(card.id))}
-          >
+          <div key={card.id} className="cursor-pointer">
             <TroublogCard
               {...card}
+              onClick={(id) =>
+                navigate(PATH.COMMUNITY_POST(id), {
+                  state: { from: "community" },
+                })
+              }
               onAvatarClick={() => {
                 if (card.authorId != null) {
                   navigate(PATH.MYPAGE(String(card.authorId)));

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -121,7 +121,14 @@ export default function CommunityPage() {
             className="cursor-pointer"
             onClick={() => navigate(PATH.COMMUNITY_POST(card.id))}
           >
-            <TroublogCard {...card} />
+            <TroublogCard
+              {...card}
+              onAvatarClick={() => {
+                if (card.authorId != null) {
+                  navigate(PATH.MYPAGE(String(card.authorId)));
+                }
+              }}
+            />
           </div>
         ))}
 

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -30,6 +30,8 @@ import {
   toPostComments,
 } from "@/mappers/communityComment.mapper";
 import { useViewerId } from "@/store/auth";
+import { getPostDetail } from "@/api/post.api";
+import { toPostDetailVM } from "@/mappers/myPostDetail.mapper";
 
 export interface CommunityPostDetailProps {
   errorType: string;
@@ -202,22 +204,45 @@ export default function CommunityPostDetail() {
 
       setLoading(true);
       try {
-        const data = await fetchPostOnce(numId);
+        // community 상세로 작성자 ID 확인
+        const communityData = await fetchPostOnce(numId);
         if (cancelled) return;
 
-        if (!data) {
+        if (!communityData) {
           setLoadError("빈 응답입니다.");
           return;
         }
 
-        const vm = toCommunityPostVM(data, viewerId);
-        setPost(vm);
-        setIsLiked(vm.isLiked);
-        setLikeCounts(vm.likeCounts);
-        setComments(vm.comments);
+        const authorIdFromCommunity =
+          communityData?.userInfoResDto?.userId ?? null;
+        const isMineNow =
+          authorIdFromCommunity != null &&
+          viewerId != null &&
+          String(authorIdFromCommunity) === String(viewerId);
 
-        // 댓글은 비동기로 시작(상세 렌더는 먼저)
-        void loadComments(numId, 1);
+        if (isMineNow) {
+          try {
+            const resp = await getPostDetail(numId);
+            const vm = toPostDetailVM(resp as any, viewerId);
+            setPost(vm);
+            setIsLiked(vm.isLiked);
+            setLikeCounts(vm.likeCounts);
+            void loadComments(numId, 1);
+          } catch {
+            // post.api 실패 시 기존 커뮤니티 응답으로 폴백
+            const vm = toCommunityPostVM(communityData, viewerId);
+            setPost(vm);
+            setIsLiked(vm.isLiked);
+            setLikeCounts(vm.likeCounts);
+            void loadComments(numId, 1);
+          }
+        } else {
+          const vm = toCommunityPostVM(communityData, viewerId);
+          setPost(vm);
+          setIsLiked(vm.isLiked);
+          setLikeCounts(vm.likeCounts);
+          void loadComments(numId, 1);
+        }
       } catch (err: any) {
         if (!cancelled) setLoadError(err?.message ?? "포스트 불러오기 실패");
       } finally {
@@ -615,9 +640,11 @@ export default function CommunityPostDetail() {
                     </div>
 
                     {/* 팔로우 버튼 */}
-                    <button className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white cursor-pointer">
-                      팔로우
-                    </button>
+                    {!post.isMine && (
+                      <button className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white cursor-pointer">
+                        팔로우
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -7,8 +7,8 @@ import KebabDropdown from "@/components/Menu/KebabDropdown";
 import KebabMenuButton from "@/components/Menu/KebabMenuButton";
 import { PATH } from "@/constants/paths";
 import useClickOutside from "@/hooks/useClickOutside";
-import { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import imageIcon from "@/assets/icons/image.svg";
 import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
@@ -30,7 +30,7 @@ import {
   toPostComments,
 } from "@/mappers/communityComment.mapper";
 import { useViewerId } from "@/store/auth";
-import { getPostDetail } from "@/api/post.api";
+import { deletePost, getPostDetail } from "@/api/post.api";
 import { toPostDetailVM } from "@/mappers/myPostDetail.mapper";
 
 export interface CommunityPostDetailProps {
@@ -81,6 +81,7 @@ export default function CommunityPostDetail() {
 
   // 케밥 메뉴
   const [showMenu, setShowMenu] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
   // 섹션 추적
@@ -91,6 +92,41 @@ export default function CommunityPostDetail() {
   const inflightPostRef = useRef(
     new Map<number, ReturnType<typeof getCommunityPostDetail>>()
   );
+
+  const location = useLocation();
+  const from = (location.state as any)?.from;
+
+  // 포스트 삭제
+  const handleDeletePost = useCallback(async () => {
+    if (!postId) return;
+    if (
+      !window.confirm(
+        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setDeleting(true);
+      await deletePost(Number(postId));
+      alert("문서가 영구 삭제되었습니다.");
+
+      if (from === "community") {
+        navigate(PATH.COMMUNITY, { replace: true });
+      } else {
+        navigate(-1);
+      }
+    } catch (err: any) {
+      console.error(err);
+      alert(
+        err?.response?.data?.message ??
+          "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setDeleting(false);
+      setShowMenu(false);
+    }
+  }, [postId, navigate, from]);
 
   // 공유 기능 (URL 복사 후 안내 메시지 띄우기)
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -510,18 +546,13 @@ export default function CommunityPostDetail() {
                           options={[
                             {
                               label: "포스트 수정",
-                              onClick: () => {
-                                setShowMenu(false);
-                              },
+                              onClick: () => setShowMenu(false),
                             },
                             {
-                              label: "삭제",
-                              onClick: () => {
-                                setShowMenu(false);
-                              },
+                              label: deleting ? "삭제 중..." : "삭제",
+                              onClick: () => !deleting && handleDeletePost(),
                             },
                           ]}
-                          position={{ top: "0.1rem", left: "1.5rem" }}
                         />
                       )}
                     </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -86,8 +86,18 @@ export default function CommunityPostDetail() {
   const [currentSection, setCurrentSection] = useState<number>(0);
   const sectionRefs = useRef<(HTMLElement | null)[]>([]);
 
-  // ===== 컨텍스트/판정 유틸 =====
+  // 이어서 작성 안내 경고창
+  const resumePromptShownRef = useRef<Record<number, boolean>>({});
+
+  // 컨텍스트/판정 유틸
   type FromSource = "home" | "community" | "search" | "mypage" | undefined;
+
+  type DetailContentItem = {
+    id?: number;
+    subTitle?: string | null;
+    body?: string | null;
+    sequence?: number;
+  };
 
   function useDetailContext() {
     const location = useLocation();
@@ -104,9 +114,6 @@ export default function CommunityPostDetail() {
 
     return { from, ownerId, viewerId: viewerIdInStore };
   }
-
-  const isDraftStatus = (s?: string) =>
-    s === "작성 중" || s === "DRAFT" || s === "WRITING";
 
   function shouldTryMyDetailFirst(params: {
     from?: FromSource;
@@ -132,6 +139,104 @@ export default function CommunityPostDetail() {
 
     // 기본은 커뮤니티 우선
     return false;
+  }
+
+  // 별점 enum/문자 → 숫자
+  const parseStar = (raw: unknown) => {
+    if (typeof raw === "number") return raw;
+    if (typeof raw !== "string") return 0;
+    const k = raw.toUpperCase();
+    const map: Record<string, number> = {
+      ONE_STAR: 1,
+      TWO_STARS: 2,
+      THREE_STARS: 3,
+      FOUR_STARS: 4,
+      FIVE_STARS: 5,
+      ONE: 1,
+      TWO: 2,
+      THREE: 3,
+      FOUR: 4,
+      FIVE: 5,
+      NONE: 0,
+    };
+    return map[k] ?? 0;
+  };
+
+  // 상세 응답 → FREEFORM 프리필 state
+  function buildFreeformPrefill(detail: any) {
+    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+      ? detail.contents
+      : [];
+
+    const blocks = contents
+      .slice()
+      .sort(
+        (a: DetailContentItem, b: DetailContentItem) =>
+          (a.sequence ?? 0) - (b.sequence ?? 0)
+      )
+      .map((c: DetailContentItem, i: number) => ({
+        id: c.id ?? i,
+        title: c.subTitle ?? "",
+        content: c.body ?? "",
+        isSaved: false,
+      }));
+
+    return {
+      editorType: "FREEFORM" as const,
+      title: detail?.title ?? "",
+      tags: detail?.postTags ?? [],
+      errorType: detail?.errorTag ?? null,
+      blocks,
+      savePrefill: {
+        importance: parseStar(detail?.starRating),
+        description: detail?.introduction ?? "",
+        visibility: detail?.isVisible ? "public" : "private",
+        projectId: detail?.projectId ?? null,
+        projectName: undefined,
+        thumbnail: detail?.thumbnailUrl ?? null,
+      },
+      projectId: detail?.projectId ?? undefined,
+    };
+  }
+
+  // 상세 응답 → TEMPLATE 프리필 state
+  function buildTemplatePrefill(detail: any) {
+    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+      ? detail.contents
+      : [];
+
+    const blocks = contents
+      .slice()
+      .sort(
+        (a: DetailContentItem, b: DetailContentItem) =>
+          (a.sequence ?? 0) - (b.sequence ?? 0)
+      )
+      .map((c: DetailContentItem, i: number) => ({
+        id: c.id ?? i,
+        content: c.body ?? "",
+        checklist: [],
+        checklistItems: [],
+        checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
+        question: c.subTitle ?? `질문 ${i + 1}`,
+        isSaved: false,
+      }));
+
+    return {
+      editorType: "TEMPLATE" as const,
+      title: detail?.title ?? "",
+      tags: detail?.postTags ?? [],
+      errorType: detail?.errorTag ?? null,
+      blocks,
+      savePrefill: {
+        importance: parseStar(detail?.starRating),
+        description: detail?.introduction ?? "",
+        visibility: detail?.isVisible ? "public" : "private",
+        projectId: detail?.projectId ?? null,
+        projectName: undefined,
+        thumbnail: detail?.thumbnailUrl ?? null,
+      },
+      projectId: detail?.projectId ?? undefined,
+    };
   }
 
   // 공유 토스트
@@ -215,7 +320,7 @@ export default function CommunityPostDetail() {
     }
   };
 
-  // ===== 상세 로드 =====
+  // 상세 로드
   const {
     from: fromCtx,
     ownerId,
@@ -255,23 +360,59 @@ export default function CommunityPostDetail() {
       void loadComments(numId, 1, currentViewerId ?? null);
     };
 
-    const loadMine = async () => {
-      const myDetail = await getPostDetail(numId);
+    const loadMine = async (id: number) => {
+      const myDetail = await getPostDetail(id);
+
+      // 화면용 VM 세팅
       const vmMine = toPostDetailVM(myDetail as any, currentViewerId);
       setPost(vmMine);
       setIsLiked(vmMine.isLiked);
       setLikeCounts(vmMine.likeCounts);
       setIsCommunitySource(false);
-      // 작성중/비공개면 댓글/좋아요 숨김 (렌더에서 가드됨)
-      if (
-        isDraftStatus(
-          (myDetail as any)?.postStatus ?? (vmMine as any)?.postStatus
-        )
-      ) {
-        // 필요시 에디터로 자동 이동하려면 아래 주석 해제
-        // const editorPath = (myDetail as any)?.templateType === "FREEFORM"
-        //   ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
-        // navigate(editorPath, { replace: true, state: { postId: numId, mode: "edit", from: "detail" }});
+
+      // 초안 여부 판단 (completedAt이 null)
+      const completedAt = (myDetail as any)?.completedAt ?? null;
+      const templateTypeRaw =
+        (myDetail as any)?.templateType ?? (vmMine as any)?.templateType;
+      const tt = String(templateTypeRaw ?? "").toUpperCase(); // "FREE_FORM" | "GUIDELINE" | "FREEFORM"
+      const isDraft = completedAt == null;
+
+      // 이 postId에 대해 안내창을 이미 띄웠다면 다시 띄우지 않음
+      if (isDraft && !resumePromptShownRef.current[id]) {
+        resumePromptShownRef.current[id] = true;
+
+        const ok = window.confirm(
+          tt === "FREE_FORM" || tt === "FREEFORM"
+            ? "이 문서는 자유형식 글 작성 중이에요. 이어서 작성할까요?"
+            : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?"
+        );
+
+        if (ok) {
+          const baseState =
+            tt === "FREE_FORM" || tt === "FREEFORM"
+              ? buildFreeformPrefill(myDetail)
+              : buildTemplatePrefill(myDetail);
+
+          const editorPath =
+            tt === "FREE_FORM" || tt === "FREEFORM"
+              ? PATH.FREEFORM_WRITING
+              : PATH.TEMP_WRITING;
+
+          navigate(editorPath, {
+            replace: true,
+            state: {
+              ...baseState,
+              // 이어쓰기 식별자 (에디터에서 이 값이 있으면 editPost 분기)
+              postId: id,
+              mode: "edit",
+              from: "community-detail",
+              projectId: (myDetail as any)?.projectId ?? undefined,
+              savePrefill: {
+                ...(baseState as any).savePrefill,
+              },
+            },
+          });
+        }
       }
     };
 
@@ -279,7 +420,7 @@ export default function CommunityPostDetail() {
       try {
         if (preferMyFirst) {
           try {
-            await loadMine();
+            await loadMine(numId);
           } catch {
             await loadCommunity();
           }
@@ -289,7 +430,7 @@ export default function CommunityPostDetail() {
           } catch (err: any) {
             const status = err?.response?.status ?? err?.status;
             if (status === 401 || status === 403 || status === 404) {
-              await loadMine();
+              await loadMine(numId);
             } else {
               throw err;
             }
@@ -311,6 +452,40 @@ export default function CommunityPostDetail() {
       cancelled = true;
     };
   }, [postId, currentViewerId, fromCtx, ownerId, preferMyFirst, navigate]);
+
+  // 수정 화면으로 이동(프리필 포함)
+  const goEditWithPrefill = useCallback(async () => {
+    const pid = Number(postId);
+    if (!Number.isFinite(pid)) return;
+
+    setShowMenu(false);
+
+    try {
+      const myDetail = await getPostDetail(pid);
+      const tt = String((myDetail as any)?.templateType ?? "").toUpperCase(); // FREE_FORM | GUIDELINE | FREEFORM
+
+      const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
+      const editorPath = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
+      const prefill = isFreeform
+        ? buildFreeformPrefill(myDetail)
+        : buildTemplatePrefill(myDetail);
+
+      navigate(editorPath, {
+        replace: true,
+        state: {
+          ...prefill,
+          postId: pid,
+          mode: "edit",
+          from: "community-detail",
+        },
+      });
+    } catch (err) {
+      console.error(err);
+      alert(
+        "수정 화면으로 이동하기 위한 상세 데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요."
+      );
+    }
+  }, [postId, navigate, setShowMenu]);
 
   // 작성자 프로필 클릭
   const handleProfileClick = () => {
@@ -577,18 +752,7 @@ export default function CommunityPostDetail() {
                             {
                               label: "포스트 수정",
                               onClick: () => {
-                                setShowMenu(false);
-                                const editorPath =
-                                  (post as any)?.templateType === "FREEFORM"
-                                    ? PATH.FREEFORM_WRITING
-                                    : PATH.TEMP_WRITING;
-                                navigate(editorPath, {
-                                  state: {
-                                    postId: Number(postId),
-                                    mode: "edit",
-                                    from: "community-detail",
-                                  },
-                                });
+                                void goEditWithPrefill();
                               },
                             },
                             {

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -744,9 +744,20 @@ export default function CommunityPostDetail() {
       </div>
 
       {/* 목차 */}
-      <div className="inline-flex items-start mt-[588px] mr-[89px] sticky top-[588px] h-fit">
+      <div
+        className="inline-flex items-start mt-[588px] mr-[89px]
+    sticky top-[588px] h-fit
+    w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px]
+    flex-shrink-0"
+      >
         {/* 목차 리스트 */}
-        <div className="flex flex-col items-start gap-[16px] border-l border-gray3 p-[12px] text-body-20-regular text-gray3">
+        <div
+          className=" flex flex-col items-start gap-[16px]
+      border-l border-gray3
+      pl-[12px] pr-[8px]  
+      text-body-20-regular text-gray3
+      w-full"
+        >
           {post.questions.map((q, idx) => (
             <button
               key={idx}

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -39,7 +39,7 @@ export interface CommunityPostDetailProps {
   tags: string[];
   date: string;
   isMine: boolean;
-  authorId: number;
+  authorId?: number;
   authorProfile?: string;
   authorName: string;
   authorFollowers: number;
@@ -54,10 +54,8 @@ export interface CommunityPostDetailProps {
 }
 
 export default function CommunityPostDetail() {
-  const { postId } = useParams<{ postId: string }>(); // postId 불러오기
+  const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
-  // 중앙 상태의 로그인 사용자 ID
-  const viewerId = useViewerId();
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
   const [loading, setLoading] = useState(true);
@@ -88,47 +86,55 @@ export default function CommunityPostDetail() {
   const [currentSection, setCurrentSection] = useState<number>(0);
   const sectionRefs = useRef<(HTMLElement | null)[]>([]);
 
-  // 진행 중 요청 캐시(StrictMode 중복호출 디듀프)
-  const inflightPostRef = useRef(
-    new Map<number, ReturnType<typeof getCommunityPostDetail>>()
-  );
+  // ===== 컨텍스트/판정 유틸 =====
+  type FromSource = "home" | "community" | "search" | "mypage" | undefined;
 
-  const location = useLocation();
-  const from = (location.state as any)?.from;
+  function useDetailContext() {
+    const location = useLocation();
+    const viewerIdInStore = useViewerId();
 
-  // 포스트 삭제
-  const handleDeletePost = useCallback(async () => {
-    if (!postId) return;
-    if (
-      !window.confirm(
-        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
-      )
-    )
-      return;
+    const stateFrom = (location.state as any)?.from as FromSource | undefined;
+    const stateOwnerId = (location.state as any)?.ownerId as number | undefined;
 
-    try {
-      setDeleting(true);
-      await deletePost(Number(postId));
-      alert("문서가 영구 삭제되었습니다.");
+    const qs = new URLSearchParams(location.search);
+    const qsFrom = (qs.get("from") as FromSource) || undefined;
+    const qsOwnerId = qs.get("ownerId");
+    const ownerId = stateOwnerId ?? (qsOwnerId ? Number(qsOwnerId) : undefined);
+    const from = stateFrom ?? qsFrom;
 
-      if (from === "community") {
-        navigate(PATH.COMMUNITY, { replace: true });
-      } else {
-        navigate(-1);
-      }
-    } catch (err: any) {
-      console.error(err);
-      alert(
-        err?.response?.data?.message ??
-          "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
-      );
-    } finally {
-      setDeleting(false);
-      setShowMenu(false);
-    }
-  }, [postId, navigate, from]);
+    return { from, ownerId, viewerId: viewerIdInStore };
+  }
 
-  // 공유 기능 (URL 복사 후 안내 메시지 띄우기)
+  const isDraftStatus = (s?: string) =>
+    s === "작성 중" || s === "DRAFT" || s === "WRITING";
+
+  function shouldTryMyDetailFirst(params: {
+    from?: FromSource;
+    ownerId?: number;
+    viewerId?: number | null;
+  }) {
+    const { from, ownerId, viewerId } = params;
+    const isMine =
+      viewerId != null &&
+      ownerId != null &&
+      String(ownerId) === String(viewerId);
+
+    // 포스트 상세를 먼저 시도해야 하는 경우
+    if (from === "home") return true;
+    if (from === "mypage" && isMine) return true;
+    if (from === "search" && isMine) return true;
+    if (from === "community" && isMine) return true;
+
+    // 커뮤니티 상세를 먼저 시도해야 하는 경우
+    if (from === "community" && !isMine) return false;
+    if (from === "search" && !isMine) return false;
+    if (from === "mypage" && !isMine) return false;
+
+    // 기본은 커뮤니티 우선
+    return false;
+  }
+
+  // 공유 토스트
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
     message: "",
@@ -136,12 +142,10 @@ export default function CommunityPostDetail() {
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const copyToClipboard = async (text: string) => {
-    // https(또는 localhost)에서 우선 시도
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
       return true;
     }
-    // 폴백 (일부 iOS/구형 브라우저)
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.position = "fixed";
@@ -150,8 +154,7 @@ export default function CommunityPostDetail() {
     ta.focus();
     ta.select();
     try {
-      const ok = document.execCommand("copy");
-      return ok;
+      return document.execCommand("copy");
     } finally {
       document.body.removeChild(ta);
     }
@@ -185,24 +188,16 @@ export default function CommunityPostDetail() {
     }
   };
 
-  const fetchPostOnce = (id: number) => {
-    const map = inflightPostRef.current;
-    if (!map.has(id)) {
-      const p = getCommunityPostDetail(id).finally(() => {
-        // 같은 tick 끝나고 캐시 비우기 (메모리 누수 방지 & 후속 요청 허용)
-        setTimeout(() => map.delete(id), 0);
-      });
-      map.set(id, p);
-    }
-    return map.get(id)!;
-  };
-
   // 댓글 로더
-  const loadComments = async (id: number, page1: number) => {
+  const loadComments = async (
+    id: number,
+    page1: number,
+    currentViewerId: number | null
+  ) => {
     setCLoading(true);
     try {
       const resp = await getCommunityComments(id, page1, 10);
-      const mapped = toPostComments(resp.content, viewerId);
+      const mapped = toPostComments(resp.content, currentViewerId);
 
       setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
 
@@ -220,76 +215,299 @@ export default function CommunityPostDetail() {
     }
   };
 
-  // 포스트 + 댓글 1페이지 로드 (StrictMode 안전)
+  // ===== 상세 로드 =====
+  const {
+    from: fromCtx,
+    ownerId,
+    viewerId: currentViewerId,
+  } = useDetailContext();
+  const preferMyFirst = shouldTryMyDetailFirst({
+    from: fromCtx,
+    ownerId,
+    viewerId: currentViewerId,
+  });
+  const [isCommunitySource, setIsCommunitySource] = useState(true); // 좋아요/댓글 표시 가드
+
   useEffect(() => {
     let cancelled = false;
 
-    // 새 포스트 들어올 때 댓글 상태 초기화
     setComments([]);
     setCPage(1);
     setCHasNext(false);
+    setLoading(true);
+    setLoadError(null);
+
+    const numId = Number(postId);
+    if (!Number.isFinite(numId)) {
+      setLoadError("잘못된 포스트 ID");
+      setLoading(false);
+      return;
+    }
+
+    const loadCommunity = async () => {
+      const communityData = await getCommunityPostDetail(numId);
+      if (!communityData) throw new Error("빈 응답입니다."); // 널 가드
+      const vm = toCommunityPostVM(communityData, currentViewerId);
+      setPost(vm);
+      setIsLiked(vm.isLiked);
+      setLikeCounts(vm.likeCounts);
+      setIsCommunitySource(true);
+      void loadComments(numId, 1, currentViewerId ?? null);
+    };
+
+    const loadMine = async () => {
+      const myDetail = await getPostDetail(numId);
+      const vmMine = toPostDetailVM(myDetail as any, currentViewerId);
+      setPost(vmMine);
+      setIsLiked(vmMine.isLiked);
+      setLikeCounts(vmMine.likeCounts);
+      setIsCommunitySource(false);
+      // 작성중/비공개면 댓글/좋아요 숨김 (렌더에서 가드됨)
+      if (
+        isDraftStatus(
+          (myDetail as any)?.postStatus ?? (vmMine as any)?.postStatus
+        )
+      ) {
+        // 필요시 에디터로 자동 이동하려면 아래 주석 해제
+        // const editorPath = (myDetail as any)?.templateType === "FREEFORM"
+        //   ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
+        // navigate(editorPath, { replace: true, state: { postId: numId, mode: "edit", from: "detail" }});
+      }
+    };
 
     (async () => {
-      const idStr = postId ?? "";
-      const numId = Number(idStr);
-      if (!Number.isFinite(numId)) {
-        setLoadError("잘못된 포스트 ID");
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
       try {
-        // community 상세로 작성자 ID 확인
-        const communityData = await fetchPostOnce(numId);
-        if (cancelled) return;
-
-        if (!communityData) {
-          setLoadError("빈 응답입니다.");
-          return;
-        }
-
-        const authorIdFromCommunity =
-          communityData?.userInfoResDto?.userId ?? null;
-        const isMineNow =
-          authorIdFromCommunity != null &&
-          viewerId != null &&
-          String(authorIdFromCommunity) === String(viewerId);
-
-        if (isMineNow) {
+        if (preferMyFirst) {
           try {
-            const resp = await getPostDetail(numId);
-            const vm = toPostDetailVM(resp as any, viewerId);
-            setPost(vm);
-            setIsLiked(vm.isLiked);
-            setLikeCounts(vm.likeCounts);
-            void loadComments(numId, 1);
+            await loadMine();
           } catch {
-            // post.api 실패 시 기존 커뮤니티 응답으로 폴백
-            const vm = toCommunityPostVM(communityData, viewerId);
-            setPost(vm);
-            setIsLiked(vm.isLiked);
-            setLikeCounts(vm.likeCounts);
-            void loadComments(numId, 1);
+            await loadCommunity();
           }
         } else {
-          const vm = toCommunityPostVM(communityData, viewerId);
-          setPost(vm);
-          setIsLiked(vm.isLiked);
-          setLikeCounts(vm.likeCounts);
-          void loadComments(numId, 1);
+          try {
+            await loadCommunity();
+          } catch (err: any) {
+            const status = err?.response?.status ?? err?.status;
+            if (status === 401 || status === 403 || status === 404) {
+              await loadMine();
+            } else {
+              throw err;
+            }
+          }
         }
       } catch (err: any) {
-        if (!cancelled) setLoadError(err?.message ?? "포스트 불러오기 실패");
+        if (!cancelled)
+          setLoadError(
+            err?.response?.data?.message ??
+              err?.message ??
+              "포스트 불러오기 실패"
+          );
       } finally {
-        if (!cancelled) setLoading(false); // 반드시 한 번은 내려가도록
+        if (!cancelled) setLoading(false);
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [postId, viewerId]);
+  }, [postId, currentViewerId, fromCtx, ownerId, preferMyFirst, navigate]);
+
+  // 작성자 프로필 클릭
+  const handleProfileClick = () => {
+    if (!post) return;
+    navigate(PATH.MYPAGE(String(post.authorId) || ""));
+  };
+
+  // 좋아요 토글(커뮤니티 글에서만)
+  const handleToggleLike = async () => {
+    if (!postId) return;
+    if (!isCommunitySource) {
+      alert("작성 중/비공개 문서는 좋아요를 사용할 수 없어요.");
+      return;
+    }
+    if (likeLockRef.current) return;
+    likeLockRef.current = true;
+    setIsLiking(true);
+
+    const pid = Number(postId);
+    const wasLiked = isLiked;
+    const prevCount = likeCounts;
+
+    if (wasLiked) {
+      setIsLiked(false);
+      setLikeCounts(Math.max(0, prevCount - 1));
+      try {
+        await likeCommunityPost(pid);
+      } catch {
+        setIsLiked(true);
+        setLikeCounts(prevCount);
+      } finally {
+        likeLockRef.current = false;
+        setIsLiking(false);
+      }
+    } else {
+      setIsLiked(true);
+      setLikeCounts(prevCount + 1);
+      try {
+        const res = await likeCommunityPost(pid);
+        setLikeCounts(res?.likeCount ?? prevCount + 1);
+      } catch (err: any) {
+        const status = err?.response?.status ?? err?.status;
+        if (status === 409) {
+          setIsLiked(true);
+          setLikeCounts(prevCount);
+        } else {
+          setIsLiked(false);
+          setLikeCounts(prevCount);
+        }
+      } finally {
+        likeLockRef.current = false;
+        setIsLiking(false);
+      }
+    }
+  };
+
+  // 댓글 제출(커뮤니티 글에서만)
+  const handleSubmitComment = async () => {
+    if (!postId || !isCommunitySource) return;
+    const contents = commentInput.trim();
+    if (!contents || isCommentPosting) return;
+
+    setIsCommentPosting(true);
+
+    const optimistic = makeOptimisticComment({ contents });
+    setComments((prev) => [optimistic, ...prev]);
+    setPost((p) =>
+      p ? { ...p, commentCounts: (p.commentCounts ?? 0) + 1 } : p
+    );
+    setCommentInput("");
+
+    try {
+      const created = await createCommunityComment(Number(postId), {
+        contents,
+      });
+      const mapped = toPostComment(created, currentViewerId, {
+        isReply: false,
+      });
+      setComments((prev) => {
+        const i = prev.findIndex((c) => c.id === optimistic.id);
+        if (i === -1) return [mapped, ...prev];
+        const next = [...prev];
+        next[i] = mapped;
+        return next;
+      });
+    } catch {
+      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+      setPost((p) =>
+        p ? { ...p, commentCounts: Math.max(0, (p.commentCounts ?? 1) - 1) } : p
+      );
+      setCommentInput(contents);
+    } finally {
+      setIsCommentPosting(false);
+    }
+  };
+
+  // 대댓글 제출
+  const handleReply = async (parentId: string, replyContent: string) => {
+    if (!postId || !isCommunitySource) return;
+    const contents = replyContent.trim();
+    if (!contents) return;
+
+    const optimistic = makeOptimisticComment({ contents, parentId });
+    setComments((prev) => [...prev, optimistic]);
+
+    try {
+      const created = await replyCommunityComment(
+        Number(postId),
+        Number(parentId),
+        { contents }
+      );
+      const mapped = toPostComment(created, currentViewerId, {
+        isReply: true,
+        parentId,
+      });
+      setComments((prev) => {
+        const i = prev.findIndex((c) => c.id === optimistic.id);
+        if (i === -1) return [...prev, mapped];
+        const next = [...prev];
+        next[i] = mapped;
+        return next;
+      });
+    } catch {
+      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+      console.error("대댓글 작성 실패");
+    }
+  };
+
+  // 댓글 내용 수정
+  const handleEdit = async (id: string, newContent: string) => {
+    if (!postId || !isCommunitySource) return;
+    const pid = Number(postId);
+    const cid = Number(id);
+    try {
+      const updated = await updateCommunityComment({
+        postId: pid,
+        commentId: cid,
+        contents: newContent,
+      });
+      const vm = toPostComment(updated, currentViewerId);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, content: vm.content, date: vm.date } : c
+        )
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  // 댓글 삭제 (soft)
+  const handleDelete = async (id: string) => {
+    if (!isCommunitySource) return;
+    try {
+      await softDeleteCommunityComment(Number(id));
+      setComments((prev) => prev.filter((c) => c.id !== id));
+      setPost((prev) =>
+        prev
+          ? { ...prev, commentCounts: Math.max(0, prev.commentCounts - 1) }
+          : prev
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  // 포스트 삭제
+  const handleDeletePost = useCallback(async () => {
+    if (!postId) return;
+    if (
+      !window.confirm(
+        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setDeleting(true);
+      await deletePost(Number(postId));
+      alert("문서가 영구 삭제되었습니다.");
+
+      if (fromCtx === "community") {
+        navigate(PATH.COMMUNITY, { replace: true });
+      } else {
+        navigate(-1);
+      }
+    } catch (err: any) {
+      console.error(err);
+      alert(
+        err?.response?.data?.message ??
+          "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setDeleting(false);
+      setShowMenu(false);
+    }
+  }, [postId, navigate, fromCtx]);
 
   // 스크롤 감시
   useEffect(() => {
@@ -315,194 +533,6 @@ export default function CommunityPostDetail() {
     }
   };
 
-  // 작성자 프로필 클릭 핸들러
-  const handleProfileClick = () => {
-    // 작성자 마이페이지로
-    if (!post) return;
-    // post 객체에 작성자 userId가 있다면 사용, 없으면 API 응답 구조 확인 필요
-    navigate(PATH.MYPAGE(String(post.authorId) || ""));
-  };
-
-  // 포스트 좋아요 토글
-  const handleToggleLike = async () => {
-    if (!postId) return;
-    if (likeLockRef.current) return;
-    likeLockRef.current = true;
-    setIsLiking(true);
-
-    const pid = Number(postId);
-    const wasLiked = isLiked;
-    const prevCount = likeCounts;
-
-    if (wasLiked) {
-      // 낙관적 감소
-      setIsLiked(false);
-      setLikeCounts(Math.max(0, prevCount - 1));
-
-      try {
-        await likeCommunityPost(pid);
-        // 성공 시 그대로 둔다
-      } catch {
-        // 실패 시 롤백
-        setIsLiked(true);
-        setLikeCounts(prevCount);
-      } finally {
-        likeLockRef.current = false;
-        setIsLiking(false);
-      }
-    } else {
-      // 낙관적 증가
-      setIsLiked(true);
-      setLikeCounts(prevCount + 1);
-
-      try {
-        const res = await likeCommunityPost(pid);
-        // 서버 카운트로 보정(응답에 likeCount 포함)
-        setLikeCounts(res?.likeCount ?? prevCount + 1);
-      } catch (err: any) {
-        const status = err?.response?.status ?? err?.status;
-        if (status === 409) {
-          // 이미 좋아요 상태인 경우 -> isLiked는 true 유지, 카운트는 원래 값으로 되돌림
-          setIsLiked(true);
-          setLikeCounts(prevCount);
-        } else {
-          // 기타 에러 → 완전 롤백
-          setIsLiked(false);
-          setLikeCounts(prevCount);
-        }
-      } finally {
-        likeLockRef.current = false;
-        setIsLiking(false);
-      }
-    }
-  };
-
-  // 댓글 제출
-  const handleSubmitComment = async () => {
-    if (!postId) return;
-    const contents = commentInput.trim();
-    if (!contents || isCommentPosting) return;
-
-    setIsCommentPosting(true);
-
-    // 낙관적 추가
-    const optimistic = makeOptimisticComment({ contents });
-    setComments((prev) => [optimistic, ...prev]);
-    setPost((p) =>
-      p ? { ...p, commentCounts: (p.commentCounts ?? 0) + 1 } : p
-    );
-    setCommentInput("");
-
-    try {
-      const created = await createCommunityComment(Number(postId), {
-        contents,
-      });
-      const mapped = toPostComment(created, viewerId, { isReply: false });
-      setComments((prev) => {
-        const i = prev.findIndex((c) => c.id === optimistic.id);
-        if (i === -1) return [mapped, ...prev];
-        const next = [...prev];
-        next[i] = mapped;
-        return next;
-      });
-    } catch {
-      // 실패 → 롤백
-      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setPost((p) =>
-        p ? { ...p, commentCounts: Math.max(0, (p.commentCounts ?? 1) - 1) } : p
-      );
-      setCommentInput(contents);
-    } finally {
-      setIsCommentPosting(false);
-    }
-  };
-
-  // 대댓글 제출 (부모 id, 내용)
-  const handleReply = async (parentId: string, replyContent: string) => {
-    if (!postId) return;
-    const contents = replyContent.trim();
-    if (!contents) return;
-
-    // 낙관적 추가
-    const optimistic = makeOptimisticComment({ contents, parentId });
-    setComments((prev) => [...prev, optimistic]);
-
-    try {
-      const created = await replyCommunityComment(
-        Number(postId),
-        Number(parentId),
-        { contents }
-      );
-
-      // 백엔드에서 parentCommentId가 null로 올 수 있으므로 강제 보정
-      const mapped = toPostComment(created, viewerId, {
-        isReply: true,
-        parentId,
-      });
-      setComments((prev) => {
-        const i = prev.findIndex((c) => c.id === optimistic.id);
-        if (i === -1) return [...prev, mapped];
-        const next = [...prev];
-        next[i] = mapped;
-        return next;
-      });
-    } catch {
-      // 실패 → 롤백
-      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      // 에러 메시지를 표시하거나 로깅
-      console.error("대댓글 작성 실패");
-    }
-  };
-
-  // 댓글 내용 수정
-  const handleEdit = async (id: string, newContent: string) => {
-    if (!postId) return;
-    const pid = Number(postId);
-    const cid = Number(id);
-    try {
-      // 서버 수정
-      const updated = await updateCommunityComment({
-        postId: pid,
-        commentId: cid,
-        contents: newContent,
-      });
-
-      const vm = toPostComment(updated, viewerId);
-
-      // 목록 반영 (id 일치하는 아이템 교체)
-      setComments((prev) =>
-        prev.map((c) =>
-          c.id === id
-            ? {
-                ...c,
-                content: vm.content,
-                date: vm.date,
-              }
-            : c
-        )
-      );
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  // 댓글 삭제 (soft)
-  const handleDelete = async (id: string) => {
-    try {
-      await softDeleteCommunityComment(Number(id));
-      // 목록에서 제거 (부모/대댓글 동일)
-      setComments((prev) => prev.filter((c) => c.id !== id));
-      // 카운트 갱신
-      setPost((prev) =>
-        prev
-          ? { ...prev, commentCounts: Math.max(0, prev.commentCounts - 1) }
-          : prev
-      );
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
   // 로딩/에러 처리
   if (loading) {
     return (
@@ -517,7 +547,7 @@ export default function CommunityPostDetail() {
   if (loadError || !post) {
     return (
       <div className="flex justify-center">
-        <div className="max-w-[1200px] w-full pt-[180px] text-red-600">
+        <div className="max-w=[1200px] w-full pt-[180px] text-red-600">
           {loadError ?? "포스트를 찾을 수 없습니다."}
         </div>
       </div>
@@ -546,7 +576,20 @@ export default function CommunityPostDetail() {
                           options={[
                             {
                               label: "포스트 수정",
-                              onClick: () => setShowMenu(false),
+                              onClick: () => {
+                                setShowMenu(false);
+                                const editorPath =
+                                  (post as any)?.templateType === "FREEFORM"
+                                    ? PATH.FREEFORM_WRITING
+                                    : PATH.TEMP_WRITING;
+                                navigate(editorPath, {
+                                  state: {
+                                    postId: Number(postId),
+                                    mode: "edit",
+                                    from: "community-detail",
+                                  },
+                                });
+                              },
                             },
                             {
                               label: deleting ? "삭제 중..." : "삭제",
@@ -565,13 +608,8 @@ export default function CommunityPostDetail() {
 
               {/* 태그 & 작성일 */}
               <div className="flex items-center gap-[16px]">
-                {/* 태그 */}
                 <TagList tags={post.tags} variant="post" />
-
-                {/* 구분점 */}
                 <div className="text-body-16-regular text-gray3">·</div>
-
-                {/* 작성일 */}
                 <div className="text-body-20-regular text-gray3">
                   {post.date}
                 </div>
@@ -580,9 +618,7 @@ export default function CommunityPostDetail() {
 
             {/* 작성자 정보 & 중요도 */}
             <div className="flex w-full items-center justify-between">
-              {/* 작성자 정보 */}
               <div className="flex items-center gap-[20px]">
-                {/* 프로필 이미지 */}
                 <img
                   src={post.authorProfile || imageIcon}
                   onError={(e) => {
@@ -591,12 +627,9 @@ export default function CommunityPostDetail() {
                   alt="profile"
                   className="w-[66px] h-[66px]"
                 />
-
-                {/* 작성자명 */}
                 <div className="text-head-24-bold">{post.authorName}</div>
               </div>
 
-              {/* 중요도 */}
               {post.isMine && post.importance !== 0 && (
                 <div className="flex items-center gap-[8px]">
                   <img
@@ -643,7 +676,6 @@ export default function CommunityPostDetail() {
                       className="flex items-center gap-[28px] cursor-pointer"
                       onClick={handleProfileClick}
                     >
-                      {/* 프로필 이미지 */}
                       <img
                         src={post.authorProfile || imageIcon}
                         onError={(e) => {
@@ -653,7 +685,6 @@ export default function CommunityPostDetail() {
                         className="w-[131px] h-[131px]"
                       />
                       <div className="flex flex-col items-start gap-[13px]">
-                        {/* 작성자명 & 팔로워 수 */}
                         <div className="flex flex-col items-start gap-[2px]">
                           <div className="text-head-24-bold">
                             {post.authorName}
@@ -662,15 +693,12 @@ export default function CommunityPostDetail() {
                             {post.authorFollowers} 팔로워
                           </div>
                         </div>
-
-                        {/* 한줄 소개 */}
                         <div className="text-body-18-regular">
                           {post.authorBio}
                         </div>
                       </div>
                     </div>
 
-                    {/* 팔로우 버튼 */}
                     {!post.isMine && (
                       <button className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white cursor-pointer">
                         팔로우
@@ -681,140 +709,142 @@ export default function CommunityPostDetail() {
               </div>
             </div>
 
-            {/* 좋아요, 공유 */}
-            <div className="flex pt-[52px] pb-[20px] items-center self-stretch border-b border-gray1">
-              <div className="flex items-center gap-[20px]">
-                {/* 좋아요 */}
+            {/* 좋아요, 공유 (커뮤니티 글에서만 노출) */}
+            {isCommunitySource && (
+              <div className="flex pt-[52px] pb-[20px] items-center self-stretch border-b border-gray1">
+                <div className="flex items-center gap-[20px]">
+                  <button
+                    type="button"
+                    aria-pressed={isLiked}
+                    aria-busy={isLiking}
+                    disabled={isLiking}
+                    onClick={handleToggleLike}
+                    className={`flex items-center gap-[8px] ${
+                      isLiking
+                        ? "opacity-60 cursor-not-allowed"
+                        : "cursor-pointer"
+                    }`}
+                  >
+                    <img
+                      src={isLiked ? heartIcon : likeEmptyIcon}
+                      alt="like"
+                      className="w-[40px] h-[40px]"
+                    />
+                    <div className="text-body-20-regular text-gray3">
+                      {likeCounts}
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleCopyLink}
+                    className="cursor-pointer"
+                    aria-label="현재 페이지 링크 복사"
+                  >
+                    <img
+                      src={shareIcon}
+                      alt="share"
+                      className="w-[40px] h-[40px]"
+                    />
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* 댓글 작성 창 (커뮤니티 글에서만) */}
+            {isCommunitySource && (
+              <div className="flex flex-col items-end gap-[12px] self-stretch">
+                <div className="flex flex-col items-start gap-[36px] self-stretch">
+                  <div className="text-head-32-semibold">
+                    {post.commentCounts}개의 댓글
+                  </div>
+                  <textarea
+                    value={commentInput}
+                    onChange={(e) => setCommentInput(e.target.value)}
+                    placeholder="댓글을 작성해주세요."
+                    className="flex pt-[28px] pl-[32px] pb-[130px] w-full items-start self-stretch resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
+                  ></textarea>
+                </div>
+
                 <button
-                  type="button"
-                  aria-pressed={isLiked}
-                  aria-busy={isLiking}
-                  disabled={isLiking}
-                  onClick={handleToggleLike}
-                  className={`flex items-center gap-[8px] ${
-                    isLiking
-                      ? "opacity-60 cursor-not-allowed"
-                      : "cursor-pointer"
+                  disabled={!commentInput.trim() || isCommentPosting}
+                  onClick={handleSubmitComment}
+                  className={`flex pt-[8px] pl-[32px] pb-[12px] pr-[31px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
+                    commentInput.trim() && !isCommentPosting
+                      ? "bg-primary"
+                      : "bg-subColor1"
                   }`}
                 >
-                  <img
-                    src={isLiked ? heartIcon : likeEmptyIcon}
-                    alt="like"
-                    className="w-[40px] h-[40px]"
-                  />
-                  <div className="text-body-20-regular text-gray3">
-                    {likeCounts}
-                  </div>
-                </button>
-
-                {/* 공유 버튼 */}
-                <button
-                  type="button"
-                  onClick={handleCopyLink}
-                  className="cursor-pointer"
-                  aria-label="현재 페이지 링크 복사"
-                >
-                  <img
-                    src={shareIcon}
-                    alt="share"
-                    className="w-[40px] h-[40px]"
-                  />
+                  {isCommentPosting ? "작성 중…" : "작성하기"}
                 </button>
               </div>
-            </div>
-
-            {/* 댓글 작성 창 */}
-            <div className="flex flex-col items-end gap-[12px] self-stretch">
-              <div className="flex flex-col items-start gap-[36px] self-stretch">
-                <div className="text-head-32-semibold">
-                  {post.commentCounts}개의 댓글
-                </div>
-                <textarea
-                  value={commentInput}
-                  onChange={(e) => setCommentInput(e.target.value)}
-                  placeholder="댓글을 작성해주세요."
-                  className="flex pt-[28px] pl-[32px] pb-[130px] w-full items-start self-stretch resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
-                ></textarea>
-              </div>
-
-              {/* 작성하기 버튼 */}
-              <button
-                disabled={!commentInput.trim() || isCommentPosting}
-                onClick={handleSubmitComment}
-                className={`flex pt-[8px] pl-[32px] pb-[12px] pr-[31px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
-                  commentInput.trim() && !isCommentPosting
-                    ? "bg-primary"
-                    : "bg-subColor1"
-                }`}
-              >
-                {isCommentPosting ? "작성 중…" : "작성하기"}
-              </button>
-            </div>
-          </div>
-
-          {/* 댓글 목록 */}
-          <div className="flex flex-col items-end self-stretch">
-            {comments
-              .filter((c) => !c.isReply) // 부모 댓글만
-              .map((parent) => (
-                <div key={parent.id} className="w-full">
-                  <PostComment
-                    {...parent}
-                    onEdit={(newContent) => handleEdit(parent.id, newContent)}
-                    onDelete={() => handleDelete(parent.id)}
-                    onReply={(replyContent) =>
-                      handleReply(parent.id, replyContent)
-                    }
-                  />
-                  {/* 답글 목록 */}
-                  {comments
-                    .filter((c) => c.parentId === parent.id)
-                    .map((reply) => (
-                      <PostComment
-                        key={reply.id}
-                        {...reply}
-                        onEdit={(newContent) =>
-                          handleEdit(reply.id, newContent)
-                        }
-                        onDelete={() => handleDelete(reply.id)}
-                        onReply={(replyContent) =>
-                          handleReply(reply.id, replyContent)
-                        }
-                      />
-                    ))}
-                </div>
-              ))}
-
-            {/* 댓글 더 보기 */}
-            {cHasNext && postId && (
-              <button
-                disabled={cLoading}
-                onClick={() => loadComments(Number(postId), cPage)}
-                className={`mt-4 px-6 py-2 rounded-full text-white ${
-                  cLoading ? "bg-gray-300" : "bg-primary"
-                }`}
-              >
-                {cLoading ? "불러오는 중…" : "댓글 더 보기"}
-              </button>
             )}
           </div>
+
+          {/* 댓글 목록 (커뮤니티 글에서만) */}
+          {isCommunitySource && (
+            <div className="flex flex-col items-end self-stretch">
+              {comments
+                .filter((c) => !c.isReply)
+                .map((parent) => (
+                  <div key={parent.id} className="w-full">
+                    <PostComment
+                      {...parent}
+                      onEdit={(newContent) => handleEdit(parent.id, newContent)}
+                      onDelete={() => handleDelete(parent.id)}
+                      onReply={(replyContent) =>
+                        handleReply(parent.id, replyContent)
+                      }
+                    />
+                    {comments
+                      .filter((c) => c.parentId === parent.id)
+                      .map((reply) => (
+                        <PostComment
+                          key={reply.id}
+                          {...reply}
+                          onEdit={(newContent) =>
+                            handleEdit(reply.id, newContent)
+                          }
+                          onDelete={() => handleDelete(reply.id)}
+                          onReply={(replyContent) =>
+                            handleReply(reply.id, replyContent)
+                          }
+                        />
+                      ))}
+                  </div>
+                ))}
+
+              {cHasNext && postId && (
+                <button
+                  disabled={cLoading}
+                  onClick={() =>
+                    loadComments(Number(postId), cPage, currentViewerId ?? null)
+                  }
+                  className={`mt-4 px-6 py-2 rounded-full text-white ${
+                    cLoading ? "bg-gray-300" : "bg-primary"
+                  }`}
+                >
+                  {cLoading ? "불러오는 중…" : "댓글 더 보기"}
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
       {/* 목차 */}
       <div
         className="inline-flex items-start mt-[588px] mr-[89px]
-    sticky top-[588px] h-fit
-    w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px]
-    flex-shrink-0"
+        sticky top-[588px] h-fit
+        w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px]
+        flex-shrink-0"
       >
-        {/* 목차 리스트 */}
         <div
           className=" flex flex-col items-start gap-[16px]
-      border-l border-gray3
-      pl-[12px] pr-[8px]  
-      text-body-20-regular text-gray3
-      w-full"
+          border-l border-gray3
+          pl-[12px] pr-[8px]  
+          text-body-20-regular text-gray3
+          w-full"
         >
           {post.questions.map((q, idx) => (
             <button

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import HeaderWoSearch from "@/components/Header/HeaderWoSearch";
 import DropDownButton from "@/components/Button/DropDownButton";
 import CategoryTag from "@/components/TemplateWrite/CategoryTag";
@@ -18,6 +18,7 @@ import {
   startSummary,
   getSummaryStatus,
   cancelSummary,
+  editPost,
 } from "@/api/post.api";
 
 export type BlockData = {
@@ -42,6 +43,10 @@ type IncomingFreeformState = {
     thumbnail?: string | null;
   };
   projectId?: number;
+
+  // 수정 식별용
+  postId?: number;
+  mode?: "edit" | "create";
 };
 
 const errorOptions = [
@@ -56,6 +61,21 @@ const errorOptions = [
   "Timeout/Error Handling",
   "Third-Party Library Error",
 ];
+
+const ERROR_CODE_TO_LABEL: Record<string, string> = {
+  BUILD_COMPILE_ERROR: "Build/Compile Error",
+  RUNTIME_ERROR: "Runtime Error",
+  DEPENDENCY_VERSION_ERROR: "Dependency/Version Error",
+  NETWORK_API_ERROR: "Network/API Error",
+  AUTHENTICATION_AUTHORIZATION_ERROR: "Authentication/Authorization Error",
+  DATABASE_ERROR: "Database Error",
+  UI_RENDERING_ERROR: "UI/Rendering Error",
+  CONFIGURATION_ERROR: "Configuration Error",
+  TIMEOUT_ERROR_HANDLING: "Timeout/Error Handling",
+  THIRD_PARTY_LIBRARY_ERROR: "Third-Party Library Error",
+};
+const toErrorLabel = (code?: string | null) =>
+  code ? ERROR_CODE_TO_LABEL[code] ?? code : null;
 
 export default function FreeFormWritePage() {
   const [title, setTitle] = useState("");
@@ -103,6 +123,15 @@ export default function FreeFormWritePage() {
   const initialProjectId = location.state?.projectId;
   const { data: projectList, loading: projectsLoading } = useProjectList();
 
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+
+  // 수정여부 판단
+  const resumePostId = useMemo(() => {
+    const pid = location.state?.postId;
+    return typeof pid === "number" && Number.isFinite(pid) ? pid : null;
+  }, [location.state]);
+  const isResume = resumePostId != null;
+
   // 프리필 반영
   useEffect(() => {
     if (
@@ -111,10 +140,18 @@ export default function FreeFormWritePage() {
     ) {
       setTitle(location.state.title ?? "");
       setSelectedTags(location.state.tags ?? []);
-      setSelectedErrorType(location.state.errorType ?? null);
+      setSelectedErrorType(toErrorLabel(location.state.errorType) ?? null);
       setBlocks(location.state.blocks);
+
+      // 프리필 후 최상단으로 포커스
+      setTimeout(() => titleInputRef.current?.focus(), 0);
     }
   }, [location.state]);
+
+  // 초기 진입 시에도 한 번 보장
+  useEffect(() => {
+    setTimeout(() => titleInputRef.current?.focus(), 0);
+  }, []);
 
   const toContentDtoList = (items: BlockData[]): PostContentDto[] =>
     items
@@ -146,7 +183,7 @@ export default function FreeFormWritePage() {
   };
 
   const buildCreateForm = (
-    postStatus: "COMPLETED" | "DRAFT",
+    postStatus: "COMPLETED" | "WRITING",
     meta: PostSavePayload | null = previewMeta
   ): PostForm => ({
     title,
@@ -156,12 +193,15 @@ export default function FreeFormWritePage() {
     isSummaryCreated: false,
     postStatus,
     starRating: String(meta?.importance ?? 0),
+    templateType:
+      location.state?.editorType === "FREEFORM" ? "FREE_FORM" : "GUIDELINE",
     thumbnailImageUrl: meta?.thumbnail ?? undefined,
     projectId: Number(meta?.projectId ?? 0),
     errorTag: selectedErrorType ?? "",
     contents: toContentDtoList(blocks),
   });
 
+  // (원본 저장 함수) create ↔ edit 분기
   const saveOriginalOnly = async (
     meta: PostSavePayload | null = previewMeta
   ) => {
@@ -171,15 +211,29 @@ export default function FreeFormWritePage() {
     }
     try {
       const req = toCreatePostRequest(buildCreateForm("COMPLETED", meta));
-      console.debug("[createPost] payload", req);
-      await createPost(req);
+      console.debug(
+        isResume ? "[editPost] payload" : "[createPost] payload",
+        req
+      );
+
+      if (isResume && resumePostId) {
+        await editPost(resumePostId, req as any);
+      } else {
+        await createPost(req);
+      }
+
       navigate(PATH.PROJECT_DETAIL(String(meta.projectId)), {
         state: { projectName: meta.projectName },
       });
     } catch (err: any) {
       const status = err?.response?.status;
       const data = err?.response?.data;
-      console.error("createPost error", status, data, err);
+      console.error(
+        isResume ? "editPost error" : "createPost error",
+        status,
+        data,
+        err
+      );
 
       if (status === 401) {
         setStatusMessage("로그인이 만료되었어요. 다시 로그인해주세요.");
@@ -258,6 +312,8 @@ export default function FreeFormWritePage() {
     setIsTemplateSelectModalOpen(true);
   };
 
+  // (요약 시작 분기) 기존: 생성 → 요약 시작
+  // 이어쓰기면 수정(WRITING) → 기존 postId로 요약 시작
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -270,12 +326,20 @@ export default function FreeFormWritePage() {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      const req = toCreatePostRequest(buildCreateForm("DRAFT"));
-      const created = await createPost(req);
-      const postId = created.id;
-      setCreatedPostId(postId);
+      const req = toCreatePostRequest(buildCreateForm("WRITING"));
 
-      const start = await startSummary(postId, { type });
+      let targetPostId: number;
+      if (isResume && resumePostId) {
+        await editPost(resumePostId, req as any);
+        targetPostId = resumePostId;
+      } else {
+        const created = await createPost(req);
+        targetPostId = created.id;
+      }
+
+      setCreatedPostId(targetPostId);
+
+      const start = await startSummary(targetPostId, { type });
       setSummaryTaskId(start.taskId);
     } catch (e) {
       console.error(e);
@@ -327,6 +391,7 @@ export default function FreeFormWritePage() {
     };
   }, [isLoadingModalOpen, createdPostId, summaryTaskId]);
 
+  // (나중에 완료 저장) create ↔ edit 분기
   const handleLater = async () => {
     if (
       !title.trim() ||
@@ -341,7 +406,11 @@ export default function FreeFormWritePage() {
 
     try {
       const req = toCreatePostRequest(buildCreateForm("COMPLETED"));
-      await createPost(req);
+      if (isResume && resumePostId) {
+        await editPost(resumePostId, req as any);
+      } else {
+        await createPost(req);
+      }
       navigate(PATH.PROJECT_DETAIL(String(previewMeta.projectId)), {
         state: { projectName: previewMeta.projectName },
       });
@@ -402,6 +471,7 @@ export default function FreeFormWritePage() {
           {/* 제목/태그 + 상단 액션바 */}
           <div className="flex flex-col items-start gap-[40px]">
             <input
+              ref={titleInputRef}
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -412,7 +482,7 @@ export default function FreeFormWritePage() {
               <div className="flex gap-[36px] items-center">
                 <DropDownButton
                   options={errorOptions}
-                  placeholder="에러 종류를 선택하세요"
+                  placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
                   width="w-[340px]"
                   onSelect={(selectedError) =>
                     setSelectedErrorType(selectedError)

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -47,6 +47,9 @@ export default function HomePage() {
   const [showDropdown, setShowDropdown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [removedRecentIds, setRemovedRecentIds] = useState<Set<number>>(
+    new Set()
+  );
 
   const navigate = useNavigate();
 
@@ -242,7 +245,7 @@ export default function HomePage() {
   const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
   const dropdownRef = useClickOutside(() => setShowDropdown(false));
 
-  // 카드 수정/삭제 후 현재 목록 갱신(1페이지부터 새로)
+  // 프로젝트 폴더 카드 수정/삭제 후 현재 목록 갱신(1페이지부터 새로)
   const handleCardUpdated = useCallback(() => {
     void loadPage(1, { append: false, useOnce: false });
   }, [loadPage]);
@@ -250,6 +253,15 @@ export default function HomePage() {
   const handleCardDeleted = useCallback(() => {
     void loadPage(1, { append: false, useOnce: false });
   }, [loadPage]);
+
+  // 트러블슈팅 카드 삭제 후 목록 갱신
+  const handleRecentDeleted = useCallback((postId: number) => {
+    setRemovedRecentIds((prev) => {
+      const next = new Set(prev);
+      next.add(postId);
+      return next;
+    });
+  }, []);
 
   return (
     <div className="flex px-[156px] pt-[79px] pb-[158px] flex-col items-start gap-[40px]">
@@ -375,17 +387,25 @@ export default function HomePage() {
         ) : (
           <>
             <div className="flex flex-wrap gap-[24px]">
-              {recentCards.map((card) => (
-                <TroublogCard
-                  key={card.id}
-                  {...card}
-                  onAvatarClick={() => {
-                    if (viewerId != null)
-                      navigate(PATH.MYPAGE(String(viewerId)));
-                    else navigate(PATH.LOGIN); // 로그인 유도 등
-                  }}
-                />
-              ))}
+              {recentCards
+                .filter((c) => !removedRecentIds.has(c.id))
+                .map((card) => (
+                  <TroublogCard
+                    key={card.id}
+                    {...card}
+                    onDeleted={handleRecentDeleted}
+                    onClick={(id) =>
+                      navigate(PATH.COMMUNITY_POST(id), {
+                        state: { from: "home" },
+                      })
+                    }
+                    onAvatarClick={() => {
+                      if (viewerId != null)
+                        navigate(PATH.MYPAGE(String(viewerId)));
+                      else navigate(PATH.LOGIN);
+                    }}
+                  />
+                ))}
             </div>
             {hasNextRecents && !isLoadingRecents && (
               <div ref={recentsSentinel} className="h-6 w-full" />

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -15,6 +15,7 @@ import useTroubleCards from "@/hooks/useTroubleCards";
 import { PATH } from "@/constants/paths";
 import { useNavigate } from "react-router-dom";
 import plusIcon from "@/assets/icons/plus.svg";
+import { useViewerId } from "@/store/auth";
 
 const PAGE_SIZE = 10;
 
@@ -48,6 +49,8 @@ export default function HomePage() {
   const [creating, setCreating] = useState(false);
 
   const navigate = useNavigate();
+
+  const viewerId = useViewerId();
 
   const goGuide = useCallback(
     (projectId?: number) => {
@@ -373,7 +376,15 @@ export default function HomePage() {
           <>
             <div className="flex flex-wrap gap-[24px]">
               {recentCards.map((card) => (
-                <TroublogCard key={card.id} {...card} />
+                <TroublogCard
+                  key={card.id}
+                  {...card}
+                  onAvatarClick={() => {
+                    if (viewerId != null)
+                      navigate(PATH.MYPAGE(String(viewerId)));
+                    else navigate(PATH.LOGIN); // 로그인 유도 등
+                  }}
+                />
               ))}
             </div>
             {hasNextRecents && !isLoadingRecents && (

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -394,11 +394,16 @@ export default function HomePage() {
                     key={card.id}
                     {...card}
                     onDeleted={handleRecentDeleted}
-                    onClick={(id) =>
-                      navigate(PATH.COMMUNITY_POST(id), {
-                        state: { from: "home" },
-                      })
-                    }
+                    onClick={() => {
+                      const ownerId = card.authorId ?? viewerId;
+                      const qs = new URLSearchParams({
+                        from: "home",
+                        ownerId: ownerId != null ? String(ownerId) : "",
+                      });
+                      navigate(
+                        `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+                      );
+                    }}
                     onAvatarClick={() => {
                       if (viewerId != null)
                         navigate(PATH.MYPAGE(String(viewerId)));

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -5,6 +5,7 @@ import { useInfiniteMyTroubleSearch } from "@/hooks/useInfiniteMyTroubleSearch";
 import { useInfiniteUserTroubleSearch } from "@/hooks/useInfiniteUserTroubleSearch";
 import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useViewerId } from "@/store/auth";
 
 const SearchResultPage = () => {
   const location = useLocation();
@@ -12,7 +13,7 @@ const SearchResultPage = () => {
 
   const sp = new URLSearchParams(location.search);
   const query = sp.get("query") ?? "";
-  // scope: 화이트리스트로 안전하게 정규화
+
   type SearchScope = "my" | "mypage" | "user" | "community";
   const scopeRaw = sp.get("scope");
   const scope: SearchScope =
@@ -22,13 +23,13 @@ const SearchResultPage = () => {
     scopeRaw === "community"
       ? scopeRaw
       : "community";
-  // size: 1~50 범위로 클램프
+
   const sizeParam = Number(sp.get("size"));
   const size =
     Number.isFinite(sizeParam) && sizeParam >= 1 && sizeParam <= 50
       ? sizeParam
       : 10;
-  // userId: 정수 문자열만 허용
+
   const userIdStr = sp.get("userId");
   const userId =
     userIdStr && /^\d+$/.test(userIdStr) ? Number(userIdStr) : null;
@@ -37,6 +38,10 @@ const SearchResultPage = () => {
   const isUserScope = scope === "user" && !!userId;
   const isCommunityScope = scope === "community";
 
+  // 현재 로그인한 사용자
+  const viewerId = useViewerId();
+
+  // 접근 제한 여부(표시만)
   const isBlocked = (card: any) => {
     const vis = String(card.visibility ?? "").toUpperCase(); // "PUBLIC" | "PRIVATE"
     const st = String(card.status ?? "").toUpperCase(); // "INPROGRESS" 등
@@ -44,7 +49,7 @@ const SearchResultPage = () => {
     return vis === "PRIVATE" || (st === "INPROGRESS" && !mine);
   };
 
-  // 현재 로그인한 사용자 트러블슈팅 문서 내 검색
+  // 내 검색
   const my = useInfiniteMyTroubleSearch(
     isMyScope ? query : "",
     size,
@@ -52,22 +57,20 @@ const SearchResultPage = () => {
     { enabled: isMyScope }
   );
 
-  // 특정 사용자 트러블슈팅 문서 내 검색
+  // 특정 사용자 검색
   const other = useInfiniteUserTroubleSearch(
     isUserScope ? query : "",
     userId,
     size
   );
 
-  // 커뮤니티 게시글 검색
+  // 커뮤니티 검색
   const community = useInfiniteCommunityTroubleSearch(
     isCommunityScope ? query : "",
     size
   );
 
-  // 활성 훅 선택
   const active = isUserScope ? other : isMyScope ? my : community;
-  // 활성 훅이 바뀔 때 비교용 키(불필요한 재부착 방지)
   const activeKey = isUserScope
     ? `user:${userId}`
     : isMyScope
@@ -82,10 +85,9 @@ const SearchResultPage = () => {
   const displayTotal = (active as any).displayTotal ?? totalElements;
   const hasNext = active.hasNext;
 
-  // 하단 센티널 관찰자
+  // 무한스크롤
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
-
   const loadMoreRef = useRef<() => void>(() => {});
   useEffect(() => {
     loadMoreRef.current = active.loadMore;
@@ -93,11 +95,8 @@ const SearchResultPage = () => {
 
   useEffect(() => {
     const el = sentinelRef.current;
-
-    // 센티널이 없거나 더 로드할 게 없으면 관찰 안 함
     if (!el || !hasNext) return;
 
-    // 기존 옵저버 있으면 정리 (StrictMode/리렌더 대응)
     if (observerRef.current) {
       observerRef.current.disconnect();
       observerRef.current = null;
@@ -106,36 +105,17 @@ const SearchResultPage = () => {
     observerRef.current = new IntersectionObserver(
       (entries) => {
         const [entry] = entries;
-        if (entry.isIntersecting) {
-          // 최신 loadMore 실행
-          loadMoreRef.current?.();
-        }
+        if (entry.isIntersecting) loadMoreRef.current?.();
       },
       { root: null, rootMargin: "400px 0px", threshold: 0 }
     );
 
     observerRef.current.observe(el);
-
     return () => {
       observerRef.current?.disconnect();
       observerRef.current = null;
     };
   }, [hasNext, activeKey, query, size]);
-
-  // 별점 enum → 숫자 변환
-  const parseStar = (raw: unknown) => {
-    if (typeof raw === "number") return raw;
-    if (typeof raw !== "string") return 0;
-    const k = raw.toUpperCase();
-    const map: Record<string, number> = {
-      ONE_STAR: 1,
-      TWO_STARS: 2,
-      THREE_STARS: 3,
-      FOUR_STARS: 4,
-      FIVE_STARS: 5,
-    };
-    return map[k] ?? 0;
-  };
 
   return (
     <div className="mt-[179px] mb-[68px] flex w-[1200px] flex-col items-start gap-[56px] mx-auto">
@@ -145,12 +125,10 @@ const SearchResultPage = () => {
           : `총 ${displayTotal}개의 포스트를 찾았어요.`}
       </span>
 
-      {/* 에러 */}
       {error && (
         <div className="text-red-600 text-body-16-regular">{error}</div>
       )}
 
-      {/* 결과 리스트 */}
       <div className="flex flex-col items-start self-stretch">
         {loadingInitial && items.length === 0 ? (
           <>
@@ -170,106 +148,35 @@ const SearchResultPage = () => {
                 : Number.parseInt(String(card.id), 10);
             const idValid = Number.isFinite(idNum);
 
-            // 원본 검색 아이템
-            const raw = card.raw; // (MyTroubleServerItem | undefined)
-            const contents = raw?.contents ?? [];
-
-            // 어떤 에디터로 갈지: 하나라도 USER_WRITTEN이 아니면 TEMPLATE
-            const goFreeform = contents.every(
-              (c) => (c.authorType ?? "USER_WRITTEN") === "USER_WRITTEN"
-            );
-
-            // FREEFORM 프리필 블록
-            const freeformBlocks =
-              contents
-                .slice()
-                .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
-                .map((c, i) => ({
-                  id: c.id ?? i,
-                  title: c.subTitle ?? "",
-                  content: c.body ?? "",
-                  isSaved: false,
-                })) ?? [];
-
-            // TEMPLATE 프리필 블록
-            const templateBlocks =
-              contents
-                .slice()
-                .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
-                .map((c, i) => ({
-                  id: c.id ?? i,
-                  content: c.body ?? "",
-                  checklist: [],
-                  checklistItems: [],
-                  checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
-                  question: c.subTitle ?? `질문 ${i + 1}`,
-                  isSaved: false,
-                })) ?? [];
-
-            const prefillBase = {
-              title: card.title,
-              tags: card.tags,
-              errorType: card.errorCategory || null,
-              savePrefill: {
-                importance: parseStar(raw?.starRating),
-                visibility: card.visibility, // "public" | "private"
-                projectId: raw?.projectId ?? null,
-                projectName: undefined,
-                thumbnail: raw?.thumbnailUrl ?? null,
-              } as const,
-            };
+            // 본인 글 여부
+            const mine = !!card.isMine;
+            const ownerId =
+              mine && viewerId != null ? Number(viewerId) : undefined;
 
             return (
               <TroubleShootingCard
                 key={card.id}
                 {...card}
-                // 클릭 막기: blocked 이거나 id가 유효하지 않으면 onClick 전달 안 함
                 onClick={
                   blocked || !idValid
                     ? undefined
                     : () => {
-                        // 안내 메시지
-                        const ok = window.confirm(
-                          goFreeform
-                            ? "이 문서는 자유형식으로 작성된 글이에요.\n이어쓰기 화면으로 이동할까요?"
-                            : "이 문서는 가이드 템플릿 기반으로 작성된 글이에요.\n이어쓰기 화면으로 이동할까요?"
-                        );
-                        if (!ok) return;
-
-                        if (goFreeform) {
-                          // FREEFORM 편집으로 이동 + 프리필
-                          navigate(PATH.FREEFORM_WRITING, {
-                            state: {
-                              editorType: "FREEFORM",
-                              ...prefillBase,
-                              blocks: freeformBlocks, // FreeFormWritePage에서 그대로 반영
-                            },
-                          });
-                        } else {
-                          // TEMPLATE 편집으로 이동 + 프리필
-                          navigate(PATH.TEMP_WRITING, {
-                            state: {
-                              editorType: "TEMPLATE",
-                              ...prefillBase,
-                              blocks: templateBlocks, // TempWritePage에서 그대로 반영
-                            },
-                          });
-                        }
+                        // 상세 페이지로만 이동. 본인 글이면 ownerId 같이 전달
+                        navigate(PATH.COMMUNITY_POST(idNum), {
+                          state: { from: "search", ownerId },
+                        });
                       }
                 }
-                // TroubleShootingCard가 직접 처리할 수 있도록 명시적 disabled 전달
                 disabled={blocked || !idValid}
               />
             );
           })
         )}
 
-        {/* 로딩 인디케이터 / 센티널 */}
         <div className="w-full flex flex-col items-center mt-4">
           {loadingMore && (
             <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
           )}
-          {/* 이 div가 뷰포트에 들어오면 다음 페이지 로드 시도 */}
           {hasNext && <div ref={sentinelRef} style={{ height: 1 }} />}
         </div>
       </div>

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -39,8 +39,9 @@ const SearchResultPage = () => {
 
   const isBlocked = (card: any) => {
     const vis = String(card.visibility ?? "").toUpperCase(); // "PUBLIC" | "PRIVATE"
-    const st = String(card.status ?? "").toUpperCase(); // "COMPLETED" | "IN_PROGRESS" 등
-    return vis === "PRIVATE" || st === "IN_PROGRESS";
+    const st = String(card.status ?? "").toUpperCase(); // "INPROGRESS" 등
+    const mine = !!card.isMine;
+    return vis === "PRIVATE" || (st === "INPROGRESS" && !mine);
   };
 
   // 현재 로그인한 사용자 트러블슈팅 문서 내 검색
@@ -121,6 +122,21 @@ const SearchResultPage = () => {
     };
   }, [hasNext, activeKey, query, size]);
 
+  // 별점 enum → 숫자 변환
+  const parseStar = (raw: unknown) => {
+    if (typeof raw === "number") return raw;
+    if (typeof raw !== "string") return 0;
+    const k = raw.toUpperCase();
+    const map: Record<string, number> = {
+      ONE_STAR: 1,
+      TWO_STARS: 2,
+      THREE_STARS: 3,
+      FOUR_STARS: 4,
+      FIVE_STARS: 5,
+    };
+    return map[k] ?? 0;
+  };
+
   return (
     <div className="mt-[179px] mb-[68px] flex w-[1200px] flex-col items-start gap-[56px] mx-auto">
       <span className="text-head-32-regular self-stretch">
@@ -153,6 +169,56 @@ const SearchResultPage = () => {
                 ? card.id
                 : Number.parseInt(String(card.id), 10);
             const idValid = Number.isFinite(idNum);
+
+            // 원본 검색 아이템
+            const raw = card.raw; // (MyTroubleServerItem | undefined)
+            const contents = raw?.contents ?? [];
+
+            // 어떤 에디터로 갈지: 하나라도 USER_WRITTEN이 아니면 TEMPLATE
+            const goFreeform = contents.every(
+              (c) => (c.authorType ?? "USER_WRITTEN") === "USER_WRITTEN"
+            );
+
+            // FREEFORM 프리필 블록
+            const freeformBlocks =
+              contents
+                .slice()
+                .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+                .map((c, i) => ({
+                  id: c.id ?? i,
+                  title: c.subTitle ?? "",
+                  content: c.body ?? "",
+                  isSaved: false,
+                })) ?? [];
+
+            // TEMPLATE 프리필 블록
+            const templateBlocks =
+              contents
+                .slice()
+                .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+                .map((c, i) => ({
+                  id: c.id ?? i,
+                  content: c.body ?? "",
+                  checklist: [],
+                  checklistItems: [],
+                  checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
+                  question: c.subTitle ?? `질문 ${i + 1}`,
+                  isSaved: false,
+                })) ?? [];
+
+            const prefillBase = {
+              title: card.title,
+              tags: card.tags,
+              errorType: card.errorCategory || null,
+              savePrefill: {
+                importance: parseStar(raw?.starRating),
+                visibility: card.visibility, // "public" | "private"
+                projectId: raw?.projectId ?? null,
+                projectName: undefined,
+                thumbnail: raw?.thumbnailUrl ?? null,
+              } as const,
+            };
+
             return (
               <TroubleShootingCard
                 key={card.id}
@@ -161,10 +227,35 @@ const SearchResultPage = () => {
                 onClick={
                   blocked || !idValid
                     ? undefined
-                    : () =>
-                        navigate(PATH.COMMUNITY_POST(idNum), {
-                          state: { from: "search", query, scope, userId },
-                        })
+                    : () => {
+                        // 안내 메시지
+                        const ok = window.confirm(
+                          goFreeform
+                            ? "이 문서는 자유형식으로 작성된 글이에요.\n이어쓰기 화면으로 이동할까요?"
+                            : "이 문서는 가이드 템플릿 기반으로 작성된 글이에요.\n이어쓰기 화면으로 이동할까요?"
+                        );
+                        if (!ok) return;
+
+                        if (goFreeform) {
+                          // FREEFORM 편집으로 이동 + 프리필
+                          navigate(PATH.FREEFORM_WRITING, {
+                            state: {
+                              editorType: "FREEFORM",
+                              ...prefillBase,
+                              blocks: freeformBlocks, // FreeFormWritePage에서 그대로 반영
+                            },
+                          });
+                        } else {
+                          // TEMPLATE 편집으로 이동 + 프리필
+                          navigate(PATH.TEMP_WRITING, {
+                            state: {
+                              editorType: "TEMPLATE",
+                              ...prefillBase,
+                              blocks: templateBlocks, // TempWritePage에서 그대로 반영
+                            },
+                          });
+                        }
+                      }
                 }
                 // TroubleShootingCard가 직접 처리할 수 있도록 명시적 disabled 전달
                 disabled={blocked || !idValid}

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -19,6 +19,7 @@ import {
   startSummary,
   getSummaryStatus,
   cancelSummary,
+  editPost,
 } from "@/api/post.api";
 
 type IncomingTemplateState = {
@@ -36,6 +37,47 @@ type IncomingTemplateState = {
     thumbnail?: string | null;
   };
   projectId?: number;
+
+  // 수정 식별용
+  postId?: number;
+  mode?: "edit" | "create";
+};
+
+const ERROR_CODE_TO_LABEL: Record<string, string> = {
+  BUILD_COMPILE_ERROR: "Build/Compile Error",
+  RUNTIME_ERROR: "Runtime Error",
+  DEPENDENCY_VERSION_ERROR: "Dependency/Version Error",
+  NETWORK_API_ERROR: "Network/API Error",
+  AUTHENTICATION_AUTHORIZATION_ERROR: "Authentication/Authorization Error",
+  DATABASE_ERROR: "Database Error",
+  UI_RENDERING_ERROR: "UI/Rendering Error",
+  CONFIGURATION_ERROR: "Configuration Error",
+  TIMEOUT_ERROR_HANDLING: "Timeout/Error Handling",
+  THIRD_PARTY_LIBRARY_ERROR: "Third-Party Library Error",
+};
+const toErrorLabel = (code?: string | null) =>
+  code ? ERROR_CODE_TO_LABEL[code] ?? code : null;
+
+const enrichBlocksWithChecklist = (blocks: BlockData[]): BlockData[] => {
+  return blocks.map((b, i) => {
+    // 질문 문구로 먼저 매칭 시도 → 없으면 인덱스 fallback
+    const matched =
+      questionData.find(
+        (q) => q.question === b.question || q.question === b.checklistTitle
+      ) ?? questionData[i];
+
+    return {
+      ...b,
+      question: b.question ?? matched?.question ?? `질문 ${i + 1}`,
+      checklistItems:
+        b.checklistItems && b.checklistItems.length > 0
+          ? b.checklistItems
+          : matched?.checklistItems ?? [],
+      checklistTitle: b.checklistTitle ?? matched?.title ?? "",
+      checklist: Array.isArray(b.checklist) ? b.checklist : [],
+      isSaved: b.isSaved ?? false,
+    };
+  });
 };
 
 const TempWritePage = () => {
@@ -67,6 +109,15 @@ const TempWritePage = () => {
   const location = useLocation() as { state?: IncomingTemplateState };
   const initialProjectId = location.state?.projectId;
 
+  // 수정여부 판단
+  const resumePostId = ((): number | null => {
+    const pid = location.state?.postId;
+    return typeof pid === "number" && Number.isFinite(pid) ? pid : null;
+  })();
+  const isResume = resumePostId != null;
+
+  const initialActiveSetRef = useRef(false);
+
   type SummaryStatus =
     | "PENDING"
     | "STARTED"
@@ -95,11 +146,22 @@ const TempWritePage = () => {
     if (location.state?.editorType === "TEMPLATE") {
       if (location.state.title) setTitle(location.state.title);
       if (location.state.tags) setSelectedTags(location.state.tags);
-      if (location.state.errorType !== undefined)
-        setSelectedErrorType(location.state.errorType ?? null);
-      if (location.state.blocks?.length) setBlocks(location.state.blocks);
+      if (location.state?.errorType !== undefined)
+        setSelectedErrorType(toErrorLabel(location.state.errorType) ?? null);
+      if (location.state.blocks?.length) {
+        // 프리필 블록에 체크리스트를 보강해서 주입
+        setBlocks(enrichBlocksWithChecklist(location.state.blocks));
+      }
     }
   }, [location.state]);
+
+  useEffect(() => {
+    if (initialActiveSetRef.current) return;
+    if (blocks.length > 0) {
+      setActiveIndex(blocks.length - 1); // 최상단(화면상 첫 블록)
+      initialActiveSetRef.current = true;
+    }
+  }, [blocks.length]);
 
   // 첫 블록 생성 (프리필 없을 때만)
   useEffect(() => {
@@ -186,6 +248,7 @@ const TempWritePage = () => {
     setIsTemplateSelectModalOpen(true);
   };
 
+  // (요약 시작) create ↔ edit 분기
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -198,13 +261,20 @@ const TempWritePage = () => {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      // 요약을 돌릴 거라 임시로 DRAFT로 생성
-      const req = toCreatePostRequest(buildCreateForm("DRAFT"));
-      const created = await createPost(req);
-      const postId = created.id;
-      setCreatedPostId(postId);
+      const req = toCreatePostRequest(buildCreateForm("WRITING"));
 
-      const start = await startSummary(postId, { type });
+      let targetPostId: number;
+      if (isResume && resumePostId) {
+        await editPost(resumePostId, req as any);
+        targetPostId = resumePostId;
+      } else {
+        const created = await createPost(req);
+        targetPostId = created.id;
+      }
+
+      setCreatedPostId(targetPostId);
+
+      const start = await startSummary(targetPostId, { type });
       setSummaryTaskId(start.taskId);
     } catch (e) {
       console.error(e);
@@ -256,6 +326,7 @@ const TempWritePage = () => {
     };
   }, [isLoadingModalOpen, createdPostId, summaryTaskId]);
 
+  // (나중에 완료 저장) create ↔ edit 분기
   const handleLater = async () => {
     if (
       !title.trim() ||
@@ -270,7 +341,11 @@ const TempWritePage = () => {
 
     try {
       const req = toCreatePostRequest(buildCreateForm("COMPLETED"));
-      await createPost(req);
+      if (isResume && resumePostId) {
+        await editPost(resumePostId, req as any);
+      } else {
+        await createPost(req);
+      }
       navigate(PATH.PROJECT_DETAIL(String(previewMeta.projectId)), {
         state: { projectName: previewMeta.projectName },
       });
@@ -301,7 +376,7 @@ const TempWritePage = () => {
     }
   };
 
-  const buildCreateForm = (postStatus: "COMPLETED" | "DRAFT") => {
+  const buildCreateForm = (postStatus: "COMPLETED" | "WRITING") => {
     const form: PostForm = {
       title,
       introduction: previewMeta?.description ?? "",
@@ -310,6 +385,7 @@ const TempWritePage = () => {
       isSummaryCreated: false,
       postStatus,
       starRating: String(previewMeta?.importance ?? 0),
+      templateType: "GUIDELINE",
       thumbnailImageUrl: previewMeta?.thumbnail ?? undefined,
       projectId: previewMeta?.projectId ?? 0,
       errorTag: selectedErrorType ?? "",
@@ -361,7 +437,7 @@ const TempWritePage = () => {
                   "Timeout/Error Handling",
                   "Third-Party Library Error",
                 ]}
-                placeholder="에러 종류를 선택하세요"
+                placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
                 width="w-[340px] h-[36px]"
                 onSelect={(selectedError) =>
                   setSelectedErrorType(selectedError)

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -2,6 +2,8 @@ import { type PropsWithChildren, useEffect, useRef } from "react";
 import { connectAlertSSE } from "@/api/alert.api";
 import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
 import api from "@/api/axios";
+import { useNotificationStore } from "@/store/notification";
+import type { AlertServerItem } from "@/types/alert.model";
 
 async function tryRefreshOnce() {
   try {
@@ -10,6 +12,11 @@ async function tryRefreshOnce() {
   } catch {
     return false;
   }
+}
+
+// 타입 가드
+function isAlertPayload(x: any): x is AlertServerItem {
+  return x && typeof x === "object" && "title" in x && "message" in x;
 }
 
 export default function AlertSSEProvider({ children }: PropsWithChildren) {
@@ -67,8 +74,11 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       const close = connectAlertSSE(
         {
           onOpen: () => console.log("[SSE] connected"),
-          onMessage: () => {
-            // TODO: 알림 스토어 반영
+          onMessage: (payload) => {
+            if (!isAlertPayload(payload)) {
+              return;
+            }
+            useNotificationStore.getState().pushFromSSE(payload);
           },
           onError: (e) => console.warn("[SSE] error", e),
           onUnauthorized: async () => {

--- a/src/store/notification.ts
+++ b/src/store/notification.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import type { AlertServerItem } from "@/types/alert.model";
+
+type Toast = { id: number; title: string; message: string; link?: string };
+
+interface NotificationState {
+  hasNew: boolean;
+  toasts: Toast[];
+  pushFromSSE: (a: AlertServerItem) => void;
+  popToast: (id: number) => void;
+  clearNew: () => void;
+}
+
+export const useNotificationStore = create<NotificationState>((set) => ({
+  hasNew: false,
+  toasts: [],
+  pushFromSSE: (a) =>
+    set((s) => ({
+      hasNew: true,
+      toasts: [
+        ...s.toasts,
+        {
+          id: Date.now(),
+          title: a.title ?? "알림",
+          message: a.message ?? "",
+          link: a.targetUrl ?? undefined,
+        },
+      ],
+    })),
+  popToast: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  clearNew: () => set(() => ({ hasNew: false })),
+}));

--- a/src/types/alert.model.ts
+++ b/src/types/alert.model.ts
@@ -13,5 +13,6 @@ export interface AlertServerItem {
   message: string;
   alertType: string;
   isRead: boolean;
+  targetUrl: string;
   userId: number;
 }

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -8,7 +8,7 @@ export interface CommunityServerCard {
     userId: number;
     nickname: string;
     profileImageUrl: string | null;
-  };
+  } | null;
   id: number;
   title: string;
   thumbnailUrl: string | null;

--- a/src/types/troubles.server.ts
+++ b/src/types/troubles.server.ts
@@ -1,15 +1,83 @@
 import type { PaginatedResponse } from "@/types/common.model";
 
+// 공통 사용자 요약 (서버 키 이름은 parent마다 다르지만 구조는 동일)
+export interface UserBrief {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+
+// /my/search의 경우
+export interface TroubleSearchCard {
+  postCardUserInfoResDto: UserBrief;
+  id: number;
+  title: string;
+  thumbnailUrl: string | null;
+  completedAt: string | null;
+  errorTag: string | null;
+  postTags: string[];
+  likeCount: number;
+  commentCount: number;
+}
+
+export type MyTroubleSearchPage = PaginatedResponse<TroubleSearchCard>;
+export type UserTroubleSearchPage = PaginatedResponse<TroubleSearchCard>;
+
+// community/search의 경우
+export type StarRatingLabel =
+  | "NONE"
+  | "ONE_STAR"
+  | "TWO_STARS"
+  | "THREE_STARS"
+  | "FOUR_STARS"
+  | "FIVE_STARS";
+
+export interface CommunitySearchContentBlock {
+  id: number;
+  subTitle: string | null;
+  body: string | null;
+  sequence: number;
+}
+
+export interface CommunityTroubleSearchItem {
+  id: number;
+  title: string;
+  introduction: string | null;
+  likeCount: number;
+  commentCount: number;
+  isVisible: boolean;
+  isSummaryCreated: boolean;
+  isDeleted: boolean;
+  postStatus: string;
+  starRating: StarRatingLabel;
+  templateType: string | null;
+  checklistError: number[];
+  checklistReason: number[];
+  createdAt: string;
+  updatedAt: string;
+  userInfo: UserBrief;
+  projectId: number;
+  errorTag: string | null;
+  postTags: string[];
+  contents: CommunitySearchContentBlock[];
+  thumbnailUrl: string | null;
+}
+
+export type CommunityTroubleSearchPage =
+  PaginatedResponse<CommunityTroubleSearchItem>;
+
+// 상세/기존 API 호환용 (authorType/summaryType)
 export interface TroubleContentBlock {
   id: number;
   subTitle: string | null;
   body: string | null;
   sequence: number;
-  authorType: string;
-  summaryType: string;
+  authorType: string; // 상세 응답에서만 존재
+  summaryType: string; // 상세 응답에서만 존재
 }
 
-export interface MyTroubleServerItem {
+// 예전의 MyTroubleDetailItem은 상세 전용으로 이름을 바꿔두는 걸 추천
+export interface MyTroubleDetailItem {
   id: number;
   title: string;
   introduction: string | null;
@@ -33,5 +101,4 @@ export interface MyTroubleServerItem {
   thumbnailUrl: string | null;
 }
 
-// 서버 페이징 응답 (ApiResponse로 감싸지지 않는 케이스)
-export type MyTroublesServerPage = PaginatedResponse<MyTroubleServerItem>;
+export type MyTroubleDetailPage = PaginatedResponse<MyTroubleDetailItem>;

--- a/src/utils/owner.ts
+++ b/src/utils/owner.ts
@@ -1,0 +1,21 @@
+export type PostCardUserInfo = {
+  userId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+} | null;
+
+export function getOwnerIdFromCard(item: {
+  postCardUserInfoResDto: PostCardUserInfo;
+}): number | undefined {
+  return item.postCardUserInfoResDto?.userId ?? undefined;
+}
+export function getAuthorNameFromCard(item: {
+  postCardUserInfoResDto: PostCardUserInfo;
+}): string {
+  return item.postCardUserInfoResDto?.nickname ?? "알 수 없음";
+}
+export function getAuthorProfileFromCard(item: {
+  postCardUserInfoResDto: PostCardUserInfo;
+}): string | null {
+  return item.postCardUserInfoResDto?.profileImageUrl ?? null;
+}


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 트러블로그 카드 케밥 메뉴 클릭 가능하도록 수정
- [x] 트러블슈팅 문서 라우팅 관리
- [x] 포스트 수정 API 연동
- [x] UI 일부 수정
- [x] 변경된 API 응답 데이터에 대응할 수 있도록 수정
- [x] 실시간 알림 토스트 메시지, 알림 아이콘 색상 변경 등 효과 추가

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 실시간 알림 토스트 추가(하단 중앙, 자동 사라짐, 클릭 시 내부/외부 링크로 이동), 헤더 벨에 신규 알림 표시 및 호버 시 초기화
  - 카드에서 게시글 영구 삭제 지원(확인 팝업, 삭제 중 상태 표시)
  - 아바타 클릭으로 작성자 마이페이지 이동

- UX 개선
  - 카드 상세 이동 로직 정비(소유자 컨텍스트 반영, 비공개·작성중 접근 차단)
  - 정렬 기준 ‘likes’ → ‘importance’ 변경
  - 마이페이지에서 타인 페이지는 공개 글만 표시 및 태그 통계 반영
  - 헤더 검색창 포커스/스타일 개선, 알림/토스트의 내부·외부 링크 처리 보강
  - 케밥 버튼 아이콘 크기·터치 영역 설정 추가
  - 편집 재개(이어쓰기) 및 공유/복사 UX 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->