### PR TITLE
FEAT: 카카오 로그인 새 주소 연결

### DIFF
--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -6,7 +6,7 @@ import TagList from "./TagList";
 import type { StatusType, VisibilityType } from "@/types/project";
 import { PATH } from "@/constants/paths";
 import { useCallback, useState } from "react";
-import { deletePost } from "@/api/post.api";
+import { hardDeletePost } from "@/api/post.api";
 
 export interface TroublogCardProps {
   id: number;
@@ -76,7 +76,7 @@ export default function TroublogCard({
 
     try {
       setDeleting(true);
-      await deletePost(id);
+      await hardDeletePost(id);
       onDeleted?.(id); // 부모에 알림(목록 갱신)
     } catch (err: any) {
       console.error(err);

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -1,48 +1,21 @@
 import kakaoLogoIcon from "@/assets/icons/kakaologo.svg";
-import { ensureKakaoReady } from "./kakaoLoader";
 import { KAKAO_REDIRECT_URI } from "../../config";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 const KakaoLoginButton = () => {
-  const [loading, setLoading] = useState(false);
-  const redirectUri = KAKAO_REDIRECT_URI;
+  const redirectUri = KAKAO_REDIRECT_URI; // 재현님 만드신 링크
   const navigate = useNavigate();
 
-  // const onKakaoLogin = async () => {
-  //   try {
-  //     setLoading(true);
-  //     const Kakao = await ensureKakaoReady();
-  //     Kakao.Auth.authorize({
-  //       redirectUri,
-  //       scope: "profile_nickname",
-  //       throughTalk: false,
-  //     });
-  //   } catch (e) {
-  //     console.error(e);
-  //     alert("카카오 로그인 초기화에 실패했습니다.");
-  //     setLoading(false);
-  //   }
-  // };
-
-  // // 외부 URL이면 이걸 권장
-  // const handleClick = () => {
-  //   window.location.assign(redirectUri); // 또는 window.location.href = redirectUri
-  // };
-  //
   const handleClick = () => navigate(redirectUri);
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={loading}
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
       <img src={kakaoLogoIcon} className="w-[18px] h-[18px]" alt="kakao" />
-      <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
-        {loading ? "초기화 중..." : "카카오 로그인"}
-      </span>
+      <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard"></span>
     </button>
   );
 };


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 새로운 카카오로그인 링크로 userId 받아오기

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 카카오 로그인 버튼 동작을 단순화하여 클릭 시 즉시 카카오 인증 페이지로 이동합니다.

- **Style**
  - 버튼의 로딩 표시와 비활성화 상태를 제거했습니다.
  - 동적 라벨을 제거하고 카카오 로고만 표시하도록 UI를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->