### PR TITLE
FEAT: 요약 합본 조회 라우팅

### DIFF
--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -27,6 +27,10 @@ export interface TroublogCardProps {
   onAvatarClick?: () => void;
   onDeleted?: (id: number) => void;
   introduction?: string;
+
+  summaryId?: number | null;
+  postSummaryId?: number | null;
+  summaries?: any[];
 }
 
 export default function TroublogCard({

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -32,6 +32,10 @@ export interface TroubleShootingCardProps {
   onDeleted?: (postId: number) => void;
   onClick?: (postId: number) => void;
   disabled?: boolean;
+
+  summaryId?: number | null;
+  postSummaryId?: number | null;
+  summaries?: any[];
 }
 
 const TroubleShootingCard = ({

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -6,6 +6,7 @@ import { useMyPageStore } from "@/store/useMyPageStore";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import { PATH } from "@/constants/paths";
 import { useViewerId } from "@/store/auth";
+import { decideCombined } from "@/utils/combinedRoute";
 
 interface OutletContextType {
   isMyPage: boolean;
@@ -141,10 +142,18 @@ const TroubleShootingList = () => {
             {...mapToTroubleShootingCard(card)}
             onDeleted={handleDeleted}
             onClick={() => {
-              const qs = new URLSearchParams({ from: "mypage" });
-              if (isMyPage) {
-                qs.set("ownerId", String(viewerId));
+              const { goCombined, summaryId } = decideCombined(card, viewerId);
+
+              if (goCombined && summaryId != null) {
+                navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
+                  state: { from: "mypage", ownerId: viewerId ?? undefined },
+                });
+                return;
               }
+
+              const qs = new URLSearchParams({ from: "mypage" });
+              if (isMyPage && viewerId != null)
+                qs.set("ownerId", String(viewerId));
               navigate(`${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`, {
                 state: { from: "mypage" },
               });

--- a/src/mappers/cardMapper.ts
+++ b/src/mappers/cardMapper.ts
@@ -18,4 +18,8 @@ export const mapToTroubleShootingCard = (
   status: card.status,
   likeCount: card.likeCount,
   commentCount: card.commentCount,
+
+  summaryId: card.summaryId ?? null,
+  postSummaryId: (card as any).postSummaryId ?? null,
+  summaries: (card as any).summaries ?? [],
 });

--- a/src/mappers/trouble.list-to-ts-card.ts
+++ b/src/mappers/trouble.list-to-ts-card.ts
@@ -6,6 +6,7 @@ import type {
   TroubleSearchCard,
   UserBrief,
 } from "@/types/troubles.server";
+import { pickLatestSummaryId } from "@/utils/combinedRoute";
 import { formatYYMMDD } from "@/utils/troubleFormat";
 
 // 타입 가드
@@ -127,5 +128,9 @@ export const toTroubleShootingCard = (
     authorProfileImageUrl,
     authorUserId,
     isSearchResult,
+
+    summaryId: pickLatestSummaryId(item),
+    postSummaryId: (item as any).postSummaryId ?? null,
+    summaries: (item as any).summaries ?? [],
   } as TroubleShootingCardProps;
 };

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -1,5 +1,6 @@
 import type { TroublogCardProps } from "@/components/Card/TroublogCard";
 import type { TroubleListItem } from "@/types/trouble.model";
+import { pickLatestSummaryId } from "@/utils/combinedRoute";
 import { formatYYMMDD } from "@/utils/troubleFormat";
 import {
   mapStatus,
@@ -27,6 +28,10 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     likeCount: t.likeCount ?? undefined,
     commentCount: t.commentCount ?? undefined,
     introduction: t.introduction ?? undefined,
+
+    summaryId: pickLatestSummaryId(t),
+    postSummaryId: t.postSummaryId ?? null,
+    summaries: t.summaries ?? [],
   };
 };
 

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -6,6 +6,7 @@ import useCommunityCards, {
   type CommunityCardsFetcher,
 } from "@/hooks/useCommunityCards";
 import type { CommunitySort } from "@/types/community.model";
+import { decideCombined } from "@/utils/combinedRoute";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -123,9 +124,17 @@ export default function CommunityPage() {
                 const ownerId = card.authorId;
                 const qs = new URLSearchParams({ from: "community" });
                 if (ownerId != null) qs.set("ownerId", String(ownerId));
-                navigate(`${PATH.COMMUNITY_POST(id)}?${qs.toString()}`, {
-                  state: { from: "community", ownerId },
-                });
+
+                const { goCombined, summaryId } = decideCombined(card);
+                if (goCombined && summaryId != null) {
+                  navigate(PATH.COMBINED_DETAIL(id, summaryId), {
+                    state: { from: "community", ownerId },
+                  });
+                } else {
+                  navigate(`${PATH.COMMUNITY_POST(id)}?${qs.toString()}`, {
+                    state: { from: "community", ownerId },
+                  });
+                }
               }}
               onAvatarClick={() => {
                 if (card.authorId != null)

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -16,6 +16,7 @@ import { PATH } from "@/constants/paths";
 import { useNavigate } from "react-router-dom";
 import plusIcon from "@/assets/icons/plus.svg";
 import { useViewerId } from "@/store/auth";
+import { decideCombined } from "@/utils/combinedRoute";
 
 const PAGE_SIZE = 10;
 
@@ -412,9 +413,20 @@ export default function HomePage() {
                       const ownerId = card.authorId ?? viewerId;
                       const qs = new URLSearchParams({ from: "home" });
                       if (ownerId != null) qs.set("ownerId", String(ownerId));
-                      navigate(
-                        `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+
+                      const { goCombined, summaryId } = decideCombined(
+                        card,
+                        viewerId
                       );
+                      if (goCombined && summaryId != null) {
+                        navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
+                          state: { from: "home", ownerId },
+                        });
+                      } else {
+                        navigate(
+                          `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+                        );
+                      }
                     }}
                     onAvatarClick={() => {
                       if (viewerId != null)

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -6,6 +6,11 @@ import PostCombineMd from "./PostCombineMd";
 import KebabDropdown from "@/components/Menu/KebabDropdown";
 import KebabMenuButton from "@/components/Menu/KebabMenuButton";
 import HeaderWoSearch from "@/components/Header/HeaderWoSearch";
+import imageIcon from "@/assets/icons/image.svg";
+import starIcon from "@/assets/icons/star.svg";
+import heartIcon from "@/assets/icons/heart.svg";
+import likeEmptyIcon from "@/assets/icons/like_empty.svg";
+import shareIcon from "@/assets/icons/share.svg";
 import { PATH } from "@/constants/paths";
 
 import {
@@ -16,6 +21,22 @@ import {
 import type { ViewCombinedResponse } from "@/models/post.model";
 import { toTwoPaneVM } from "@/mappers/combinedDetail.mapper";
 import { useViewerId } from "@/store/auth";
+import PostComment, {
+  type PostCommentProps,
+} from "@/components/Community/PostComment";
+import {
+  createCommunityComment,
+  getCommunityComments,
+  getCommunityPostDetail,
+  likeCommunityPost,
+  replyCommunityComment,
+  softDeleteCommunityComment,
+  updateCommunityComment,
+} from "@/api/community.api";
+import {
+  toPostComment,
+  toPostComments,
+} from "@/mappers/communityComment.mapper";
 
 export default function CombinedDetailPage() {
   const { postId, summaryId } = useParams<{
@@ -34,6 +55,130 @@ export default function CombinedDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
+  // 기존 state들 아래에 추가
+  const [isMine, setIsMine] = useState(false);
+  const [importance, setImportance] = useState(0);
+  const [authorId, setAuthorId] = useState<number | null>(null);
+  const [authorName, setAuthorName] = useState("");
+  const [authorProfile, setAuthorProfile] = useState<string | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeCounts, setLikeCounts] = useState(0);
+  const [isLiking, setIsLiking] = useState(false);
+  const likeLockRef = useRef(false);
+
+  const [commentCounts, setCommentCounts] = useState(0);
+  const [comments, setComments] = useState<PostCommentProps[]>([]);
+  const [commentInput, setCommentInput] = useState("");
+  const [isCommentPosting, setIsCommentPosting] = useState(false);
+  const [cPage, setCPage] = useState(1);
+  const [cHasNext, setCHasNext] = useState(false);
+  const [cLoading, setCLoading] = useState(false);
+
+  // 뷰 모드 결정
+  const viewMode: "mine_public" | "mine_private" | "others" = isMine
+    ? isVisible
+      ? "mine_public"
+      : "mine_private"
+    : "others";
+
+  // 표시 게이트
+  const showCombined = viewMode !== "others";
+  const showAuthorCard = viewMode === "mine_public" || viewMode === "others";
+  const showSocial =
+    isVisible && (viewMode === "mine_public" || viewMode === "others");
+
+  // 공유 토스트
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
+  const showToast = (message: string) => {
+    setToast({ open: true, message });
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(
+      () => setToast({ open: false, message: "" }),
+      2000
+    );
+  };
+  const copyToClipboard = async (text: string) => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+    } catch (e) {
+      // 일부 환경/권한에서 Clipboard API가 실패할 수 있음 — 폴백으로 진행
+      console.warn("Clipboard API failed, falling back.", e);
+    }
+    // textarea 폴백
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.top = "-9999px";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    let ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } finally {
+      document.body.removeChild(ta);
+    }
+    return ok;
+  };
+
+  const handleCopyLink = async () => {
+    const ok = await copyToClipboard(window.location.href);
+    showToast(
+      ok
+        ? "링크가 복사되었어요!"
+        : "복사에 실패했어요. 주소창에서 복사해주세요."
+    );
+  };
+
+  // enum/문자 → 숫자 (중요도)
+  const parseStar = (raw: unknown) => {
+    if (typeof raw === "number") return raw;
+    if (typeof raw !== "string") return 0;
+    const k = raw.toUpperCase();
+    const map: Record<string, number> = {
+      ONE_STAR: 1,
+      TWO_STARS: 2,
+      THREE_STARS: 3,
+      FOUR_STARS: 4,
+      FIVE_STARS: 5,
+      ONE: 1,
+      TWO: 2,
+      THREE: 3,
+      FOUR: 4,
+      FIVE: 5,
+      NONE: 0,
+    };
+    return map[k] ?? 0;
+  };
+
+  // 요약 타입 한글 라벨
+  const SUMMARY_TYPE_LABELS: Record<string, string> = {
+    RESUME: "자기소개서",
+    INTERVIEW: "면접 대비",
+    BLOG: "블로그",
+    ISSUE_MANAGEMENT: "Issue 관리",
+    SHORT: "짧은 요약",
+    NONE: "없음",
+  };
+  const toKoSummaryType = (raw?: string | null) =>
+    raw ? SUMMARY_TYPE_LABELS[raw] ?? raw : null;
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -41,12 +186,59 @@ export default function CombinedDetailPage() {
         setLoading(true);
         const pid = Number(postId);
         const sid = Number(summaryId);
-        if (!Number.isFinite(pid) || !Number.isFinite(sid)) {
+        if (!Number.isFinite(pid) || !Number.isFinite(sid))
           throw new Error("잘못된 경로 파라미터");
-        }
+
         const data = await getCombinedDetail(pid, sid);
-        if (!cancelled)
-          setVm(toTwoPaneVM(data as ViewCombinedResponse, viewerId ?? null));
+
+        // 기존 vm 세팅
+        setVm(toTwoPaneVM(data as ViewCombinedResponse, viewerId ?? null));
+
+        // 합본 응답에서 상단/하단용 데이터 추출
+        const post = (data as any)?.postResDto;
+        const user = post?.userInfo ?? {};
+        const mine =
+          viewerId != null && String(user?.userId) === String(viewerId);
+
+        if (!cancelled) {
+          setIsMine(mine);
+          setImportance(parseStar(post?.starRating));
+          setAuthorId(user?.userId ?? null);
+          setAuthorName(user?.nickname ?? "");
+          setAuthorProfile(user?.profileImageUrl || null);
+          setIsVisible(!!post?.isVisible);
+          setLikeCounts(Number(post?.likeCount ?? 0));
+          setCommentCounts(Number(post?.commentCount ?? 0));
+        }
+
+        // 공개글이면 커뮤니티 상세/댓글 로딩 (좋아요 상태 가져오기 & 댓글 리스트)
+        if (post?.isVisible && Number.isFinite(pid)) {
+          try {
+            const community = await getCommunityPostDetail(pid);
+            const initLiked = !!community?.liked;
+            const initLikeCount = Number(community?.likeCount ?? likeCounts);
+            if (!cancelled) {
+              setIsLiked(initLiked);
+              setLikeCounts(initLikeCount);
+            }
+          } catch {
+            /* 커뮤 상세 실패해도 진행 */
+          }
+
+          // 1페이지 댓글
+          try {
+            const resp = await getCommunityComments(pid, 1, 10);
+            const mapped = toPostComments(resp.content, viewerId ?? null);
+            if (!cancelled) {
+              setComments(mapped);
+              setCPage((resp.page ?? 1) + 1);
+              setCHasNext(!!resp.hasNext);
+              setCommentCounts(resp.totalElements ?? commentCounts);
+            }
+          } catch {
+            /* ignore */
+          }
+        }
       } catch (e: any) {
         if (!cancelled) setErr(e?.message ?? "합본 상세 불러오기 실패");
       } finally {
@@ -57,6 +249,177 @@ export default function CombinedDetailPage() {
       cancelled = true;
     };
   }, [postId, summaryId, viewerId]);
+
+  // 댓글 페이징/갱신 핸들러
+  const loadComments = async (
+    id: number,
+    page1: number,
+    currentViewerId: number | null
+  ) => {
+    setCLoading(true);
+    try {
+      const resp = await getCommunityComments(id, page1, 10);
+      const mapped = toPostComments(resp.content, currentViewerId);
+      setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
+      setCPage((resp.page ?? page1) + 1);
+      setCHasNext(!!resp.hasNext);
+      setCommentCounts(resp.totalElements ?? commentCounts);
+    } finally {
+      setCLoading(false);
+    }
+  };
+  const reloadCommentsFirstPage = useCallback(async () => {
+    if (!postId) return;
+    await loadComments(Number(postId), 1, viewerId ?? null);
+  }, [postId, viewerId]);
+
+  // 좋아요/댓글 작성 핸들러
+  const handleToggleLike = async () => {
+    if (!postId || !isVisible) return;
+    if (likeLockRef.current) return;
+    likeLockRef.current = true;
+    setIsLiking(true);
+    const pid = Number(postId);
+    const wasLiked = isLiked;
+    const prev = likeCounts;
+
+    if (wasLiked) {
+      setIsLiked(false);
+      setLikeCounts(Math.max(0, prev - 1));
+      try {
+        await likeCommunityPost(pid);
+      } catch {
+        setIsLiked(true);
+        setLikeCounts(prev);
+      }
+    } else {
+      setIsLiked(true);
+      setLikeCounts(prev + 1);
+      try {
+        const res = await likeCommunityPost(pid);
+        setLikeCounts(res?.likeCount ?? prev + 1);
+      } catch {
+        setIsLiked(false);
+        setLikeCounts(prev);
+      }
+    }
+    likeLockRef.current = false;
+    setIsLiking(false);
+  };
+
+  const handleSubmitComment = async () => {
+    if (!postId || !isVisible) return;
+    const contents = commentInput.trim();
+    if (!contents || isCommentPosting) return;
+    setIsCommentPosting(true);
+
+    // 낙관적
+    const optimistic: PostCommentProps = {
+      id: `tmp-${Date.now()}`,
+      profile: authorProfile ?? "",
+      name: "나",
+      date: new Date().toISOString(),
+      content: contents,
+      isMine: true,
+      isReply: false,
+    };
+
+    setComments((prev) => [optimistic, ...prev]);
+    setCommentCounts((cnt) => cnt + 1);
+    setCommentInput("");
+
+    try {
+      const created = await createCommunityComment(Number(postId), {
+        contents,
+      });
+      const mapped = toPostComment(created, viewerId ?? null, {
+        isReply: false,
+      });
+      setComments((prev) => {
+        const i = prev.findIndex((c) => c.id === optimistic.id);
+        if (i === -1) return [mapped, ...prev];
+        const next = [...prev];
+        next[i] = mapped;
+        return next;
+      });
+      await reloadCommentsFirstPage();
+    } catch {
+      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+      setCommentCounts((cnt) => Math.max(0, cnt - 1));
+      setCommentInput(contents);
+    } finally {
+      setIsCommentPosting(false);
+    }
+  };
+
+  const handleReply = async (parentId: string, replyContent: string) => {
+    if (!postId || !isVisible) return;
+    const contents = replyContent.trim();
+    if (!contents) return;
+    const optimistic: PostCommentProps = {
+      id: `tmp-${Date.now()}`,
+      profile: authorProfile ?? "",
+      name: "나",
+      date: new Date().toISOString(),
+      content: contents,
+      isMine: true,
+      isReply: true,
+      parentId,
+    };
+
+    setComments((prev) => [...prev, optimistic]);
+    try {
+      const created = await replyCommunityComment(
+        Number(postId),
+        Number(parentId),
+        { contents }
+      );
+      const mapped = toPostComment(created, viewerId ?? null, {
+        isReply: true,
+        parentId,
+      });
+      setComments((prev) => {
+        const i = prev.findIndex((c) => c.id === optimistic.id);
+        if (i === -1) return [...prev, mapped];
+        const next = [...prev];
+        next[i] = mapped;
+        return next;
+      });
+      await reloadCommentsFirstPage();
+    } catch {
+      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+    }
+  };
+
+  const handleEdit = async (id: string, newContent: string) => {
+    if (!postId || !isVisible) return;
+    try {
+      const updated = await updateCommunityComment({
+        postId: Number(postId),
+        commentId: Number(id),
+        contents: newContent,
+      });
+      const vm = toPostComment(updated, viewerId ?? null);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, content: vm.content, date: vm.date } : c
+        )
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!isVisible) return;
+    try {
+      await softDeleteCommunityComment(Number(id));
+      setComments((prev) => prev.filter((c) => c.id !== id));
+      setCommentCounts((cnt) => Math.max(0, cnt - 1));
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   const goEditOriginal = useCallback(async () => {
     if (!postId) return;
@@ -151,11 +514,42 @@ export default function CombinedDetailPage() {
                 </div>
               </div>
             </div>
+
+            <div className="flex w-full items-center justify-between">
+              <div className="flex items-center gap-[20px]">
+                <img
+                  src={authorProfile || imageIcon}
+                  onError={(e) => {
+                    e.currentTarget.src = imageIcon;
+                  }}
+                  alt="profile"
+                  className="w-[66px] h-[66px] rounded-full object-cover"
+                />
+                <div className="text-head-24-bold">{authorName}</div>
+              </div>
+
+              {isMine && importance > 0 && (
+                <div className="flex items-center gap-[8px]">
+                  <img
+                    src={starIcon}
+                    alt="importance"
+                    className="w-[24px] h-[24px]"
+                  />
+                  <div className="text-body-20-regular text-gray3">
+                    {importance}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
         </div>
 
         {/* 본문: 좌(원본) | 우(요약) */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-[32px] w-full">
+        <div
+          className={`grid gap-[32px] w-full ${
+            showCombined ? "grid-cols-1 lg:grid-cols-2" : "grid-cols-1"
+          }`}
+        >
           {/* 왼쪽: 원본 */}
           <section className="flex flex-col gap-[24px]">
             <div className="text-head-24-bold">원본</div>
@@ -171,34 +565,190 @@ export default function CombinedDetailPage() {
           </section>
 
           {/* 오른쪽: 요약 */}
-          <section className="flex flex-col gap-[24px]">
-            <div className="flex items-center gap-[12px]">
-              <div className="text-head-24-bold">요약</div>
-              {vm.right.summaryType && (
-                <span className="text-body-16-regular text-gray3">
-                  ({vm.right.summaryType})
-                </span>
+          {showCombined && (
+            <section className="flex flex-col gap-[24px] lg:border-l lg:border-gray1 lg:pl-[32px]">
+              <div className="flex items-center gap-[12px]">
+                <div className="text-head-24-bold">요약</div>
+                {vm.right.summaryType && (
+                  <span className="text-body-16-regular text-gray3">
+                    ({toKoSummaryType(vm.right.summaryType)})
+                  </span>
+                )}
+              </div>
+
+              {vm.right.questions.length === 0 ? (
+                <div className="text-body-18-regular text-gray3">
+                  아직 생성된 요약이 없어요.
+                </div>
+              ) : (
+                <div className="flex flex-col gap-[32px]">
+                  {vm.right.questions.map((q, i) => (
+                    <PostCombineMd
+                      key={`R-${i}`}
+                      question={q}
+                      content={vm.right.contents[i]}
+                    />
+                  ))}
+                </div>
               )}
+            </section>
+          )}
+        </div>
+
+        {/* ===== 본문 하단 영역 ===== */}
+        {/* 작성자 정보 카드 */}
+        {showAuthorCard && (
+          <div className="flex py-[32px] px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[36px] bg-[#F2F2F2]">
+            <div className="flex justify-between items-center self-stretch">
+              <div
+                className="flex items-center gap-[28px] cursor-pointer"
+                onClick={() =>
+                  authorId && navigate(PATH.MYPAGE(String(authorId)))
+                }
+              >
+                <img
+                  src={authorProfile || imageIcon}
+                  onError={(e) => {
+                    e.currentTarget.src = imageIcon;
+                  }}
+                  alt="profile"
+                  className="w-[131px] h-[131px] rounded-full object-cover"
+                />
+                <div className="flex flex-col items-start gap-[13px]">
+                  <div className="text-head-24-bold">{authorName}</div>
+                  <div className="text-body-16-regular text-gray3">작성자</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 좋아요/공유 */}
+        {showSocial && (
+          <div className="flex pt-[52px] pb-[20px] items-center self-stretch border-b border-gray1">
+            <div className="flex items-center gap-[20px]">
+              <button
+                type="button"
+                aria-pressed={isLiked}
+                aria-busy={isLiking}
+                disabled={isLiking}
+                onClick={handleToggleLike}
+                className={`flex items-center gap-[8px] ${
+                  isLiking ? "opacity-60 cursor-not-allowed" : "cursor-pointer"
+                }`}
+              >
+                <img
+                  src={isLiked ? heartIcon : likeEmptyIcon}
+                  alt="like"
+                  className="w-[40px] h-[40px]"
+                />
+                <div className="text-body-20-regular text-gray3">
+                  {likeCounts}
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={handleCopyLink}
+                className="cursor-pointer"
+                aria-label="현재 페이지 링크 복사"
+              >
+                <img
+                  src={shareIcon}
+                  alt="share"
+                  className="w-[40px] h-[40px]"
+                />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 댓글 작성 */}
+        {showSocial && (
+          <>
+            {/* 작성 */}
+            <div className="flex flex-col items-end gap-[12px] self-stretch">
+              <div className="flex flex-col items-start gap-[36px] self-stretch">
+                <div className="text-head-32-semibold">
+                  {commentCounts}개의 댓글
+                </div>
+                <textarea
+                  value={commentInput}
+                  onChange={(e) => setCommentInput(e.target.value)}
+                  placeholder="댓글을 작성해주세요."
+                  className="flex pt-[28px] pl-[32px] pb-[130px] w-full items-start self-stretch resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
+                />
+              </div>
+
+              <button
+                disabled={!commentInput.trim() || isCommentPosting}
+                onClick={handleSubmitComment}
+                className={`flex pt-[8px] pl-[32px] pb-[12px] pr-[31px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
+                  commentInput.trim() && !isCommentPosting
+                    ? "bg-primary"
+                    : "bg-subColor1"
+                }`}
+              >
+                {isCommentPosting ? "작성 중…" : "작성하기"}
+              </button>
             </div>
 
-            {vm.right.questions.length === 0 ? (
-              <div className="text-body-18-regular text-gray3">
-                아직 생성된 요약이 없어요.
-              </div>
-            ) : (
-              <div className="flex flex-col gap-[32px]">
-                {vm.right.questions.map((q, i) => (
-                  <PostCombineMd
-                    key={`R-${i}`}
-                    question={q}
-                    content={vm.right.contents[i]}
-                  />
+            {/* 목록 */}
+            <div className="flex flex-col items-end self-stretch">
+              {comments
+                .filter((c) => !c.isReply)
+                .map((parent) => (
+                  <div key={parent.id} className="w-full">
+                    <PostComment
+                      {...parent}
+                      onEdit={(newContent) => handleEdit(parent.id, newContent)}
+                      onDelete={() => handleDelete(parent.id)}
+                      onReply={(replyContent) =>
+                        handleReply(parent.id, replyContent)
+                      }
+                    />
+                    {comments
+                      .filter((c) => c.parentId === parent.id)
+                      .map((reply) => (
+                        <PostComment
+                          key={reply.id}
+                          {...reply}
+                          onEdit={(newContent) =>
+                            handleEdit(reply.id, newContent)
+                          }
+                          onDelete={() => handleDelete(reply.id)}
+                        />
+                      ))}
+                  </div>
                 ))}
-              </div>
-            )}
-          </section>
-        </div>
+
+              {cHasNext && postId && (
+                <button
+                  disabled={cLoading}
+                  onClick={() =>
+                    loadComments(Number(postId), cPage, viewerId ?? null)
+                  }
+                  className={`mt-4 px-6 py-2 rounded-full text-white ${
+                    cLoading ? "bg-gray-300" : "bg-primary"
+                  }`}
+                >
+                  {cLoading ? "불러오는 중…" : "댓글 더 보기"}
+                </button>
+              )}
+            </div>
+          </>
+        )}
       </div>
+
+      {toast.open && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-8 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-black text-white text-body-16-regular shadow-card z-50"
+        >
+          {toast.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -16,6 +16,7 @@ import type {
 import { PATH } from "@/constants/paths";
 import useClickOutside from "@/hooks/useClickOutside";
 import { useViewerId } from "@/store/auth";
+import { decideCombined } from "@/utils/combinedRoute";
 
 type VisibilityOption = "전체" | "공개" | "비공개";
 type StatusType = "complete" | "created";
@@ -256,9 +257,20 @@ export default function ProjectDetailPage() {
                       const ownerId = card.authorId ?? viewerId;
                       const qs = new URLSearchParams({ from: "project" });
                       if (ownerId != null) qs.set("ownerId", String(ownerId));
-                      navigate(
-                        `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+
+                      const { goCombined, summaryId } = decideCombined(
+                        card,
+                        viewerId
                       );
+                      if (goCombined && summaryId != null) {
+                        navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
+                          state: { from: "project", ownerId },
+                        });
+                      } else {
+                        navigate(
+                          `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
+                        );
+                      }
                     }}
                   />
                 ))}

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -6,6 +6,7 @@ import { useInfiniteUserTroubleSearch } from "@/hooks/useInfiniteUserTroubleSear
 import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useViewerId } from "@/store/auth";
+import { decideCombined } from "@/utils/combinedRoute";
 
 const SearchResultPage = () => {
   const location = useLocation();
@@ -161,24 +162,35 @@ const SearchResultPage = () => {
                   blocked || !idValid
                     ? undefined
                     : () => {
-                        // 상세 페이지로 이동하면서 검색 범위/출처를 명시
-                        // - 쿼리로도 넘겨서 (새로고침/딥링크) 안전하게 유지
-                        const url = `${PATH.COMMUNITY_POST(
-                          idNum
-                        )}?from=search&scope=${scopeForDetail}`;
-
+                        const { goCombined, summaryId } = decideCombined(
+                          card,
+                          viewerId
+                        );
                         const ownerIdForState =
                           card.isMine && viewerId != null
                             ? Number(viewerId)
                             : undefined;
 
-                        navigate(url, {
-                          state: {
-                            from: "search",
-                            searchScope: scopeForDetail, // 상세에서 useDetailContext().searchScope 로 읽음
-                            ownerId: ownerIdForState,
-                          },
-                        });
+                        if (goCombined && summaryId != null) {
+                          navigate(PATH.COMBINED_DETAIL(idNum, summaryId), {
+                            state: {
+                              from: "search",
+                              searchScope: scopeForDetail,
+                              ownerId: ownerIdForState,
+                            },
+                          });
+                        } else {
+                          const url = `${PATH.COMMUNITY_POST(
+                            idNum
+                          )}?from=search&scope=${scopeForDetail}`;
+                          navigate(url, {
+                            state: {
+                              from: "search",
+                              searchScope: scopeForDetail,
+                              ownerId: ownerIdForState,
+                            },
+                          });
+                        }
                       }
                 }
                 disabled={blocked || !idValid}

--- a/src/pages/TempWrite/PostSuccessModal.tsx
+++ b/src/pages/TempWrite/PostSuccessModal.tsx
@@ -7,11 +7,21 @@ import postSuccessIcon from "@/assets/icons/postsuccess.svg";
 export default function PostSuccessModal({
   onClose,
   summaryId,
+  postId,
 }: {
   onClose: () => void;
   summaryId?: number;
+  postId?: number;
 }) {
   const navigate = useNavigate();
+
+  const goCombined = () => {
+    if (summaryId == null || postId == null) {
+      alert("요약 상세로 이동할 수 없어요. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+    navigate(PATH.COMBINED_DETAIL(postId, summaryId));
+  };
 
   return (
     <BaseModal
@@ -34,10 +44,7 @@ export default function PostSuccessModal({
           </span>
           <button
             className="flex w-[184px] h-[46px] px-[25px] py-[14px] justify-center items-center rounded-[50px] bg-purple-500 border-purple-500 text-white text-semibold"
-            onClick={() => {
-              if (summaryId == null) return; // 혹은 alert("요약 ID를 찾을 수 없어요.")
-              navigate(PATH.POST_SUMMARY(summaryId));
-            }}
+            onClick={goCombined}
           >
             완성 페이지로 이동
           </button>

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -833,6 +833,7 @@ const TempWritePage = () => {
             <PostSuccessModal
               onClose={() => setIsSuccessModalOpen(false)}
               summaryId={completedSummaryId}
+              postId={createdPostId ?? resumePostId ?? undefined}
             />
           )}
         </div>

--- a/src/types/trouble.model.ts
+++ b/src/types/trouble.model.ts
@@ -20,6 +20,10 @@ export interface TroubleListItem {
   likeCount: number | undefined;
   commentCount: number | undefined;
   introduction?: string;
+
+  summaryId?: number | null;
+  postSummaryId?: number | null;
+  summaries: object[] | null;
 }
 
 // 페이징 응답(서버가 ApiResponse로 감싸지 않는 케이스)

--- a/src/types/troubles.server.ts
+++ b/src/types/troubles.server.ts
@@ -19,6 +19,10 @@ export interface TroubleSearchCard {
   likeCount: number;
   commentCount: number;
   introduction: string | null;
+
+  summaryId: number | null;
+  postSummaryId: number | null;
+  summaries: object[] | null;
 }
 
 export type MyTroubleSearchPage = PaginatedResponse<TroubleSearchCard>;

--- a/src/utils/combinedRoute.ts
+++ b/src/utils/combinedRoute.ts
@@ -1,0 +1,56 @@
+type AnyCard = Record<string, any>;
+
+const norm = (s: unknown) => String(s ?? "").toUpperCase();
+
+/** 응답이 다양한 케이스를 가정하고 summaryId를 추출 */
+export function pickLatestSummaryId(x: AnyCard): number | null {
+  if (!x) return null;
+
+  // 1) 단일 필드가 바로 있는 경우
+  const direct = x.summaryId ?? x.postSummaryId ?? null;
+  if (direct != null && Number.isFinite(Number(direct))) return Number(direct);
+
+  // 2) summaries 배열에서 최신(생성일 기준 ↓) 하나 고르기
+  const arr =
+    (Array.isArray(x.summaries) && x.summaries) ||
+    (Array.isArray(x.summaryList) && x.summaryList) ||
+    [];
+
+  if (arr.length > 0) {
+    const sorted = [...arr].sort((a, b) => {
+      const ta = a.summaryCreatedAt
+        ? new Date(a.summaryCreatedAt).getTime()
+        : 0;
+      const tb = b.summaryCreatedAt
+        ? new Date(b.summaryCreatedAt).getTime()
+        : 0;
+      return tb - ta;
+    });
+    const cand = sorted[0]?.summaryId ?? sorted[0]?.id;
+    if (cand != null && Number.isFinite(Number(cand))) return Number(cand);
+  }
+
+  return null;
+}
+
+/** 'SUMMARIZED' | 'CREATED' 등 요약 완료 상태를 통일 */
+export function isSummarizedStatus(raw: unknown) {
+  const s = norm(raw);
+  return s === "SUMMARIZED" || s === "CREATED";
+}
+
+/** 내 글 판정 보조: 카드에 isMine이 있으면 우선, 없으면 authorId로 판정 */
+export function isMineCard(card: AnyCard, viewerId?: number | null) {
+  if (card?.isMine != null) return !!card.isMine;
+  if (viewerId == null) return false;
+  if (card?.authorId != null) return Number(card.authorId) === Number(viewerId);
+  return false;
+}
+
+/** 합본 상세로 갈지/summaryId는 무엇인지 한 번에 반환 */
+export function decideCombined(card: AnyCard, viewerId?: number | null) {
+  const mine = isMineCard(card, viewerId);
+  const summarized = isSummarizedStatus(card?.status);
+  const sid = pickLatestSummaryId(card);
+  return { goCombined: mine && summarized && sid != null, summaryId: sid };
+}


### PR DESCRIPTION
## 🔥 Issues

- closed #108 

## ✅ What to do

- [ ] 홈 화면, 프로젝트 상세 화면, 마이페이지에서 요약 완료 상태의 포스트 조회 시 요약 합본 조회 페이지로 라우팅되도록 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 통합 상세 보기 도입: 홈, 커뮤니티, 프로젝트, 검색, 마이페이지 등에서 카드 클릭 시 조건에 따라 통합 상세로 이동.
  * 작성 완료 모달에서 통합 상세로 즉시 이동 가능.

* 개선
  * 통합 상세 페이지 대폭 확장: 좋아요 토글, 댓글/대댓글(페이지네이션), 공유(링크 복사) 지원.
  * 작성자 프로필/이름, 중요도 표시, 본인/타인 뷰 모드에 따른 2열 레이아웃 최적화.
  * 로딩/에러 가드 및 토스트 안내로 상호작용 피드백 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->