### PR TITLE
FIX: 기능명세서 기반 에러 수정

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -31,6 +31,13 @@ const COMPUTED_BASE_URL = RAW_BASE_URL || "/api";
 const API_ORIGIN = getOriginSafely(COMPUTED_BASE_URL);
 const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
 
+// 타입 보강: 요청단위로 전역 404 스킵할 수 있게
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    __skipGlobal404?: boolean;
+  }
+}
+
 const api = axios.create({
   // baseURL: COMPUTED_BASE_URL,
   baseURL: API_BASE_URL || undefined,
@@ -42,6 +49,8 @@ const api = axios.create({
     EnvType: ENVTYPE,
   },
 });
+
+let navigating404 = false;
 
 // 공통 유틸: 로그인 페이지로의 네비게이션을 1회만
 let authNavigationPromise: Promise<void> | null = null;
@@ -137,6 +146,7 @@ api.interceptors.response.use(
   },
   async (error: AxiosError) => {
     const status = error.response?.status;
+    const cfg = error.config;
     const reqUrl = (error.config?.url ?? "") as string;
     const isRefresh = reqUrl.includes("/auth/refresh");
     const onLogin = location.pathname === PATH.ROOT;
@@ -146,6 +156,36 @@ api.interceptors.response.use(
     const reqOrigin = isAbsolute ? getOriginSafely(reqUrl) : API_ORIGIN;
     const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
     if (isExternalAbsolute) return Promise.reject(error);
+
+    const isGET = (cfg?.method ?? "get").toUpperCase() === "GET";
+    const skip = cfg?.__skipGlobal404 === true;
+
+    // 현재 라우트가 이미 404면 추가 네비게이션 방지
+    const alreadyOn404 =
+      router?.state?.location?.pathname === PATH.NOT_FOUND ||
+      router?.state?.location?.pathname === "/404";
+
+    // SSE 등 특정 엔드포인트 제외
+    const url = cfg?.url ?? "";
+    const isSSE = /\/alert|\/connect|\/events/i.test(url);
+
+    if (
+      status === 404 &&
+      isGET &&
+      !skip &&
+      !alreadyOn404 &&
+      !isSSE &&
+      !navigating404
+    ) {
+      navigating404 = true;
+      // replace로 기록 오염 최소화
+      router
+        .navigate(PATH.NOT_FOUND ?? "/404", { replace: true })
+        .finally(() => {
+          // 약간의 지연 후 플래그 해제 (동시 요청 대비)
+          setTimeout(() => (navigating404 = false), 300);
+        });
+    }
 
     // 리프레시 자체 실패 → 즉시 로그인 이동(단 1회)
     if (isRefresh) {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -40,6 +40,16 @@ declare module "axios" {
   }
 }
 
+declare global {
+  interface Window {
+    __authRefreshPromise?: Promise<string | null> | null;
+  }
+}
+const getRefreshPromise = () => window.__authRefreshPromise ?? null;
+const setRefreshPromise = (p: Promise<string | null> | null) => {
+  window.__authRefreshPromise = p;
+};
+
 const api = axios.create({
   // baseURL: COMPUTED_BASE_URL,
   baseURL: API_BASE_URL || undefined,
@@ -84,7 +94,7 @@ const navigateToAuthGuardOnce = (status: 401 | 403, rawNext?: string) => {
 };
 
 // 요청 인터셉터: 토큰 자동 첨부
-api.interceptors.request.use((config) => {
+const reqId = api.interceptors.request.use((config) => {
   const url = config.url ?? "";
   config.headers = config.headers ?? {};
 
@@ -110,10 +120,9 @@ api.interceptors.request.use((config) => {
 });
 
 // 리프레시 공용 Promise (동시 401 한 번만 처리)
-let refreshPromise: Promise<string | null> | null = null;
 const startRefresh = async (): Promise<string | null> => {
   try {
-    const r = await api.post("/auth/refresh", { __skipGlobalAuthGuard: true });
+    const r = await api.post("/auth/refresh", undefined, {});
     const newToken: string | undefined = r.data?.data?.accessToken;
     if (!newToken) {
       console.error("[Auth] Refresh response missing accessToken:", r.data);
@@ -127,7 +136,7 @@ const startRefresh = async (): Promise<string | null> => {
 };
 
 // 응답 인터셉터
-api.interceptors.response.use(
+const resId = api.interceptors.response.use(
   (res) => {
     const ct = res.headers?.["content-type"] as string | undefined;
     const url: string | undefined = (res as any)?.request?.responseURL;
@@ -198,13 +207,15 @@ api.interceptors.response.use(
         return Promise.reject(error);
       }
 
-      if (!refreshPromise) {
-        refreshPromise = startRefresh().finally(() =>
-          setTimeout(() => (refreshPromise = null), 100)
+      let p = getRefreshPromise();
+      if (!p) {
+        p = startRefresh().finally(() =>
+          setTimeout(() => setRefreshPromise(null), 100)
         );
+        setRefreshPromise(p);
       }
+      const newToken = await p;
 
-      const newToken = await refreshPromise;
       if (newToken) {
         cfg._retry = true;
         cfg.headers = cfg.headers ?? {};
@@ -227,6 +238,13 @@ api.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    api.interceptors.request.eject(reqId);
+    api.interceptors.response.eject(resId);
+  });
+}
 
 export default api;
 if (import.meta.env.DEV) {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -35,6 +35,8 @@ const ENVTYPE = import.meta.env.VITE_ENV_TYPE;
 declare module "axios" {
   export interface AxiosRequestConfig {
     __skipGlobal404?: boolean;
+    __skipGlobalAuthGuard?: boolean;
+    _retry?: boolean;
   }
 }
 
@@ -61,14 +63,17 @@ const getCurrentSpaPath = () => {
   return `${loc.pathname}${loc.search}${loc.hash}`;
 };
 
-const navigateToAuthOnce = (rawNext?: string) => {
+// 401/403 공통: 안내 화면으로 1회만 이동
+const navigateToAuthGuardOnce = (status: 401 | 403, rawNext?: string) => {
   if (!authNavigationPromise) {
-    const nextPath = rawNext ?? getCurrentSpaPath(); // 미인코딩 경로
+    const nextPath = rawNext ?? getCurrentSpaPath();
     const params = new URLSearchParams();
-    params.set("next", nextPath); // 인코딩은 URLSearchParams가 처리
-    router.navigate(`${PATH.ROOT}?${params.toString()}`, { replace: true });
+    params.set("status", String(status));
+    params.set("next", nextPath);
+    router.navigate(`${PATH.AUTH_GUARD}?${params.toString()}`, {
+      replace: true,
+    });
     authNavigationPromise = new Promise<void>((resolve) => {
-      // 짧은 쿨다운 후 게이트 해제 (동시 발화 방지)
       setTimeout(() => {
         authNavigationPromise = null;
         resolve();
@@ -127,7 +132,6 @@ const startRefresh = async (): Promise<string | null> => {
 // 응답 인터셉터
 api.interceptors.response.use(
   (res) => {
-    // 토큰 없이 HTML(카카오 302 후 200) 수신 방어
     const ct = res.headers?.["content-type"] as string | undefined;
     const url: string | undefined = (res as any)?.request?.responseURL;
     const redirectedToKakao =
@@ -135,105 +139,84 @@ api.interceptors.response.use(
     const notJson = !!ct && !ct.includes("application/json");
     const tokenExists = !!localStorage.getItem("accessToken");
 
-    if (
-      (redirectedToKakao || notJson) &&
-      !tokenExists &&
-      location.pathname !== PATH.ROOT
-    ) {
-      void navigateToAuthOnce(); // 내부에서 안전하게 계산/인코딩
+    if ((redirectedToKakao || notJson) && !tokenExists) {
+      void navigateToAuthGuardOnce(401);
     }
     return res;
   },
   async (error: AxiosError) => {
     const status = error.response?.status;
-    const cfg = error.config;
-    const reqUrl = (error.config?.url ?? "") as string;
-    const isRefresh = reqUrl.includes("/auth/refresh");
-    const onLogin = location.pathname === PATH.ROOT;
+    const cfg = (error.config ?? {}) as import("axios").AxiosRequestConfig & {
+      _retry?: boolean;
+    };
+    const reqUrl = cfg.url ?? "";
 
-    // 외부 절대 URL만 제외 (상대 경로/동일 베이스 URL은 처리)
+    // 외부 절대 URL은 제외
     const isAbsolute = /^https?:\/\//i.test(reqUrl);
-    const reqOrigin = isAbsolute ? getOriginSafely(reqUrl) : API_ORIGIN;
+    const reqOrigin = isAbsolute ? getOriginSafely(String(reqUrl)) : API_ORIGIN;
     const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
     if (isExternalAbsolute) return Promise.reject(error);
 
-    const isGET = (cfg?.method ?? "get").toUpperCase() === "GET";
-    const skip = cfg?.__skipGlobal404 === true;
-
-    // 현재 라우트가 이미 404면 추가 네비게이션 방지
+    // 404 → /404 (기존)
+    const isGET = (cfg.method ?? "get").toUpperCase() === "GET";
+    const skip404 = cfg.__skipGlobal404 === true;
     const alreadyOn404 =
       router?.state?.location?.pathname === PATH.NOT_FOUND ||
       router?.state?.location?.pathname === "/404";
-
-    // SSE 등 특정 엔드포인트 제외
-    const url = cfg?.url ?? "";
-    const isSSE = /\/alert|\/connect|\/events/i.test(url);
+    const isSSE404 = /\/alert|\/connect|\/events/i.test(String(reqUrl));
 
     if (
       status === 404 &&
       isGET &&
-      !skip &&
+      !skip404 &&
       !alreadyOn404 &&
-      !isSSE &&
+      !isSSE404 &&
       !navigating404
     ) {
       navigating404 = true;
-      // replace로 기록 오염 최소화
       router
-        .navigate(PATH.NOT_FOUND ?? "/404", { replace: true })
-        .finally(() => {
-          // 약간의 지연 후 플래그 해제 (동시 요청 대비)
-          setTimeout(() => (navigating404 = false), 300);
-        });
-    }
-
-    // 리프레시 자체 실패 → 즉시 로그인 이동(단 1회)
-    if (isRefresh) {
-      localStorage.removeItem("accessToken");
-      if (!onLogin) {
-        await navigateToAuthOnce();
-      }
+        .navigate(PATH.NOT_FOUND, { replace: true })
+        .finally(() => setTimeout(() => (navigating404 = false), 300));
       return Promise.reject(error);
     }
 
-    // 401 → 리프레시(동시성 제어)
-    if (status === 401) {
-      const cfg: any = error.config || {};
+    // 401/403 → /auth-required (새 정책)
+    const skipAuth = cfg.__skipGlobalAuthGuard === true;
+    const isSSEAuth = /\/alert|\/connect|\/events/i.test(String(reqUrl));
+
+    // 401 → 토큰 갱신 시도
+    if (status === 401 && !skipAuth && !isSSEAuth) {
       if (cfg._retry) {
-        // 이미 재시도 한 번 했는데도 401 → 토큰 정리 후 이동
+        // 이미 재시도했는데 또 401 → 토큰 정리 후 안내화면
         localStorage.removeItem("accessToken");
-        if (!onLogin) {
-          await navigateToAuthOnce();
-        }
+        await navigateToAuthGuardOnce(401);
         return Promise.reject(error);
       }
 
       if (!refreshPromise) {
-        refreshPromise = startRefresh().finally(() => {
-          // 다음 401 대비 해제
-          setTimeout(() => (refreshPromise = null), 100);
-        });
+        refreshPromise = startRefresh().finally(() =>
+          setTimeout(() => (refreshPromise = null), 100)
+        );
       }
 
       const newToken = await refreshPromise;
       if (newToken) {
         cfg._retry = true;
         cfg.headers = cfg.headers ?? {};
-        cfg.headers.Authorization = `Bearer ${newToken}`;
-        return api(cfg); // 동일 인스턴스로 재시도
+        (cfg.headers as any).Authorization = `Bearer ${newToken}`;
+        return api(cfg); // 재시도
       }
 
-      // 리프레시 실패
+      // 리프레시 실패 → 안내화면
       localStorage.removeItem("accessToken");
-      if (!onLogin) {
-        await navigateToAuthOnce();
-      }
+      await navigateToAuthGuardOnce(401);
       return Promise.reject(error);
     }
 
-    // 403 → 권한 부족: 로그인 이동(단 1회)
-    if (status === 403 && !onLogin) {
-      await navigateToAuthOnce();
+    // 403 → 접근권한 없음 화면
+    if (status === 403 && !skipAuth && !isSSEAuth) {
+      await navigateToAuthGuardOnce(403);
+      return Promise.reject(error);
     }
 
     return Promise.reject(error);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -86,7 +86,6 @@ const navigateToAuthGuardOnce = (status: 401 | 403, rawNext?: string) => {
 // 요청 인터셉터: 토큰 자동 첨부
 api.interceptors.request.use((config) => {
   const url = config.url ?? "";
-  const isRefresh = url.includes("/auth/refresh");
   config.headers = config.headers ?? {};
 
   // 외부 절대 URL은 내부 인증/EnvType 헤더 미부착
@@ -97,12 +96,10 @@ api.interceptors.request.use((config) => {
     return config;
   }
 
-  // /auth/refresh 에는 Authorization 미첨부
-  if (!isRefresh) {
-    const token = localStorage.getItem("accessToken");
-    if (token) {
-      (config.headers as any).Authorization = `Bearer ${token}`;
-    }
+  // 모든 내부 요청(리프레시 포함)에 Authorization 부착
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    (config.headers as any).Authorization = `Bearer ${token}`;
   }
 
   // EnvType은 항상 강제(리프레시 포함)
@@ -116,7 +113,7 @@ api.interceptors.request.use((config) => {
 let refreshPromise: Promise<string | null> | null = null;
 const startRefresh = async (): Promise<string | null> => {
   try {
-    const r = await api.post("/auth/refresh", {});
+    const r = await api.post("/auth/refresh", { __skipGlobalAuthGuard: true });
     const newToken: string | undefined = r.data?.data?.accessToken;
     if (!newToken) {
       console.error("[Auth] Refresh response missing accessToken:", r.data);
@@ -183,6 +180,14 @@ api.interceptors.response.use(
     // 401/403 → /auth-required (새 정책)
     const skipAuth = cfg.__skipGlobalAuthGuard === true;
     const isSSEAuth = /\/alert|\/connect|\/events/i.test(String(reqUrl));
+    const isRefreshCall = /\/auth\/refresh\b/.test(String(reqUrl));
+
+    // 리프레시 자체가 실패하면 재귀 금지, 즉시 로그아웃 흐름
+    if ((status === 401 || status === 403) && isRefreshCall && !skipAuth) {
+      localStorage.removeItem("accessToken");
+      await navigateToAuthGuardOnce(status as 401 | 403);
+      return Promise.reject(error);
+    }
 
     // 401 → 토큰 갱신 시도
     if (status === 401 && !skipAuth && !isSSEAuth) {

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -26,6 +26,7 @@ export interface TroublogCardProps {
   onClick?: (id: number) => void;
   onAvatarClick?: () => void;
   onDeleted?: (id: number) => void;
+  introduction?: string;
 }
 
 export default function TroublogCard({

--- a/src/components/Community/PostComment.tsx
+++ b/src/components/Community/PostComment.tsx
@@ -150,12 +150,14 @@ export default function PostComment({
           </div>
 
           {/* 답글 달기 버튼 */}
-          <div
-            className="text-body-16-regular text-gray3 cursor-pointer"
-            onClick={() => setReplyOpen(!replyOpen)}
-          >
-            {replyOpen ? "답글 취소" : "답글 달기"}
-          </div>
+          {onReply && (
+            <div
+              className="text-body-16-regular text-gray3 cursor-pointer"
+              onClick={() => setReplyOpen(!replyOpen)}
+            >
+              {replyOpen ? "답글 취소" : "답글 달기"}
+            </div>
+          )}
 
           {/* 답글 입력창 (임시 디자인) */}
           {replyOpen && (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,6 +12,7 @@ import { PATH } from "@/constants/paths";
 import logo from "@/assets/icons/logo.svg";
 import { useViewerId } from "@/store/auth";
 import { useNotificationStore } from "@/store/notification";
+import { useMyPageStore } from "@/store/useMyPageStore";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -27,6 +28,8 @@ const Header = () => {
   // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
   const viewerId = useViewerId();
   const myUserIdStr = viewerId != null ? String(viewerId) : null;
+  // (다른 사용자의 페이지인 경우)
+  const viewedUser = useMyPageStore((s) => s.viewedUser);
 
   const hasNew = useNotificationStore((s) => s.hasNew);
   const clearNew = useNotificationStore((s) => s.clearNew);
@@ -59,8 +62,12 @@ const Header = () => {
           "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
         );
       } else if (scope === "user" && pageUserId) {
+        const displayName =
+          viewedUser?.id === Number(pageUserId) && viewedUser?.nickname
+            ? viewedUser.nickname
+            : pageUserId;
         setPlaceholder(
-          `키워드나 태그 등의 검색어를 통해 ${pageUserId}님의 트러블슈팅을 검색해보세요!`
+          `키워드나 태그 등의 검색어를 통해 ${displayName}님의 트러블슈팅을 검색해보세요!`
         );
       } else {
         setPlaceholder(
@@ -79,8 +86,12 @@ const Header = () => {
           "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
         );
       } else {
+        const displayName =
+          viewedUser?.id === Number(pageUserId) && viewedUser?.nickname
+            ? viewedUser.nickname
+            : pageUserId ?? "사용자";
         setPlaceholder(
-          `키워드나 태그 등의 검색어를 통해 ${pageUserId}님의 트러블슈팅을 검색해보세요!`
+          `키워드나 태그 등의 검색어를 통해 ${displayName}님의 트러블슈팅을 검색해보세요!`
         );
       }
     } else if (
@@ -95,7 +106,14 @@ const Header = () => {
         "키워드나 태그 등의 검색어를 통해 다른 사람들의 트러블슈팅을 검색해보세요!"
       );
     }
-  }, [location.pathname, setPlaceholder, myUserIdStr]);
+  }, [
+    location.pathname,
+    setPlaceholder,
+    myUserIdStr,
+    location.search,
+    viewedUser?.id,
+    viewedUser?.nickname,
+  ]);
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import escapeIcon from "@/assets/icons/escape.svg";
 import useNotifications from "@/hooks/useNotifications";
+import { toInternalSpaPath } from "@/utils/url";
 
 const tabs = ["전체", "트러블슈팅", "댓글", "좋아요"] as const;
 type TabType = (typeof tabs)[number];
@@ -63,33 +64,9 @@ export default function NotificationModal() {
               >
                 <div
                   onClick={() => {
-                    const link = item.link;
-                    if (!link) return;
-                    // 내부 상대 경로 우선 처리
-                    if (
-                      link.startsWith("/") ||
-                      link.startsWith("?") ||
-                      link.startsWith("#")
-                    ) {
-                      navigate(link);
-                      return;
-                    }
-                    try {
-                      const url = new URL(link);
-                      const protocol = url.protocol.toLowerCase();
-                      // http/https 만 허용
-                      if (protocol === "http:" || protocol === "https:") {
-                        if (url.origin === window.location.origin) {
-                          navigate(url.pathname + url.search + url.hash);
-                        } else {
-                          window.location.href = url.href; // 필요 시 새 탭: window.open(url.href, "_blank", "noopener")
-                        }
-                      }
-                      // 그 외 스킴은 무시
-                    } catch {
-                      // 절대 URL 파싱 실패 → 내부 경로로 간주
-                      navigate(link);
-                    }
+                    const internal = toInternalSpaPath(item.link);
+                    if (!internal) return; // 스킴이 이상하면 무시
+                    navigate(internal);
                   }}
                   className={clsx(
                     "text-body-20-regular cursor-pointer transition-all",

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -33,9 +33,14 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { id } = useParams<{ id: string }>();
-  const { selectedStatus, setSelectedStatus, resetSelectedStatus } =
-    useMyPageStore();
-  const { resetSelectedTag } = useMyPageStore();
+  const {
+    selectedStatus,
+    setSelectedStatus,
+    resetSelectedStatus,
+    resetSelectedTag,
+    setViewedUser,
+    resetViewedUser,
+  } = useMyPageStore();
 
   const [userInfo, setUserInfo] = useState<UserInfoData | null>(null);
   const [followLoading, setFollowLoading] = useState(false);
@@ -48,14 +53,24 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     try {
       const data = await getUserInfo(Number(id));
       setUserInfo(data);
+      setViewedUser({
+        id: Number(id),
+        nickname: data?.nickname ?? null,
+      });
     } catch (error) {
       console.error("사용자 정보 불러오기 실패:", error);
     }
-  }, [id]);
+  }, [id, setViewedUser]);
 
   useEffect(() => {
     refetch();
   }, [refetch]);
+
+  useEffect(() => {
+    return () => {
+      resetViewedUser();
+    };
+  }, [resetViewedUser]);
 
   // 현재 경로가 메인 페이지가 아니면 태그 탭 자동 초기화
   useEffect(() => {

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -237,34 +237,35 @@ const TroubleShootingCard = ({
                 )}
 
                 {/* 좋아요 + 댓글 수 */}
-                {(likeCount !== undefined || commentCount !== undefined) && (
-                  <div className="flex items-center gap-[12px]">
-                    {likeCount !== undefined && (
-                      <div className="flex items-center gap-[4px]">
-                        <img
-                          src={heartIcon}
-                          alt="likes"
-                          className="w-[20px] h-[20px]"
-                        />
-                        <span className="text-gray3 text-body-16-regular">
-                          {likeCount}
-                        </span>
-                      </div>
-                    )}
-                    {commentCount !== undefined && (
-                      <div className="flex items-center gap-[4px]">
-                        <img
-                          src={commentIcon}
-                          alt="comments"
-                          className="w-[20px] h-[20px]"
-                        />
-                        <span className="text-gray3 text-body-16-regular">
-                          {commentCount}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
+                {!isMine &&
+                  (likeCount !== undefined || commentCount !== undefined) && (
+                    <div className="flex items-center gap-[12px]">
+                      {likeCount !== undefined && (
+                        <div className="flex items-center gap-[4px]">
+                          <img
+                            src={heartIcon}
+                            alt="likes"
+                            className="w-[20px] h-[20px]"
+                          />
+                          <span className="text-gray3 text-body-16-regular">
+                            {likeCount}
+                          </span>
+                        </div>
+                      )}
+                      {commentCount !== undefined && (
+                        <div className="flex items-center gap-[4px]">
+                          <img
+                            src={commentIcon}
+                            alt="comments"
+                            className="w-[20px] h-[20px]"
+                          />
+                          <span className="text-gray3 text-body-16-regular">
+                            {commentCount}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 <div className="text-gray3 text-body-16-regular">·</div>
                 <div className="text-gray3 text-body-16-regular">
                   {createdAt}

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import SortButtonGroup from "../Project/SortButtonGroup";
 import TroubleShootingCard from "./TroubleShootingCard";
 import { mapToTroubleShootingCard } from "@/mappers/cardMapper";
@@ -37,6 +37,16 @@ const TroubleShootingList = () => {
   const selectedStatus = useMyPageStore((state) => state.selectedStatus);
   const selectedTag = useMyPageStore((state) => state.selectedTag);
 
+  // 작성 중일 땐 정렬 옵션 숨김
+  const shouldShowSort = isMyPage && selectedStatus !== "inProgress";
+
+  // 작성 중으로 전환되면 정렬을 최신순으로 강제 맞춤(혼란 방지)
+  useEffect(() => {
+    if (isMyPage && selectedStatus === "inProgress" && sortBy !== "latest") {
+      setSortBy("latest");
+    }
+  }, [isMyPage, selectedStatus, sortBy, setSortBy]);
+
   // 내 마이페이지면 내 카드만, 아니면 다른 사람 카드만
   const base = useMemo(
     () =>
@@ -64,6 +74,40 @@ const TroubleShootingList = () => {
 
   const sortedCards = statusFiltered;
 
+  // 빈 상태 메시지
+  const emptyMessage = useMemo(() => {
+    if (isLoading) return null;
+    if (sortedCards.length > 0) return null;
+
+    const sortLabel = sortBy === "latest" ? "최신순" : "중요도순";
+
+    if (isMyPage) {
+      if (selectedStatus === "inProgress") {
+        return "작성 중인 트러블슈팅이 없어요.";
+      }
+      if (selectedStatus === "complete") {
+        return `작성 완료된 트러블슈팅이 없어요. (${sortLabel})`;
+      }
+      if (selectedStatus === "created") {
+        return `작성+요약 완료된 트러블슈팅이 없어요. (${sortLabel})`;
+      }
+      return `조건에 맞는 트러블슈팅이 없어요. (${sortLabel})`;
+    } else {
+      // 다른 사용자 페이지
+      if (selectedTag) {
+        return `선택한 태그에 해당하는 트러블슈팅이 없어요.`;
+      }
+      return `아직 공개된 트러블슈팅이 없어요. (${sortLabel})`;
+    }
+  }, [
+    isLoading,
+    sortedCards.length,
+    isMyPage,
+    selectedStatus,
+    sortBy,
+    selectedTag,
+  ]);
+
   const handleDeleted = async () => {
     try {
       await reload();
@@ -75,13 +119,22 @@ const TroubleShootingList = () => {
   return (
     <div className="flex flex-col items-end gap-[40px] w-[948px] pb-[78px]">
       {/* 정렬 기준 선택 */}
-      {isMyPage && <SortButtonGroup selected={sortBy} onSelect={setSortBy} />}
+      {shouldShowSort && (
+        <SortButtonGroup selected={sortBy} onSelect={setSortBy} />
+      )}
 
       {/* 에러/로딩 */}
       {error && <div className="text-red-600 self-start">{error}</div>}
 
       {/* 트러블로그 목록 */}
       <div className="flex flex-col items-start self-stretch">
+        {/* 빈 상태 안내 */}
+        {!error && !isLoading && sortedCards.length === 0 && emptyMessage && (
+          <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white mb-3">
+            <span className="text-body-20-regular">{emptyMessage}</span>
+          </div>
+        )}
+
         {sortedCards.map((card) => (
           <TroubleShootingCard
             key={card.id}

--- a/src/components/Project/ProjectAccordion.tsx
+++ b/src/components/Project/ProjectAccordion.tsx
@@ -1,11 +1,13 @@
-import { useId, useState } from "react";
+import { useEffect, useState } from "react";
 import arrowForwardIcon from "@/assets/icons/arrow-forward.svg";
+import { useViewerId } from "@/store/auth";
 
 interface ProjectAccordionProps {
   title: React.ReactNode;
   headerExtra?: React.ReactNode;
   defaultOpen?: boolean;
   children: React.ReactNode;
+  persistKey?: string;
 }
 
 export default function ProjectAccordion({
@@ -13,9 +15,43 @@ export default function ProjectAccordion({
   headerExtra,
   defaultOpen = true,
   children,
+  persistKey,
 }: ProjectAccordionProps) {
+  const viewerId = useViewerId();
+  // 게스트/사용자별 네임스페이스 (로그아웃 전까지 유지)
+  const userScope = viewerId != null ? `u${viewerId}` : "guest";
+  const storageKey =
+    persistKey != null ? `accordion:${userScope}:${persistKey}` : null;
+
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const panelId = useId();
+
+  // 저장된 상태를 초기화에 반영
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw === "1") setIsOpen(true);
+      else if (raw === "0") setIsOpen(false);
+      else localStorage.setItem(storageKey, defaultOpen ? "1" : "0");
+    } catch {
+      /* no-op */
+    }
+    // storageKey 변경 시 해당 키의 상태를 로드
+  }, [storageKey, defaultOpen]);
+
+  const toggle = () => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      if (storageKey) {
+        try {
+          localStorage.setItem(storageKey, next ? "1" : "0");
+        } catch {
+          /* no-op */
+        }
+      }
+      return next;
+    });
+  };
 
   return (
     <div className="flex flex-col w-full">
@@ -23,10 +59,9 @@ export default function ProjectAccordion({
       <div className="flex items-stretch gap-[8px] sm:gap-[12px] mb-[24px] sm:mb-[36px] h-9 sm:h-[36px]">
         <button
           type="button"
-          onClick={() => setIsOpen((prev) => !prev)}
+          onClick={toggle}
           className="flex items-center gap-[8px] sm:gap-[12px]"
           aria-expanded={isOpen}
-          aria-controls={panelId}
         >
           <img
             src={arrowForwardIcon}
@@ -49,8 +84,6 @@ export default function ProjectAccordion({
 
       {/* 펼쳐진 내용 */}
       <div
-        id={panelId}
-        aria-hidden={!isOpen}
         className={
           (isOpen ? "flex" : "hidden") + " flex-col gap-[36px] sm:gap-[60px]"
         }

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -23,4 +23,5 @@ export const PATH = {
   PREVIEW: "/preview",
 
   NOT_FOUND: "/404",
+  AUTH_GUARD: "/auth-required",
 };

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -21,4 +21,6 @@ export const PATH = {
   TEMP_WRITING: "/tempwriting",
   FREEFORM_WRITING: "/freeformwriting",
   PREVIEW: "/preview",
+
+  NOT_FOUND: "/404",
 };

--- a/src/hooks/useInfiniteCommunityTroubleSearch.ts
+++ b/src/hooks/useInfiniteCommunityTroubleSearch.ts
@@ -38,6 +38,7 @@ function toTroubleSearchCard(x: CommunityTroubleSearchItem): TroubleSearchCard {
     likeCount: x.likeCount,
     commentCount: x.commentCount,
     postCardUserInfoResDto: x.userInfo,
+    introduction: x.introduction,
   };
 }
 

--- a/src/mappers/cardMapper.ts
+++ b/src/mappers/cardMapper.ts
@@ -8,8 +8,7 @@ export const mapToTroubleShootingCard = (
   isMine: card.isMine,
   errorCategory: card.errorCategory,
   title: card.title,
-  content:
-    "프론트엔드 개발 중 React 앱에서 백엔드 API(Spring Boot 서버)에 데이터를 요청했는데, 브라우저 콘솔에서 CORS policy: No 'Access-Control-Allow-Origin' header 오류가 발생했습니다. 로컬 개발 환경에서는 정상 작동했으나, EC2에 배포한 서버에서만 해당 오류가 발생했습니다.",
+  content: card.introduction ?? "",
   tags: card.tags,
   importance: card.importance,
   createdAt: card.createdAt,

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -26,6 +26,7 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     // thumbnailUrl: t.imageUrl ?? undefined,
     likeCount: t.likeCount ?? undefined,
     commentCount: t.commentCount ?? undefined,
+    introduction: t.introduction ?? undefined,
   };
 };
 

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -24,6 +24,8 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     importance: t.starRating ?? 0,
     summaryType: mapSummaryType(t.summaryType),
     // thumbnailUrl: t.imageUrl ?? undefined,
+    likeCount: t.likeCount ?? undefined,
+    commentCount: t.commentCount ?? undefined,
   };
 };
 

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -95,7 +95,13 @@ export default function CommunityPostDetail() {
   const resumePromptShownRef = useRef<Record<number, boolean>>({});
 
   // 컨텍스트/판정 유틸
-  type FromSource = "home" | "community" | "search" | "mypage" | undefined;
+  type FromSource =
+    | "home"
+    | "community"
+    | "search"
+    | "mypage"
+    | "project"
+    | undefined;
 
   type DetailContentItem = {
     id?: number;
@@ -132,7 +138,7 @@ export default function CommunityPostDetail() {
       String(ownerId) === String(viewerId);
 
     // 포스트 상세를 먼저 시도해야 하는 경우
-    if (from === "home") return true;
+    if (from === "home" || from === "project") return true;
     if (from === "mypage" && isMine) return true;
     if (from === "search" && isMine) return true;
     if (from === "community" && isMine) return true;

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -562,6 +562,12 @@ export default function CommunityPostDetail() {
     }
   };
 
+  // 댓글 1페이지를 강제 새로고침(작성/삭제 직후 사용)
+  const reloadCommentsFirstPage = useCallback(async () => {
+    if (!postId) return;
+    await loadComments(Number(postId), 1, detailCtx.viewerId ?? null);
+  }, [postId, detailCtx.viewerId]);
+
   // 댓글 제출(커뮤니티 글에서만)
   const handleSubmitComment = async () => {
     if (!postId || !isCommunitySource) return;
@@ -591,6 +597,7 @@ export default function CommunityPostDetail() {
         next[i] = mapped;
         return next;
       });
+      await reloadCommentsFirstPage();
     } catch {
       setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
       setPost((p) =>
@@ -628,6 +635,7 @@ export default function CommunityPostDetail() {
         next[i] = mapped;
         return next;
       });
+      await reloadCommentsFirstPage();
     } catch {
       setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
       console.error("대댓글 작성 실패");
@@ -1068,9 +1076,6 @@ export default function CommunityPostDetail() {
                             handleEdit(reply.id, newContent)
                           }
                           onDelete={() => handleDelete(reply.id)}
-                          onReply={(replyContent) =>
-                            handleReply(reply.id, replyContent)
-                          }
                         />
                       ))}
                   </div>

--- a/src/pages/Error/AuthGuardPage.tsx
+++ b/src/pages/Error/AuthGuardPage.tsx
@@ -1,0 +1,83 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+import { useViewerId } from "@/store/auth";
+
+export default function AuthGuardPage() {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const viewerId = useViewerId();
+
+  const params = new URLSearchParams(loc.search);
+  const status = params.get("status") === "403" ? 403 : 401; // default 401
+  const next = params.get("next") || "/";
+
+  const title = status === 403 ? "접근 권한이 없어요" : "로그인이 필요해요";
+  const desc =
+    status === 403
+      ? "이 페이지에 접근할 권한이 없습니다. 권한이 있는 계정으로 다시 시도해 주세요."
+      : "요청하신 페이지를 보려면 로그인이 필요합니다.";
+
+  const goBack = () => {
+    if (window.history.length > 1) nav(-1);
+    else nav(PATH.HOME, { replace: true });
+  };
+
+  const goHome = () => nav(PATH.HOME, { replace: true });
+
+  const goLogin = () => {
+    const sp = new URLSearchParams();
+    sp.set("next", next);
+    nav(`${PATH.ROOT}?${sp.toString()}`, { replace: true });
+  };
+
+  const goMyPage = () => {
+    if (viewerId != null) nav(PATH.MYPAGE(String(viewerId)));
+    else goLogin();
+  };
+
+  return (
+    <main className="w-full flex items-center justify-center py-24 px-6">
+      <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
+        <div className="flex flex-col items-center text-center gap-6">
+          <div className="flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
+            <span className="text-4xl" aria-hidden>
+              {status === 403 ? "🚫" : "🔐"}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h1 className="text-head-32-semibold">{title}</h1>
+            <p className="text-body-16-regular text-gray-500">{desc}</p>
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+            <button
+              onClick={goBack}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              이전 페이지
+            </button>
+            <button
+              onClick={goHome}
+              className="px-4 h-11 rounded-lg bg-primary text-white hover:opacity-90 transition"
+            >
+              홈으로 가기
+            </button>
+            <button
+              onClick={goLogin}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              로그인하기
+            </button>
+            <button
+              onClick={goMyPage}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              {viewerId != null ? "내 마이페이지" : "프로필/로그인"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/Error/NotFoundPage.tsx
+++ b/src/pages/Error/NotFoundPage.tsx
@@ -1,17 +1,10 @@
-import { useMemo } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { PATH } from "@/constants/paths";
 import { useViewerId } from "@/store/auth";
 
 export default function NotFoundPage() {
   const navigate = useNavigate();
-  const location = useLocation();
   const viewerId = useViewerId();
-
-  const missingPath = useMemo(() => {
-    const full = location.pathname + (location.search || "");
-    return full.length > 80 ? full.slice(0, 77) + "..." : full;
-  }, [location.pathname, location.search]);
 
   const goBack = () => {
     // 히스토리가 거의 없는 진입(새로고침/딥링크) 대비
@@ -32,15 +25,6 @@ export default function NotFoundPage() {
     }
   };
 
-  const goSearch = () => {
-    const sp = new URLSearchParams();
-    sp.set("query", "");
-    sp.set("scope", "community");
-    sp.set("page", "1");
-    sp.set("size", "10");
-    navigate(`${PATH.SEARCH}?${sp.toString()}`);
-  };
-
   return (
     <main className="w-full flex items-center justify-center py-24 px-6">
       <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
@@ -56,12 +40,6 @@ export default function NotFoundPage() {
             <p className="text-body-16-regular text-gray-500">
               요청하신 주소가 변경되었거나 삭제되었을 수 있어요.
             </p>
-            <p className="text-body-14-regular text-gray-400">
-              <span className="mr-1">요청 경로:</span>
-              <code className="rounded bg-gray-50 px-2 py-1 text-gray-600">
-                {missingPath || "/"}
-              </code>
-            </p>
           </div>
 
           <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
@@ -76,12 +54,6 @@ export default function NotFoundPage() {
               className="px-4 h-11 rounded-lg bg-primary text-white hover:opacity-90 transition"
             >
               홈으로 가기
-            </button>
-            <button
-              onClick={goSearch}
-              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
-            >
-              검색으로 찾아보기
             </button>
             <button
               onClick={goMyPage}

--- a/src/pages/Error/NotFoundPage.tsx
+++ b/src/pages/Error/NotFoundPage.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+import { useViewerId } from "@/store/auth";
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const viewerId = useViewerId();
+
+  const missingPath = useMemo(() => {
+    const full = location.pathname + (location.search || "");
+    return full.length > 80 ? full.slice(0, 77) + "..." : full;
+  }, [location.pathname, location.search]);
+
+  const goBack = () => {
+    // 히스토리가 거의 없는 진입(새로고침/딥링크) 대비
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate(PATH.HOME, { replace: true });
+    }
+  };
+
+  const goHome = () => navigate(PATH.HOME, { replace: true });
+
+  const goMyPage = () => {
+    if (viewerId != null) {
+      navigate(PATH.MYPAGE(String(viewerId)));
+    } else {
+      navigate(PATH.ROOT);
+    }
+  };
+
+  const goSearch = () => {
+    const sp = new URLSearchParams();
+    sp.set("query", "");
+    sp.set("scope", "community");
+    sp.set("page", "1");
+    sp.set("size", "10");
+    navigate(`${PATH.SEARCH}?${sp.toString()}`);
+  };
+
+  return (
+    <main className="w-full flex items-center justify-center py-24 px-6">
+      <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
+        <div className="flex flex-col items-center text-center gap-6">
+          <div className="flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
+            <span className="text-4xl" aria-hidden>
+              🧭
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h1 className="text-head-32-semibold">페이지를 찾을 수 없어요</h1>
+            <p className="text-body-16-regular text-gray-500">
+              요청하신 주소가 변경되었거나 삭제되었을 수 있어요.
+            </p>
+            <p className="text-body-14-regular text-gray-400">
+              <span className="mr-1">요청 경로:</span>
+              <code className="rounded bg-gray-50 px-2 py-1 text-gray-600">
+                {missingPath || "/"}
+              </code>
+            </p>
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+            <button
+              onClick={goBack}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              이전 페이지
+            </button>
+            <button
+              onClick={goHome}
+              className="px-4 h-11 rounded-lg bg-primary text-white hover:opacity-90 transition"
+            >
+              홈으로 가기
+            </button>
+            <button
+              onClick={goSearch}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              검색으로 찾아보기
+            </button>
+            <button
+              onClick={goMyPage}
+              className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+            >
+              {viewerId != null ? "내 마이페이지" : "로그인/프로필"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -304,6 +304,7 @@ export default function HomePage() {
       {/* Project Folders 영역 */}
       <ProjectAccordion
         title="Project Folders"
+        persistKey="home:project-folders"
         headerExtra={
           <button
             type="button"
@@ -367,7 +368,7 @@ export default function HomePage() {
       </ProjectAccordion>
 
       {/* Recents 영역 */}
-      <ProjectAccordion title="Recents">
+      <ProjectAccordion title="Recents" persistKey="home:recents">
         {isLoadingRecents && recentCards.length === 0 ? (
           <div className="w-full flex h-[330px] justify-center items-center rounded-[16px] bg-white shadow-card">
             <span className="text-body-20-regular">불러오는 중…</span>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -105,6 +105,7 @@ export default function HomePage() {
     error: recentsError,
     hasNext: hasNextRecents,
     sentinelRef: recentsSentinel,
+    reload: recentsReload,
   } = useTroubleCards(
     { type: "all" },
     { infinite: true, pageSize: 10, sortBy: "latest" }
@@ -250,9 +251,21 @@ export default function HomePage() {
     void loadPage(1, { append: false, useOnce: false });
   }, [loadPage]);
 
+  // 프로젝트 폴더 삭제 후 목록 갱신
   const handleCardDeleted = useCallback(() => {
-    void loadPage(1, { append: false, useOnce: false });
-  }, [loadPage]);
+    (async () => {
+      // 프로젝트 목록 갱신
+      await loadPage(1, { append: false, useOnce: false });
+      // Recents 갱신
+      try {
+        await recentsReload?.();
+      } catch (e) {
+        console.error("Recents reload failed", e);
+      }
+      // 삭제 필터 상태 초기화
+      setRemovedRecentIds(new Set());
+    })();
+  }, [loadPage, recentsReload]);
 
   // 트러블슈팅 카드 삭제 후 목록 갱신
   const handleRecentDeleted = useCallback((postId: number) => {

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -27,6 +27,11 @@ export default function ProjectDetailPage() {
   const isInvalid = Number.isNaN(projectId);
   const viewerId = useViewerId();
 
+  // 트러블슈팅 문서 삭제 상태
+  const [removedRecentIds, setRemovedRecentIds] = useState<Set<number>>(
+    new Set()
+  );
+
   // 라우팅 시 폴더 카드에서 넘겨준 이름 사용, 없으면 api로 조회
   const location = useLocation() as { state?: { projectName?: string } };
   const [projectName, setProjectName] = useState<string>(
@@ -132,6 +137,15 @@ export default function ProjectDetailPage() {
     troubleOpts
   );
 
+  // 트러블슈팅 카드 삭제 후 목록 갱신
+  const handleRecentDeleted = useCallback((postId: number) => {
+    setRemovedRecentIds((prev) => {
+      const next = new Set(prev);
+      next.add(postId);
+      return next;
+    });
+  }, []);
+
   return (
     <div className="flex w-full px-[156px] pt-[79px] pb-[158px] flex-col items-start gap-[36px]">
       {/* 상단 나의 프로젝트 텍스트 및 글쓰기 버튼 */}
@@ -228,20 +242,23 @@ export default function ProjectDetailPage() {
             </div>
           ) : (
             <div className="flex flex-wrap justify-center sm:justify-start gap-[24px] w-full">
-              {cards.map((card) => (
-                <TroublogCard
-                  key={card.id}
-                  {...card}
-                  onClick={() => {
-                    const ownerId = card.authorId ?? viewerId;
-                    const qs = new URLSearchParams({ from: "project" });
-                    if (ownerId != null) qs.set("ownerId", String(ownerId));
-                    navigate(
-                      `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
-                    );
-                  }}
-                />
-              ))}
+              {cards
+                .filter((c) => !removedRecentIds.has(c.id))
+                .map((card) => (
+                  <TroublogCard
+                    key={card.id}
+                    {...card}
+                    onDeleted={handleRecentDeleted}
+                    onClick={() => {
+                      const ownerId = card.authorId ?? viewerId;
+                      const qs = new URLSearchParams({ from: "project" });
+                      if (ownerId != null) qs.set("ownerId", String(ownerId));
+                      navigate(
+                        `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+                      );
+                    }}
+                  />
+                ))}
             </div>
           )}
         </ProjectAccordion>

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@/types/trouble.model";
 import { PATH } from "@/constants/paths";
 import useClickOutside from "@/hooks/useClickOutside";
+import { useViewerId } from "@/store/auth";
 
 type VisibilityOption = "전체" | "공개" | "비공개";
 type StatusType = "complete" | "created";
@@ -24,6 +25,7 @@ export default function ProjectDetailPage() {
   const { id: routeProjectId } = useParams<{ id: string }>();
   const projectId = Number(routeProjectId);
   const isInvalid = Number.isNaN(projectId);
+  const viewerId = useViewerId();
 
   // 라우팅 시 폴더 카드에서 넘겨준 이름 사용, 없으면 api로 조회
   const location = useLocation() as { state?: { projectName?: string } };
@@ -227,7 +229,18 @@ export default function ProjectDetailPage() {
           ) : (
             <div className="flex flex-wrap justify-center sm:justify-start gap-[24px] w-full">
               {cards.map((card) => (
-                <TroublogCard key={card.id} {...card} />
+                <TroublogCard
+                  key={card.id}
+                  {...card}
+                  onClick={() => {
+                    const ownerId = card.authorId ?? viewerId;
+                    const qs = new URLSearchParams({ from: "project" });
+                    if (ownerId != null) qs.set("ownerId", String(ownerId));
+                    navigate(
+                      `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+                    );
+                  }}
+                />
               ))}
             </div>
           )}

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -182,7 +182,10 @@ export default function ProjectDetailPage() {
           </span>
         </div>
       ) : (
-        <ProjectAccordion title={titleLoading ? "불러오는 중…" : projectName}>
+        <ProjectAccordion
+          title={titleLoading ? "불러오는 중…" : projectName}
+          persistKey={`project:${projectId}`}
+        >
           <div className="flex flex-col sm:flex-row justify-between gap-4 w-full">
             {/* 작성 상태 필터 버튼 */}
             <div className="flex items-center gap-[24px] self-stretch">

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -22,6 +22,7 @@ import TroubleShootingList from "@/components/MyPage/TroubleShootingList";
 import CommunityPostDetail from "@/pages/Community/CommunityPostDetail";
 import PreviewPage from "@/pages/TempWrite/PreviewPage";
 import NotFoundPage from "@/pages/Error/NotFoundPage";
+import AuthGuardPage from "@/pages/Error/AuthGuardPage";
 
 export const router = createBrowserRouter(
   [
@@ -97,6 +98,8 @@ export const router = createBrowserRouter(
       ),
     },
 
+    // 에러 페이지
+    { path: PATH.AUTH_GUARD, element: <AuthGuardPage /> },
     {
       path: PATH.NOT_FOUND,
       element: <NotFoundPage />,

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,6 +21,7 @@ import CommunityPage from "@/pages/Community/CommunityPage";
 import TroubleShootingList from "@/components/MyPage/TroubleShootingList";
 import CommunityPostDetail from "@/pages/Community/CommunityPostDetail";
 import PreviewPage from "@/pages/TempWrite/PreviewPage";
+import NotFoundPage from "@/pages/Error/NotFoundPage";
 
 export const router = createBrowserRouter(
   [
@@ -94,6 +95,15 @@ export const router = createBrowserRouter(
           <PreviewPage />
         </ProtectedRoute>
       ),
+    },
+
+    {
+      path: PATH.NOT_FOUND,
+      element: <NotFoundPage />,
+    },
+    {
+      path: "*",
+      element: <NotFoundPage />,
     },
   ],
   {

--- a/src/store/useMyPageStore.ts
+++ b/src/store/useMyPageStore.ts
@@ -2,11 +2,16 @@ import { create } from "zustand";
 import type { StatusType } from "@/types/project";
 
 type StatusFilter = StatusType | "all" | null;
+type ViewedUser = { id: number | null; nickname: string | null };
 
 interface MyPageStore {
   selectedStatus: StatusFilter;
   setSelectedStatus: (status: StatusFilter) => void;
   resetSelectedStatus: () => void;
+
+  viewedUser: ViewedUser;
+  setViewedUser: (payload: ViewedUser) => void;
+  resetViewedUser: () => void;
 
   selectedTag: string | null;
   setSelectedTag: (tag: string | null) => void;
@@ -17,6 +22,10 @@ export const useMyPageStore = create<MyPageStore>((set) => ({
   selectedStatus: "all",
   setSelectedStatus: (status) => set({ selectedStatus: status }),
   resetSelectedStatus: () => set({ selectedStatus: "all" }),
+
+  viewedUser: { id: null, nickname: null },
+  setViewedUser: (payload) => set({ viewedUser: payload }),
+  resetViewedUser: () => set({ viewedUser: { id: null, nickname: null } }),
 
   selectedTag: null,
   setSelectedTag: (tag) => set({ selectedTag: tag }),

--- a/src/types/trouble.model.ts
+++ b/src/types/trouble.model.ts
@@ -19,6 +19,7 @@ export interface TroubleListItem {
   summaryType: TroubleSummaryType | string;
   likeCount: number | undefined;
   commentCount: number | undefined;
+  introduction?: string;
 }
 
 // 페이징 응답(서버가 ApiResponse로 감싸지 않는 케이스)

--- a/src/types/trouble.model.ts
+++ b/src/types/trouble.model.ts
@@ -17,6 +17,8 @@ export interface TroubleListItem {
   techs: string[];
   status: TroubleStatus | string;
   summaryType: TroubleSummaryType | string;
+  likeCount: number | undefined;
+  commentCount: number | undefined;
 }
 
 // 페이징 응답(서버가 ApiResponse로 감싸지 않는 케이스)

--- a/src/types/troubles.server.ts
+++ b/src/types/troubles.server.ts
@@ -18,6 +18,7 @@ export interface TroubleSearchCard {
   postTags: string[];
   likeCount: number;
   commentCount: number;
+  introduction: string | null;
 }
 
 export type MyTroubleSearchPage = PaginatedResponse<TroubleSearchCard>;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,22 @@
+export const toInternalSpaPath = (input?: string | null): string | null => {
+  if (!input) return null;
+
+  // 이미 내부 경로라면 그대로
+  if (input.startsWith("/") || input.startsWith("?") || input.startsWith("#")) {
+    return input;
+  }
+
+  // 위험 스킴 차단
+  if (/^[a-z][a-z0-9+.-]*:/i.test(input)) {
+    try {
+      const u = new URL(input);
+      if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+      return u.pathname + u.search + u.hash; // http/https 절대 URL → 경로만 사용
+    } catch {
+      return null;
+    }
+  }
+
+  // 도메인 없는 상대 경로 → 내부 경로로 정규화
+  return input.startsWith("/") ? input : `/${input}`;
+};


### PR DESCRIPTION
## 🔥 Issues

- closed #99 

## ✅ What to do

- [x] 내 트러블슈팅 문서 조회 API / 커뮤니티 트러블슈팅 문서 조회 API 호출 로직 정리
- [x] 프로젝트 상세 화면에서 트러블슈팅 문서 삭제 시 목록 갱신
- [x] 틀정 사용자 페이지에서 검색창 placeholder에 id 대신 사용자명 포함시키기
- [x] 404 / 401, 403 에러 반환 시 `NotFoundPage` / `AuthGuardPage`로 라우팅
- [x] 알림 클릭 시 링크 이동 배포 환경에서도 잘 작동하도록 url 정규화
- [x] 아코디언 메뉴 열림/닫힘 상태 유지
- [x] 토큰 재발급 오류 수정
- [x] 커뮤니티 포스트 댓글 입력 시 목록 갱신, 대댓글에는 대댓글 달지 못하도록 막기
- [x] 다른 사용자의 페이지에서 트러블슈팅 문서 좋아요, 댓글 수 표시
- [x] 트러블슈팅 문서 목록에 소개글 표시

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 404 페이지와 인증 필요 페이지 추가, 라우팅 반영
  - 아코디언 펼침 상태가 사용자·섹션별로 영구 저장
  - 댓글/대댓글 작성 후 목록 자동 새로고침
  - 트러블 카드에 소개 문구 노출

- 개선
  - 인증/토큰 갱신 흐름 개선으로 중복 이동 및 방해 감소
  - 사용자 페이지에서 닉네임 기반 플레이스홀더 표시
  - 알림 클릭 시 내부 경로만 안전하게 이동
  - 내 게시물에는 좋아요/댓글 수 숨김
  - 마이페이지 빈 상태 메시지·정렬 표시 최적화
  - 답글 달기 버튼을 가능한 경우에만 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->