### PR TITLE
FEAT: 홈, 커뮤니티, 마이페이지, 검색 및 공통 컴포넌트 반응형 UI로 수정

### DIFF
--- a/src/components/Button/CancelButton.tsx
+++ b/src/components/Button/CancelButton.tsx
@@ -14,7 +14,7 @@ const CancelButton = ({
       onClick={onClick}
       type="button"
       disabled={disabled}
-      className="flex px-[57px] py-4 justify-center items-center rounded-xl border border-gray1 text-gray3 text-head-20-semibold"
+      className="flex px-5 sm:px-10 py-3.5 sm:py-4 justify-center items-center rounded-xl border border-gray1 text-gray3 text-head-18-semibold sm:text-head-20-semibold disabled:opacity-60 disabled:cursor-not-allowed"
     >
       {label}
     </button>

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -8,7 +8,7 @@ const FollowButton = ({ label, colorClass, onClick }: ButtonProps) => {
   return (
     <button
       onClick={onClick}
-      className={`w-[296px] h-[42px] py-[9px] justify-center items-center rounded-[10px] text-head-20-semibold ${colorClass} text-white`}
+      className={`w-full md:w-[296px] min-h-10 sm:min-h-11 md:h-[42px] px-4 justify-center items-center rounded-[10px] text-head-20-semibold ${colorClass} text-white`}
     >
       {label}
     </button>

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -8,7 +8,8 @@ const FollowButton = ({ label, colorClass, onClick }: ButtonProps) => {
   return (
     <button
       onClick={onClick}
-      className={`w-full md:w-[296px] min-h-10 sm:min-h-11 md:h-[42px] px-4 justify-center items-center rounded-[10px] text-head-20-semibold ${colorClass} text-white`}
+      type="button"
+      className={`flex w-full md:w-[296px] min-h-10 sm:min-h-11 md:h-[42px] px-4 justify-center items-center rounded-[10px] text-head-20-semibold ${colorClass} text-white`}
     >
       {label}
     </button>

--- a/src/components/Button/SaveButton.tsx
+++ b/src/components/Button/SaveButton.tsx
@@ -16,7 +16,7 @@ const SaveButton = ({
       onClick={onClick}
       type={type}
       disabled={disabled}
-      className="flex px-[57px] py-4 justify-center items-center rounded-xl bg-primary text-white text-head-20-semibold"
+      className="flex px-5 sm:px-10 py-3.5 sm:py-4 justify-center items-center rounded-xl bg-primary text-white text-head-18-semibold sm:text-head-20-semibold disabled:opacity-60 disabled:cursor-not-allowed"
     >
       {label}
     </button>

--- a/src/components/Card/CardFooterInfo.tsx
+++ b/src/components/Card/CardFooterInfo.tsx
@@ -23,7 +23,7 @@ export default function CardFooterInfo({
   if (isMine) {
     if (status === "complete" && visibility === "public") {
       return (
-        <div className="flex items-center gap-[6px]">
+        <div className="flex items-center gap-1.5 sm:gap-[6px]">
           <LikeCount count={likeCount} />
           <CommentCount count={commentCount} />
         </div>
@@ -32,13 +32,19 @@ export default function CardFooterInfo({
 
     if (status !== "inProgress" && importance !== undefined) {
       return (
-        <div className="flex items-center gap-1">
+        <div
+          className="flex items-center gap-1"
+          aria-label={`중요도 ${importance}`}
+        >
           <img
             src={star}
-            alt="중요도 아이콘"
-            className="w-4 h-4 sm:w-[20px] sm:h-[20px]"
+            alt=""
+            aria-hidden
+            className="w-4 h-4 sm:w-5 sm:h-5"
           />
-          <span className="text-gray3 text-body-16-regular">{importance}</span>
+          <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums leading-none">
+            {importance}
+          </span>
         </div>
       );
     }
@@ -47,7 +53,7 @@ export default function CardFooterInfo({
   }
 
   return (
-    <div className="flex items-center gap-[6px]">
+    <div className="flex items-center gap-1.5 sm:gap-[6px]">
       <LikeCount count={likeCount} />
       <CommentCount count={commentCount} />
     </div>
@@ -56,26 +62,22 @@ export default function CardFooterInfo({
 
 function LikeCount({ count = 0 }: { count?: number }) {
   return (
-    <div className="flex items-center gap-1">
-      <img
-        src={heart}
-        className="w-4 h-4 sm:w-[20px] sm:h-[20px]"
-        alt="좋아요"
-      />
-      <span className="text-gray3 text-body-16-regular">{count}</span>
+    <div className="flex items-center gap-1" aria-label={`좋아요 ${count}개`}>
+      <img src={heart} className="w-4 h-4 sm:w-5 sm:h-5" alt="" aria-hidden />
+      <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums leading-none">
+        {count}
+      </span>
     </div>
   );
 }
 
 function CommentCount({ count = 0 }: { count?: number }) {
   return (
-    <div className="flex items-center gap-1">
-      <img
-        src={comment}
-        className="w-4 h-4 sm:w-[20px] sm:h-[20px]"
-        alt="댓글"
-      />
-      <span className="text-gray3 text-body-16-regular">{count}</span>
+    <div className="flex items-center gap-1" aria-label={`댓글 ${count}개`}>
+      <img src={comment} className="w-4 h-4 sm:w-5 sm:h-5" alt="" aria-hidden />
+      <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums leading-none">
+        {count}
+      </span>
     </div>
   );
 }

--- a/src/components/Card/CardHeaderRight.tsx
+++ b/src/components/Card/CardHeaderRight.tsx
@@ -26,7 +26,6 @@ export default function CardHeaderRight({
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
-  // 카드 클릭으로 전파되지 않도록 막는 핸들러
   const stopCardClick = {
     onClick: (e: React.MouseEvent) => e.stopPropagation(),
     onKeyDown: (e: React.KeyboardEvent) => e.stopPropagation(),
@@ -37,7 +36,7 @@ export default function CardHeaderRight({
       <img
         src={authorProfileImageUrl || image}
         alt="작성자 프로필"
-        className="w-[28px] h-[28px] sm:w-[36px] sm:h-[36px] rounded-full"
+        className="w-7 h-7 sm:w-9 sm:h-9 rounded-full ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50"
         role="button"
         tabIndex={0}
         aria-label="작성자 프로필 보기"
@@ -62,18 +61,14 @@ export default function CardHeaderRight({
       {status !== "inProgress" && (
         <div className="relative" {...stopCardClick}>
           <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
-
           {showMenu && (
-            // 아이템 클릭 시 카드 onClick 방지
             <div {...stopCardClick}>
               <KebabDropdown
                 options={[
                   {
                     label: deleting ? "삭제 중..." : "삭제",
                     onClick: () => {
-                      if (!deleting) {
-                        onDelete?.();
-                      }
+                      if (!deleting) onDelete?.();
                     },
                   },
                 ]}

--- a/src/components/Card/CardPreviewArea.tsx
+++ b/src/components/Card/CardPreviewArea.tsx
@@ -21,13 +21,14 @@ export default function CardPreviewArea({
   deleting,
 }: CardPreviewAreaProps) {
   return (
-    <div
-      className="bg-gray1 rounded-2xl h-[180px] sm:h-[210px]
- flex flex-col p-3 sm:p-4
-"
-    >
-      <div className="flex justify-between items-start">
-        <span className="text-body-16-semibold">[{errorCategory}]</span>
+    <div className="bg-gray1 rounded-2xl h-[170px] sm:h-[200px] md:h-[210px] xl:h-[220px] flex flex-col p-3 sm:p-4">
+      <div className="flex justify-between items-start gap-2 min-w-0">
+        <span
+          className="text-body-16-semibold truncate max-w-[65%] sm:max-w-[70%]"
+          title={errorCategory}
+        >
+          [{errorCategory}]
+        </span>
         <CardHeaderRight
           isMine={isMine}
           status={status}

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -27,6 +27,9 @@ export interface TroublogCardProps {
   onAvatarClick?: () => void;
   onDeleted?: (id: number) => void;
   introduction?: string;
+  summaryId?: number;
+  postSummaryId?: number;
+  summaries?: object[];
 }
 
 export default function TroublogCard({

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -27,10 +27,6 @@ export interface TroublogCardProps {
   onAvatarClick?: () => void;
   onDeleted?: (id: number) => void;
   introduction?: string;
-
-  summaryId?: number | null;
-  postSummaryId?: number | null;
-  summaries?: any[];
 }
 
 export default function TroublogCard({
@@ -115,8 +111,8 @@ export default function TroublogCard({
       />
 
       {/* 제목, 날짜, 태그 영역 */}
-      <div className="flex justify-between items-end p-3 sm:p-4">
-        <div className="flex flex-col items-start gap-[14px] sm:gap-[18px]">
+      <div className="flex justify-between items-end p-3">
+        <div className="flex flex-col items-start gap-[14px]">
           <CardTitleSection
             title={title}
             visibility={visibility}

--- a/src/components/Community/PostComment.tsx
+++ b/src/components/Community/PostComment.tsx
@@ -28,39 +28,36 @@ export default function PostComment({
   onDelete,
   onReply,
 }: PostCommentProps) {
-  // 댓글 수정 상태 관리
   const [editMode, setEditMode] = useState(false);
   const [editContent, setEditContent] = useState(content);
   const [editPosting, setEditPosting] = useState(false);
 
-  // 답글 달기 상태 관리
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyPosting, setReplyPosting] = useState(false);
   const [replyContent, setReplyContent] = useState("");
 
-  // 삭제 확인 모달
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [deletePosting, setDeletePosting] = useState(false);
 
   return (
-    <div className="flex w-[1200px]">
+    <div className="flex w-full max-w-[1200px]">
       {isReply && (
-        <div className="mt-[31px] ml-[38px] mr-[16px]">
+        <div className="mt-6 sm:mt-[31px] ml-6 sm:ml-[38px] mr-4 sm:mr-[16px]">
           <img
             src={replyIcon}
             alt=""
             aria-hidden="true"
-            className="w-[20px] h-[21px]"
+            className="w-4 h-4 sm:w-[20px] sm:h-[21px]"
           />
         </div>
       )}
-      <div className="flex w-full py-[24px] items-center border-b border-gray1 bg-white">
-        <div className="flex w-full flex-col items-start gap-[36px]">
+      <div className="flex w-full py-4 sm:py-[24px] items-center border-b border-gray1 bg-white">
+        <div className="flex w-full flex-col items-start gap-6 sm:gap-[36px]">
           {/* 댓글 정보 */}
-          <div className="flex flex-col items-start gap-[36px] self-stretch">
+          <div className="flex flex-col items-start gap-6 sm:gap-[36px] self-stretch">
             {/* 작성자 정보 & 작성일 & (수정, 삭제 버튼) */}
             <div className="flex w-full justify-between">
-              <div className="flex items-center gap-[11px]">
+              <div className="flex items-center gap-3 sm:gap-[11px]">
                 {/* 프로필 이미지 */}
                 <img
                   src={profile || image}
@@ -69,7 +66,7 @@ export default function PostComment({
                     e.currentTarget.src = image;
                   }}
                   alt="profile"
-                  className="w-[52px] h-[52px]"
+                  className="w-10 h-10 sm:w-[52px] sm:h-[52px] rounded-full object-cover"
                 />
 
                 <div className="flex flex-col items-start gap-[2px]">
@@ -83,16 +80,13 @@ export default function PostComment({
               {/* 수정, 삭제 버튼 (작성자 본인일 경우) */}
               {isMine && (
                 <div className="flex items-center gap-[8px] text-body-16-regular text-gray3">
-                  {/* 수정 */}
                   <div
                     className="cursor-pointer"
                     onClick={() => setEditMode(true)}
                   >
                     수정
                   </div>
-                  {/* 구분점 */}
                   <div>·</div>
-                  {/* 삭제 */}
                   <div
                     className="cursor-pointer"
                     onClick={() => setShowDeleteModal(true)}
@@ -103,7 +97,7 @@ export default function PostComment({
               )}
             </div>
 
-            {/* 댓글 내용 (수정 옵션 포함 - 임시 디자인) */}
+            {/* 댓글 내용 (수정 옵션 포함) */}
             {editMode ? (
               <div className="w-full">
                 <textarea
@@ -133,8 +127,6 @@ export default function PostComment({
                         setEditPosting(true);
                         await onEdit?.(editContent);
                         setEditMode(false);
-                      } catch {
-                        // 실패 시 유지
                       } finally {
                         setEditPosting(false);
                       }
@@ -145,7 +137,9 @@ export default function PostComment({
                 </div>
               </div>
             ) : (
-              <div className="text-body-20-regular">{content}</div>
+              <div className="text-body-20-regular break-words w-full">
+                {content}
+              </div>
             )}
           </div>
 
@@ -159,7 +153,7 @@ export default function PostComment({
             </div>
           )}
 
-          {/* 답글 입력창 (임시 디자인) */}
+          {/* 답글 입력창 */}
           {replyOpen && (
             <div className="w-full mt-2">
               <textarea
@@ -181,8 +175,6 @@ export default function PostComment({
                     await onReply?.(replyContent);
                     setReplyContent("");
                     setReplyOpen(false);
-                  } catch {
-                    // 실패 시 유지하거나 토스트 노출 등
                   } finally {
                     setReplyPosting(false);
                   }

--- a/src/components/Community/PostGuideMd.tsx
+++ b/src/components/Community/PostGuideMd.tsx
@@ -9,17 +9,33 @@ type GuideContent = string | ImageItem;
 export default function PostGuideMd({
   question,
   content,
+  widthClass = "w-full sm:w-[600px] md:w-[720px] lg:w-[920px] xl:w-[1200px]",
+  proseSize = "lg", // 기본은 살짝 키운 크기
 }: {
   question: string;
   content: GuideContent[];
+  widthClass?: string;
+  proseSize?: "base" | "lg" | "xl";
 }) {
-  return (
-    <section className="w-[1200px]">
-      <div className="text-head-24-bold mb-6">{question}</div>
+  const proseScale =
+    proseSize === "xl" ? "prose-xl" : proseSize === "lg" ? "prose-lg" : "prose";
 
-      {/* 마크다운 + 이미지 렌더 */}
+  return (
+    <section className={`${widthClass}`}>
+      <div className="text-head-24-bold mb-6 break-words">{question}</div>
+
+      {/* 마크다운 + 이미지 컨테이너: 내부는 항상 부모 고정 폭을 꽉 채움 */}
       <div
-        className="prose max-w-none w-[1200px] flex p-[32px] flex-col justify-center  gap-[10px] self-stretch rounded-[20px] bg-white shadow-card "
+        className={[
+          "prose",
+          proseScale,
+          "max-w-none",
+          widthClass,
+          "flex flex-col gap-[10px] rounded-[20px] bg-white shadow-card p-[32px]",
+          "prose-p:leading-relaxed md:prose-p:leading-loose",
+          "prose-li:leading-relaxed md:prose-li:leading-loose",
+          "prose-pre:text-sm md:prose-pre:text-base",
+        ].join(" ")}
         data-color-mode="light"
       >
         {content.map((item, i) => {
@@ -30,18 +46,16 @@ export default function PostGuideMd({
                 source={item}
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeRaw, rehypeSanitize]}
-                style={{ width: "1150px" }}
               />
             );
           }
 
-          // 이미지
           return (
             <img
               key={i}
               src={item.src}
               alt={item.alt ?? ""}
-              className="rounded-lg my-4"
+              className="rounded-lg my-4 max-w-full h-auto"
               onError={(e) => {
                 const img = e.currentTarget as HTMLImageElement;
                 img.onerror = null;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -25,38 +25,32 @@ const Header = () => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
   const viewerId = useViewerId();
   const myUserIdStr = viewerId != null ? String(viewerId) : null;
-  // (다른 사용자의 페이지인 경우)
   const viewedUser = useMyPageStore((s) => s.viewedUser);
 
   const hasNew = useNotificationStore((s) => s.hasNew);
   const clearNew = useNotificationStore((s) => s.clearNew);
 
   const handleMouseEnter = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setIsNotificationModalOpen(true);
     if (hasNew) clearNew();
   };
 
   const handleMouseLeave = () => {
-    timeoutRef.current = setTimeout(() => {
-      setIsNotificationModalOpen(false);
-    }, 200);
+    timeoutRef.current = setTimeout(
+      () => setIsNotificationModalOpen(false),
+      200
+    );
   };
 
   useEffect(() => {
     const path = location.pathname;
-
-    // 검색 페이지라면 URL의 scope/userId를 읽어서 placeholder 결정
     if (path.startsWith(PATH.SEARCH)) {
       const sp = new URLSearchParams(location.search);
       const scope = sp.get("scope");
       const pageUserId = sp.get("userId") ?? "";
-
       if (scope === "my" || scope === "mypage") {
         setPlaceholder(
           "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
@@ -115,16 +109,12 @@ const Header = () => {
     viewedUser?.nickname,
   ]);
 
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) =>
     setSearch(e.target.value);
-  };
 
   const handleSubmitSearch = () => {
     if (!search.trim()) return;
-
     const currentPath = location.pathname;
-
-    // 검색 페이지에 있다면, 기존 쿼리의 scope/userId를 우선 보존
     const existing = new URLSearchParams(location.search);
     const rawScope = existing.get("scope");
     let scope: "my" | "mypage" | "user" | "community" | "project" | null =
@@ -137,12 +127,10 @@ const Header = () => {
         : null;
     let pageUserId = existing.get("userId") ?? "";
 
-    // 검색 페이지가 아니면, 기존 규칙으로 계산
     if (!scope) {
       scope = "community";
       const mypageMatch = currentPath.match(/^\/user\/mypage\/([^/]+)/);
       pageUserId = mypageMatch?.[1] ?? "";
-
       if (currentPath.startsWith(PATH.MYPAGE(""))) {
         scope = pageUserId === myUserIdStr ? "mypage" : "user";
       } else if (
@@ -163,7 +151,6 @@ const Header = () => {
     navigate(`${PATH.SEARCH}?${searchParams.toString()}`);
   };
 
-  // URL <-> 입력 동기화 (다른 페이지로 이동하면 검색창 비우기)
   useEffect(() => {
     if (location.pathname.startsWith(PATH.SEARCH)) {
       const sp = new URLSearchParams(location.search);
@@ -174,79 +161,69 @@ const Header = () => {
   }, [location.pathname, location.search]);
 
   return (
-    <div className="flex w-full py-[25px] px-[88px] gap-12 justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
+    <div className="flex w-full py-4 sm:py-5 lg:py-[25px] px-4 sm:px-6 lg:px-[88px] gap-4 sm:gap-8 lg:gap-12 justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
       <img
         src={logo}
         alt="logo"
-        className="w-[70px] h-[51px] cursor-pointer"
+        className="w-[56px] h-[40px] sm:w-[70px] sm:h-[51px] cursor-pointer"
         onClick={() => navigate(PATH.HOME)}
       />
-      <div className="flex w-full gap-12 items-center">
+      <div className="flex w-full gap-4 sm:gap-8 items-center">
+        {/* Search */}
         <div
           role="search"
           onClick={() => inputRef.current?.focus()}
-          className="
-    group flex w-full h-12 p-2 justify-between items-center gap-1
-    rounded-md border border-gray1 transition
-    focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40
-  "
+          className="group flex w-full h-10 sm:h-12 p-2 justify-between items-center gap-1 rounded-md border border-gray1 transition focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40"
         >
           <input
             ref={inputRef}
-            className="text-body-16-regular w-full h-full focus:outline-none"
+            className="text-body-14-regular sm:text-body-16-regular w-full h-full focus:outline-none"
             placeholder={placeholder}
             value={search}
             onChange={handleSearch}
             onKeyDown={(e) => e.key === "Enter" && handleSubmitSearch()}
           />
           <MdSearch
-            size={24}
             onClick={handleSubmitSearch}
-            className="cursor-pointer"
+            className="cursor-pointer text-[20px] sm:text-[24px]"
           />
         </div>
-        <div className="flex gap-10 items-center relative">
+
+        {/* Icons */}
+        <div className="flex gap-4 sm:gap-6 lg:gap-10 items-center relative">
           <FaUserGroup
-            size={40}
-            color="#525252"
-            className="cursor-pointer"
+            className="cursor-pointer text-[#525252] text-[28px] sm:text-[32px] lg:text-[40px]"
             onClick={() => navigate(PATH.COMMUNITY)}
           />
-          {/* 알림 영역 (hover 시 열림 + 벗어나면 닫힘) */}
+          {/* Notifications */}
           <div
             className="relative"
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
           >
             <BsFillBellFill
-              size={40}
+              className="cursor-pointer transition-colors text-[28px] sm:text-[32px] lg:text-[40px]"
               color={hasNew ? "#7C3AED" : "#525252"}
-              className="cursor-pointer transition-colors"
             />
             {isNotificationModalOpen && (
-              <div className="absolute right-[-10px] top-full mt-[41.5px] z-10">
+              <div className="absolute right-0 top-full mt-3 sm:mt-[41.5px] z-10">
                 <NotificationModal />
               </div>
             )}
           </div>
-          <div ref={userDropdownRef}>
+          {/* User */}
+          <div ref={userDropdownRef} className="relative">
             <FaUserCircle
-              size={40}
-              color="#525252"
-              className="cursor-pointer"
+              className="cursor-pointer text-[#525252] text-[28px] sm:text-[32px] lg:text-[40px]"
               onClick={() => setIsUserDropdownOpen((prev) => !prev)}
             />
             {isUserDropdownOpen && (
-              <div className="absolute left-1/3 top-full mt-2 z-10">
+              <div className="absolute right-0 top-full mt-2 z-10">
                 <UserMenuDropdown
                   onClose={() => setIsUserDropdownOpen(false)}
                   onNavigateToMyPage={() => {
-                    if (myUserIdStr) {
-                      navigate(PATH.MYPAGE(myUserIdStr));
-                    } else {
-                      // 미로그인/정보없음: 루트(또는 로그인)로 유도
-                      navigate(PATH.ROOT);
-                    }
+                    if (myUserIdStr) navigate(PATH.MYPAGE(myUserIdStr));
+                    else navigate(PATH.ROOT);
                     setIsUserDropdownOpen(false);
                   }}
                 />

--- a/src/components/Header/HeaderWoSearch.tsx
+++ b/src/components/Header/HeaderWoSearch.tsx
@@ -4,7 +4,7 @@ import { FaUserCircle } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import logo from "@/assets/icons/logo.svg";
 import { PATH } from "@/constants/paths";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import useClickOutside from "@/hooks/useClickOutside";
 import NotificationModal from "../Modal/NotificationModal";
 import UserMenuDropdown from "../Menu/UserMenuDropdown";
@@ -18,83 +18,81 @@ const HeaderWoSearch = () => {
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
   const closeUserDropdown = useCallback(() => setIsUserDropdownOpen(false), []);
   const userDropdownRef = useClickOutside(closeUserDropdown);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 중앙 상태에서 로그인 사용자 ID 읽기 (null | number)
+  // 로그인 사용자 ID
   const viewerId = useViewerId();
-  const myUserId = viewerId != null ? String(viewerId) : null;
+  const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
   const hasNew = useNotificationStore((s) => s.hasNew);
   const clearNew = useNotificationStore((s) => s.clearNew);
 
   const handleMouseEnter = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setIsNotificationModalOpen(true);
     if (hasNew) clearNew();
   }, [hasNew, clearNew]);
 
   const handleMouseLeave = useCallback(() => {
-    timeoutRef.current = setTimeout(() => {
-      setIsNotificationModalOpen(false);
-    }, 200);
+    timeoutRef.current = setTimeout(
+      () => setIsNotificationModalOpen(false),
+      200
+    );
   }, []);
 
   // 타이머 정리
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
 
   return (
-    <div className="flex w-full py-[25px] px-[88px] gap-[10px] justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
+    <div className="flex w-full py-4 sm:py-5 lg:py-[25px] px-4 sm:px-6 lg:px-[88px] gap-4 sm:gap-8 lg:gap-12 justify-between items-center shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
       <img
         src={logo}
         alt="logo"
-        className="w-[70px] h-[51px] cursor-pointer"
+        className="w-[56px] h-[40px] sm:w-[70px] sm:h-[51px] cursor-pointer"
         onClick={() => navigate(PATH.HOME)}
       />
-      <div className="flex gap-10 items-center relative">
+
+      {/* Icons */}
+      <div className="flex gap-4 sm:gap-6 lg:gap-10 items-center relative">
         <FaUserGroup
-          size={40}
-          color="#525252"
-          className="cursor-pointer"
+          className="cursor-pointer text-[#525252] text-[28px] sm:text-[32px] lg:text-[40px]"
           onClick={() => navigate(PATH.COMMUNITY)}
         />
-        {/* 알림 영역 (hover 시 열림 + 벗어나면 닫힘) */}
+
+        {/* 알림 (hover 시 열림) */}
         <div
           className="relative"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
           <BsFillBellFill
-            size={40}
+            className="cursor-pointer transition-colors text-[28px] sm:text-[32px] lg:text-[40px]"
             color={hasNew ? "#7C3AED" : "#525252"}
-            className="cursor-pointer transition-colors"
           />
           {isNotificationModalOpen && (
-            <div className="absolute right-[-10px] top-full mt-[41.5px] z-10">
+            <div className="absolute right-0 top-full mt-3 sm:mt-[41.5px] z-10">
               <NotificationModal />
             </div>
           )}
         </div>
-        <div ref={userDropdownRef}>
+
+        {/* 유저 메뉴 */}
+        <div ref={userDropdownRef} className="relative">
           <FaUserCircle
-            size={40}
-            color="#525252"
-            className="cursor-pointer"
+            className="cursor-pointer text-[#525252] text-[28px] sm:text-[32px] lg:text-[40px]"
             onClick={() => setIsUserDropdownOpen((prev) => !prev)}
           />
           {isUserDropdownOpen && (
-            <div className="absolute left-1/3 top-full mt-2 z-10">
+            <div className="absolute right-0 top-full mt-2 z-10">
               <UserMenuDropdown
                 onClose={() => setIsUserDropdownOpen(false)}
                 onNavigateToMyPage={() => {
-                  navigate(PATH.MYPAGE(String(myUserId)));
+                  if (myUserIdStr) navigate(PATH.MYPAGE(myUserIdStr));
+                  else navigate(PATH.ROOT);
                   setIsUserDropdownOpen(false);
                 }}
               />

--- a/src/components/Menu/KebabDropdown.tsx
+++ b/src/components/Menu/KebabDropdown.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 interface DropdownOption {
   label: string;
   onClick: () => void;
@@ -23,7 +25,7 @@ export default function KebabDropdown({
     right: position?.right || "0",
     bottom: position?.bottom,
     left: position?.left,
-  } as React.CSSProperties;
+  } as CSSProperties;
 
   return (
     <div

--- a/src/components/Menu/KebabDropdown.tsx
+++ b/src/components/Menu/KebabDropdown.tsx
@@ -18,32 +18,29 @@ export default function KebabDropdown({
   position,
 }: KebabDropdownProps) {
   const isSingleOption = options.length === 1;
-
   const dropdownStyle = {
     top: position?.top || "1.5rem",
     right: position?.right || "0",
     bottom: position?.bottom,
     left: position?.left,
-  };
+  } as React.CSSProperties;
 
   return (
     <div
-      className="absolute z-10 inline-block w-fit bg-white rounded-[8px] shadow-[0px_0px_10px_rgba(0,0,0,0.15)] overflow-hidden"
+      className="absolute z-10 inline-block w-[min(180px,80vw)] sm:w-fit bg-white rounded-[8px] shadow-[0_0_10px_rgba(0,0,0,0.15)] overflow-hidden max-w-[calc(100vw-2rem)]"
       style={dropdownStyle}
     >
-      {options.map((option, index) => {
-        return (
-          <button
-            key={index}
-            onClick={option.onClick}
-            className={`text-body-16-regular text-black text-center px-[22px] py-[9px] hover:bg-gray-100 w-full whitespace-nowrap ${
-              !isSingleOption && index !== 0 ? "border-t border-gray-200" : ""
-            }`}
-          >
-            {option.label}
-          </button>
-        );
-      })}
+      {options.map((option, index) => (
+        <button
+          key={index}
+          onClick={option.onClick}
+          className={`text-body-14-regular sm:text-body-16-regular text-black text-center px-4 py-2.5 hover:bg-gray-100 w-full whitespace-nowrap ${
+            !isSingleOption && index !== 0 ? "border-t border-gray-200" : ""
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/Menu/KebabMenuButton.tsx
+++ b/src/components/Menu/KebabMenuButton.tsx
@@ -1,4 +1,3 @@
-// KebabMenuButton.tsx
 import kebabIcon from "@/assets/icons/menu-kebab.svg";
 
 type HitArea = "compact" | "comfortable" | "spacious";
@@ -30,7 +29,7 @@ export default function KebabMenuButton({
       aria-label={ariaLabel}
       className={[
         "inline-flex items-center justify-center rounded-full",
-        "hover:bg-gray-100",
+        "hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50",
         hitAreaClass[hitArea],
         className,
       ].join(" ")}

--- a/src/components/Menu/SummaryTypeDropdown.tsx
+++ b/src/components/Menu/SummaryTypeDropdown.tsx
@@ -45,7 +45,7 @@ export default function SummaryTypeDropdown({
       </button>
 
       {open && (
-        <div className="absolute top-[48px] sm:top-[52px] left-0 min-w-[100px] sm:min-w-[120px] py-[8px] bg-white border border-gray2 rounded-[4px] shadow-card z-10 overflow-hidden">
+        <div className="absolute top-[48px] sm:top-[52px] right-0 sm:left-0 sm:right-auto min-w-[120px] max-w-[92vw] max-h-[50vh] overflow-y-auto py-[8px] bg-white border border-gray2 rounded-[4px] shadow-card z-10">
           {OPTIONS.map((o, i) => (
             <div
               key={o.label}

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -11,19 +11,19 @@ interface BaseModalProps {
 export default function BaseModal({
   onClose,
   children,
-  width = "w-[580px]",
+  width = "w-[min(580px,92vw)]",
   className = "",
 }: BaseModalProps) {
   const modalRef = useClickOutside(onClose);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
       {/* 배경 블러 */}
-      <div className="absolute inset-0 backdrop-blur-sm" />
+      <div className="absolute inset-0 backdrop-blur-sm bg-black/10" />
       {/* 모달 본문 */}
       <div
         ref={modalRef}
-        className={`relative z-10 rounded-[20px] bg-white shadow-card flex flex-col items-center ${width} ${className}`}
+        className={`relative z-10 rounded-[20px] bg-white shadow-card flex max-h-[90vh] overflow-auto flex-col items-center ${width} ${className}`}
       >
         {children}
       </div>

--- a/src/components/Modal/ConfirmDeleteModal.tsx
+++ b/src/components/Modal/ConfirmDeleteModal.tsx
@@ -1,6 +1,7 @@
 import BaseModal from "./BaseModal";
 import CancelButton from "../Button/CancelButton";
 import SaveButton from "../Button/SaveButton";
+
 interface ConfirmDeleteModalProps {
   onClose: () => void;
   onConfirm: () => void;
@@ -23,16 +24,18 @@ export default function ConfirmDeleteModal({
   return (
     <BaseModal
       onClose={onClose}
-      className="px-[64px] pt-[67px] pb-[66px] gap-[40px]"
+      className="px-6 sm:px-10 md:px-16 pt-10 sm:pt-14 pb-8 sm:pb-12 gap-6 sm:gap-10"
     >
-      <div className="flex flex-col items-center gap-[40px] self-stretch">
-        <span className="text-head-32-semibold">{title}</span>
-        <p className="text-center text-body-20-regular text-gray3 whitespace-pre-line">
+      <div className="flex flex-col items-center gap-6 sm:gap-10 self-stretch text-center">
+        <span className="text-head-24-bold sm:text-head-32-semibold">
+          {title}
+        </span>
+        <p className="text-body-16-regular sm:text-body-20-regular text-gray3 whitespace-pre-line">
           {description}
         </p>
       </div>
 
-      <div className="flex items-center gap-[17px]">
+      <div className="flex flex-col-reverse sm:flex-row items-stretch sm:items-center gap-3 sm:gap-[17px] w-full justify-center">
         <CancelButton onClick={onClose} disabled={loading} />
         <SaveButton
           onClick={onConfirm}

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -54,34 +54,24 @@ export default function FolderModal({
 
   const { uploading, progress, upload, reset: resetUpload } = useImageUpload();
 
-  // edit 모드일 때 프로젝트 상세 조회 api 호출
   useEffect(() => {
     if (mode !== "edit" || !projectId) return;
-
     let alive = true;
     (async () => {
       try {
         setSyncing(true);
-
-        // StrictMode/동시 호출 디듀프
         const detail = await fetchProjectDetailOnce(projectId);
         if (!alive) return;
-
-        // 삭제된 프로젝트 방어는 상태 갱신 전에
         if (detail.isDeleted) {
           alert("삭제된 프로젝트입니다. 목록으로 돌아갑니다.");
           onClose();
           return;
         }
-
-        // 상세 응답으로 폼 값 덮어쓰기
         setName(detail.name ?? "");
         setDescription(detail.description ?? "");
         setThumbnailPreview(detail.thumbnailImageUrl ?? null);
-
         setSelectedFile(null);
         setRemoved(false);
-
         resetUpload();
       } catch (e) {
         if (alive) console.error("프로젝트 상세 조회 실패:", e);
@@ -89,13 +79,11 @@ export default function FolderModal({
         if (alive) setSyncing(false);
       }
     })();
-
     return () => {
       alive = false;
     };
   }, [mode, projectId, onClose]);
 
-  // blob URL 정리
   useEffect(() => {
     return () => {
       if (thumbnailPreview && thumbnailPreview.startsWith("blob:")) {
@@ -109,12 +97,9 @@ export default function FolderModal({
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-
-    // 이전 blob URL 정리
     if (thumbnailPreview && thumbnailPreview.startsWith("blob:")) {
       URL.revokeObjectURL(thumbnailPreview);
     }
-
     setSelectedFile(file);
     setThumbnailPreview(URL.createObjectURL(file));
     setRemoved(false);
@@ -139,47 +124,30 @@ export default function FolderModal({
 
   const handleSubmit = async () => {
     if (disabled) return;
-
-    // 이름 유효성
     if (!name.trim()) {
       alert("프로젝트 이름을 입력해주세요.");
       return;
     }
-
     try {
-      // 선택된 새 파일이 있으면 업로드 -> URL 획득
       let uploadedUrl: string | undefined;
       if (selectedFile) {
         uploadedUrl = await upload(selectedFile);
       }
-
-      // 상위로 전달 (서버 URL 또는 빈 문자열)
       const payload: CreateProjectRequest = {
         name: name.trim(),
         description: description.trim(),
       };
-
       if (mode === "new") {
-        // 새 프로젝트: URL이 있으면 포함, 없으면 생략
-        if (uploadedUrl && uploadedUrl.trim() !== "") {
+        if (uploadedUrl && uploadedUrl.trim() !== "")
           payload.thumbnailImageUrl = uploadedUrl.trim();
-        }
       } else {
-        // 수정 모드
-        if (uploadedUrl && uploadedUrl.trim() !== "") {
-          // 새 이미지 업로드 -> 교체
+        if (uploadedUrl && uploadedUrl.trim() !== "")
           payload.thumbnailImageUrl = uploadedUrl.trim();
-        } else if (removed) {
-          // 삭제 버튼 클릭 -> 빈 문자열로 제거 의사 전달
-          payload.thumbnailImageUrl = "";
-        }
-        // 아무 조작 없음 -> 생략
+        else if (removed) payload.thumbnailImageUrl = "";
       }
-
       onSubmit?.(payload);
     } catch (err) {
       console.error("이미지 업로드/전송 실패:", err);
-      // 에러 타입에 따른 구체적인 메시지
       const message =
         err instanceof Error ? err.message : "이미지 업로드에 실패했습니다.";
       alert(message);
@@ -191,30 +159,24 @@ export default function FolderModal({
   return (
     <BaseModal
       onClose={onClose}
-      width="w-[703px]"
+      width="w-[min(703px,92vw)]"
       className="bg-white shadow-card"
     >
       {/* 헤더 */}
-      <div className="flex justify-between items-center px-[36px] mb-[24px] mt-[36px] w-full">
+      <div className="flex justify-between items-center px-6 mb-6 mt-9 w-full">
         <span className="text-head-24-bold">
           {mode === "edit" ? "폴더 수정하기" : "새 폴더"}
         </span>
-        <button onClick={onClose}>
-          <img
-            src={exitIcon}
-            alt="close"
-            className="w-[24px] h-[24px] mb-[12px] mt-[3px]"
-          />
+        <button onClick={onClose} aria-label="닫기">
+          <img src={exitIcon} alt="close" className="w-6 h-6 mb-3 mt-[3px]" />
         </button>
       </div>
+      <div className="w-full h-px bg-gray1 mb-8" />
 
-      {/* 구분선 */}
-      <div className="w-full h-[1px] bg-gray1 mb-[32px]" />
-
-      {/* 본문 */}
-      <div className="flex justify-between items-center mb-[32px] px-[36px] w-full">
+      {/* 본문: 모바일 세로, md+ 가로 */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 md:gap-8 mb-8 px-6 w-full">
         {/* 썸네일 업로드 */}
-        <div className="relative flex w-[186px] h-[186px] overflow-hidden flex-col justify-center items-center gap-[23px] rounded-[16px] border-dashed border-[2px] border-gray1 bg-[#FCFCFC]">
+        <div className="relative flex w-40 h-40 sm:w-44 sm:h-44 md:w-[186px] md:h-[186px] overflow-hidden flex-col justify-center items-center gap-6 rounded-[16px] border-dashed border-2 border-gray1 bg-[#FCFCFC] mx-auto md:mx-0">
           {thumbnailPreview ? (
             <>
               <img
@@ -222,8 +184,6 @@ export default function FolderModal({
                 alt="thumbnail"
                 className="absolute inset-0 w-full h-full object-cover"
               />
-
-              {/* 업로드 진행 표시(업로드 중에만) */}
               {uploading && (
                 <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
                   <span className="text-white text-body-14-regular">
@@ -231,11 +191,10 @@ export default function FolderModal({
                   </span>
                 </div>
               )}
-
               <button
                 onClick={handleRemoveThumb}
                 disabled={disabled}
-                className="z-20 absolute bottom-[18px] flex px-[23px] pt-[10px] pb-[11px] rounded-[8px] border-[1.5px] border-gray1 bg-white"
+                className="z-20 absolute bottom-4 flex px-6 py-2 rounded-[8px] border border-gray1 bg-white"
               >
                 <span className="text-body-14-regular">썸네일 삭제</span>
               </button>
@@ -250,13 +209,12 @@ export default function FolderModal({
               <button
                 onClick={handleUploadClick}
                 disabled={disabled}
-                className="flex px-[17px] pt-[10px] pb-[11px] justify-center items-center rounded-[8px] border-[1.5px] border-gray1 bg-white"
+                className="flex px-4 py-2 justify-center items-center rounded-[8px] border border-gray1 bg-white"
               >
                 <span className="text-body-14-regular">썸네일 업로드</span>
               </button>
             </>
           )}
-
           <input
             type="file"
             accept="image/*"
@@ -268,24 +226,24 @@ export default function FolderModal({
         </div>
 
         {/* 입력 영역 */}
-        <div className="flex flex-col gap-[30px]">
-          <div className="flex flex-col justify-center items-start gap-[8px]">
+        <div className="flex-1 w-full grid grid-cols-1 gap-6">
+          <div className="flex flex-col gap-2">
             <span className="text-head-20-semibold">폴더 이름</span>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
               disabled={disabled}
-              className="flex pl-[15px] pt-[15px] pr-[230px] pb-[14px] items-center rounded-[8px] border border-gray1 bg-white text-body-14-regular"
+              className="w-full rounded-[8px] border border-gray1 bg-white text-body-14-regular px-4 py-3"
               placeholder="폴더 이름을 입력해주세요."
             />
           </div>
-          <div className="flex flex-col justify-center items-start gap-[8px]">
+          <div className="flex flex-col gap-2">
             <span className="text-head-20-semibold">한 줄 소개</span>
             <input
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               disabled={disabled}
-              className="flex pl-[15px] pt-[15px] pr-[230px] pb-[14px] items-center rounded-[8px] border border-gray1 bg-white text-body-14-regular"
+              className="w-full rounded-[8px] border border-gray1 bg-white text-body-14-regular px-4 py-3"
               placeholder="한 줄 소개를 입력해주세요."
             />
           </div>
@@ -293,7 +251,7 @@ export default function FolderModal({
       </div>
 
       {/* 버튼 영역 */}
-      <div className="flex justify-end gap-[17px] mb-[24px] px-[36px] w-full">
+      <div className="flex justify-end gap-4 mb-6 px-6 w-full">
         <CancelButton onClick={onClose} />
         <SaveButton
           onClick={handleSubmit}

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -74,6 +74,9 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
           nickname: me.nickname,
           bio: me.bio,
           githubUrl: me.githubUrl,
+          profileUrl: (me as any).profileUrl, // ProfileData에 존재한다면 정확한 타입으로 교체
+          followerNum: (me as any).followerNum,
+          followingNum: (me as any).followingNum,
         });
         setViewedUser({ id: me.userId, nickname: me.nickname ?? null });
       } else {

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -35,14 +35,11 @@ type MyPageSideBarProps =
       onSelectTag: (tag: string | null) => void;
     };
 
-// 화면 표시용 통합 상태
 type DisplayUser = {
   userId?: number;
   nickname?: string;
   bio?: string;
-  // 내 페이지: githubUrl 사용
   githubUrl?: string;
-  // 타인 페이지: 프로필 이미지로만 사용
   profileUrl?: string;
   followerNum?: number;
   followingNum?: number;
@@ -71,24 +68,22 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const refetch = useCallback(async () => {
     try {
       if (props.isMyPage) {
-        // 내 마이페이지: getMyProfile
         const me: ProfileData = await getMyProfile();
         setUserInfo({
           userId: me.userId,
           nickname: me.nickname,
           bio: me.bio,
-          githubUrl: me.githubUrl, // 텍스트로만 표시
+          githubUrl: me.githubUrl,
         });
         setViewedUser({ id: me.userId, nickname: me.nickname ?? null });
       } else {
-        // 타 사용자: getUserInfo
         if (!id) return;
         const other: UserInfoData = await getUserInfo(Number(id));
         setUserInfo({
           userId: other.userId,
           nickname: other.nickname,
           bio: other.bio,
-          profileUrl: other.profileUrl, // 아바타 이미지로만 사용
+          profileUrl: other.profileUrl,
           followerNum: other.followerNum,
           followingNum: other.followingNum,
           isFollowed: other.isFollowed,
@@ -104,13 +99,8 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     refetch();
   }, [refetch]);
 
-  useEffect(() => {
-    return () => {
-      resetViewedUser();
-    };
-  }, [resetViewedUser]);
+  useEffect(() => () => resetViewedUser(), [resetViewedUser]);
 
-  // 현재 경로가 메인 페이지가 아니면 선택 상태 초기화
   useEffect(() => {
     const onMain = location.pathname === PATH.MYPAGE(id!);
     if (!onMain) {
@@ -130,18 +120,20 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     };
 
   const getFilterButtonClass = (status: StatusType | "all") =>
-    `flex items-center gap-[8px] self-stretch ${
-      selectedStatus === status ? "text-black text-body-16-semibold" : ""
+    `flex items-center gap-2 sm:gap-[8px] self-stretch ${
+      selectedStatus === status
+        ? "text-black text-body-16-semibold"
+        : "text-body-16-regular text-gray3"
     }`;
 
   const getMenuButtonClass = (match: boolean) =>
-    `${match ? "text-black" : "text-gray3"} text-head-20-semibold`;
+    `${
+      match ? "text-black" : "text-gray3"
+    } text-head-18-semibold sm:text-head-20-semibold`;
 
-  // 팔로우
   const handleFollow = async (targetId: number) => {
     if (!userInfo || followLoading) return;
     setFollowLoading(true);
-
     setUserInfo((prev) =>
       prev
         ? {
@@ -151,7 +143,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
           }
         : prev
     );
-
     try {
       await postFollow(targetId);
       await refetch();
@@ -171,7 +162,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     }
   };
 
-  // 언팔로우
   const handleUnfollow = async (targetId: number) => {
     if (!userInfo || followLoading) return;
     setFollowLoading(true);
@@ -184,7 +174,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
           }
         : prev
     );
-
     try {
       await postUnfollow(targetId);
       await refetch();
@@ -205,22 +194,21 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   };
 
   return (
-    <div className="flex w-[296px] flex-col items-start gap-[140px]">
+    <div className="flex w-full md:w-[296px] flex-col items-start gap-8 sm:gap-12 xl:gap-[140px] md:sticky md:top-24">
       {/* 상단 프로필 영역 */}
       <div className="flex flex-col items-center gap-3 self-stretch">
         <img
-          src={
-            // 타인 페이지면 프로필 이미지, 내 페이지는 스펙상 없으니 기본 아이콘
-            props.isMyPage ? userIcon : userInfo?.profileUrl || userIcon
-          }
+          src={props.isMyPage ? userIcon : userInfo?.profileUrl || userIcon}
           alt="user"
-          className="w-[288px] h-[288px]"
+          className="w-28 h-28 sm:w-36 sm:h-36 md:w-56 md:h-56 xl:w-[288px] xl:h-[288px] object-cover rounded-full md:rounded-none"
         />
-        <div className="flex flex-col items-start gap-3">
-          <div className="flex flex-col items-start gap-2">
-            <p className="text-head-32-semibold">{userInfo?.nickname}</p>
+        <div className="flex flex-col items-start gap-3 w-full">
+          <div className="flex flex-col items-start gap-2 w-full">
+            <p className="text-head-24-bold sm:text-head-32-semibold break-words">
+              {userInfo?.nickname}
+            </p>
 
-            <div className="flex gap-1 text-body-20-regular text-gray4">
+            <div className="flex gap-1 text-body-16-regular sm:text-body-20-regular text-gray4">
               <button onClick={handleNavigate(MYPAGE_SUBPATH.FOLLOWING, true)}>
                 팔로잉 {userInfo?.followingNum ?? 0}
               </button>
@@ -230,16 +218,17 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
               </button>
             </div>
 
-            <p className="text-body-20-regular pt-4 pb-1">{userInfo?.bio}</p>
+            <p className="text-body-16-regular sm:text-body-20-regular pt-3 sm:pt-4 pb-1 break-words whitespace-pre-wrap">
+              {userInfo?.bio}
+            </p>
 
-            {/* 내 페이지일 때만 githubUrl 텍스트 표시(링크/호버 효과 X) */}
             {props.isMyPage && userInfo?.githubUrl && (
-              <div className="inline-flex items-center gap-2 text-body-20-regular text-gray3 break-all">
+              <div className="inline-flex items-center gap-2 text-body-16-regular sm:text-body-20-regular text-gray3 break-all">
                 <img
                   src={githubIcon}
                   alt=""
                   aria-hidden="true"
-                  className="w-8 h-8"
+                  className="w-5 h-5 sm:w-8 sm:h-8"
                 />
                 <span>{userInfo.githubUrl}</span>
               </div>
@@ -270,7 +259,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
 
       {/* 하단 메뉴*/}
       {props.isMyPage ? (
-        <div className="flex flex-col items-start gap-9 self-stretch text-gray3 text-head-20-semibold">
+        <div className="flex flex-col items-start gap-6 sm:gap-8 xl:gap-9 self-stretch text-gray3 text-head-20-semibold">
           <div className="w-full">
             <div
               className={`pb-2 border-b ${
@@ -281,7 +270,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
             >
               내 트러블 슈팅
             </div>
-            <div className="flex flex-col items-start gap-[13px] pt-2 text-body-16-regular text-gray3">
+            <div className="flex flex-col items-start gap-3 sm:gap-[13px] pt-2 text-body-16-regular text-gray3">
               <button
                 onClick={() => {
                   setSelectedStatus("all");
@@ -359,15 +348,14 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       ) : (
         <>
           {/* 태그 분석 (다른 사용자) */}
-          <div className="flex flex-col items-start gap-[12px] self-stretch">
+          <div className="flex flex-col items-start gap-3 sm:gap-[12px] self-stretch">
             <div className="w-full">
-              <div className="flex flex-col items-start gap-[12px]">
+              <div className="flex flex-col items-start gap-3 sm:gap-[12px]">
                 <span className="text-head-20-semibold">태그 분석</span>
-                <div className="w-full h-[1px] bg-[#939393]" />
+                <div className="w-full h-px bg-[#939393]" />
               </div>
 
-              <div className="flex flex-col items-start gap-[10px] pt-[12px]">
-                {/* 전체 보기 */}
+              <div className="flex flex-col items-start gap-2.5 sm:gap-[10px] pt-3 sm:pt-[12px]">
                 <button
                   type="button"
                   onClick={() => props.onSelectTag(null)}
@@ -380,7 +368,6 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
                   전체 보기
                 </button>
 
-                {/* 태그 리스트 */}
                 {props.sortedTags.map(([tag, count]) => {
                   const isSelected = props.selectedTag === tag;
                   return (
@@ -388,7 +375,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
                       key={tag}
                       type="button"
                       onClick={() => props.onSelectTag(isSelected ? null : tag)}
-                      className={`transition-colors ${
+                      className={`transition-colors break-words ${
                         isSelected
                           ? "text-body-16-semibold"
                           : "text-body-16-regular text-gray3"

--- a/src/components/MyPage/TroubleShootingCard.tsx
+++ b/src/components/MyPage/TroubleShootingCard.tsx
@@ -79,7 +79,6 @@ const TroubleShootingCard = ({
     }
   };
 
-  // 문서 삭제
   const handleDelete = async () => {
     if (
       !window.confirm(
@@ -87,13 +86,10 @@ const TroubleShootingCard = ({
       )
     )
       return;
-
     try {
       setDeleting(true);
       const postId = Number(id);
-
       await hardDeletePost(postId);
-
       onDeleted?.(postId);
       console.log("문서가 영구 삭제되었습니다.");
     } catch (err: any) {
@@ -110,7 +106,7 @@ const TroubleShootingCard = ({
 
   return (
     <div
-      className={`w-full py-[30px] flex flex-col items-start gap-[10px] border-b border-gray3 bg-white ${
+      className={`w-full py-5 sm:py-7 flex flex-col items-start gap-2.5 border-b border-gray3 bg-white ${
         isClickable
           ? "cursor-pointer"
           : disabled
@@ -124,17 +120,31 @@ const TroubleShootingCard = ({
       aria-disabled={disabled || undefined}
     >
       <div className="w-full flex flex-col">
-        {/* 작성자 */}
+        {/* 작성자 (검색 결과에서만 표시) */}
         {isSearchResult && (
-          <div className="mb-[25px] flex items-center gap-[12px]">
-            <img src={imageIcon} alt="profile" className="w-[52px] h-[52px]" />
-            <span className="text-head-24-bold">{authorName}</span>
+          <div className="mb-4 sm:mb-6 flex items-center gap-3 sm:gap-[12px]">
+            <img
+              src={imageIcon}
+              alt="profile"
+              className="w-10 h-10 sm:w-[52px] sm:h-[52px] rounded-full"
+            />
+            <span
+              className="text-head-20-semibold sm:text-head-24-bold truncate"
+              title={authorName}
+            >
+              {authorName}
+            </span>
           </div>
         )}
 
         {/* 에러 종류 + 케밥 메뉴 */}
-        <div className="flex justify-between items-start mb-[24px]">
-          <div className="text-body-16-regular">{errorCategory}</div>
+        <div className="flex justify-between items-start mb-4 sm:mb-6">
+          <div
+            className="text-body-14-regular sm:text-body-16-regular text-gray-800 truncate"
+            title={errorCategory}
+          >
+            {errorCategory}
+          </div>
           {!isSearchResult && isMine && (
             <div
               ref={menuRef}
@@ -158,89 +168,91 @@ const TroubleShootingCard = ({
             </div>
           )}
         </div>
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center self-stretch gap-[20px]">
+
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center self-stretch gap-4 md:gap-6">
           {/* 트러블로그 내용 영역 */}
-          <div className="w-full md:w-[680px] flex flex-col items-start gap-[34px]">
-            <div className="flex flex-col items-start gap-[24px] self-stretch">
+          <div className="w-full md:flex-1 md:min-w-0 flex flex-col items-start gap-6">
+            <div className="flex flex-col items-start gap-4 self-stretch min-w-0">
               {/* 제목 */}
-              <div className="flex flex-col items-start gap-[16px]">
-                <div className="flex items-center gap-[8px] self-stretch">
-                  <div className="text-head-24-bold break-words">{title}</div>
-                  {shouldShowSummaryType && summaryType && (
-                    <div className="text-gray3 text-body-16-regular">
-                      · {summaryType}
-                    </div>
-                  )}
-                  {shouldShowVisibilityIcon && visibility && (
-                    <img
-                      src={visibility === "public" ? publicIcon : privateIcon}
-                      alt={visibility}
-                      className="w-[24px] h-[24px]"
-                    />
-                  )}
+              <div className="flex flex-wrap items-center gap-2 self-stretch min-w-0">
+                <div className="text-head-24-bold break-words min-w-0">
+                  {title}
                 </div>
+                {shouldShowSummaryType && summaryType && (
+                  <div className="text-gray3 text-body-14-regular sm:text-body-16-regular">
+                    · {summaryType}
+                  </div>
+                )}
+                {shouldShowVisibilityIcon && visibility && (
+                  <img
+                    src={visibility === "public" ? publicIcon : privateIcon}
+                    alt={visibility}
+                    className="w-5 h-5 sm:w-6 sm:h-6"
+                  />
+                )}
               </div>
-              {/* 내용 프리뷰 */}
-              <div className="w-full text-gray3 text-ellipsis text-body-20-regular break-words">
+              {/* 내용 프리뷰 (모바일에서 라인 클램프) */}
+              <div className="w-full text-gray3 text-body-14-regular sm:text-body-16-regular md:text-body-20-regular break-words min-w-0 line-clamp-3 sm:line-clamp-2">
                 {content}
               </div>
             </div>
             {/* 태그 + 중요도 + 날짜 */}
-            <div className="flex flex-wrap items-center gap-[12px]">
+            <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
               <TagList tags={tags} variant="mypage" />
-              <div className="flex items-center gap-[12px]">
+              <div className="flex items-center gap-3">
                 {!isSearchResult && importance !== undefined && (
-                  <>
-                    <div className="flex items-center gap-[4px]">
-                      <img
-                        src={starIcon}
-                        alt="star"
-                        className="w-[20px] h-[20px]"
-                      />
-                      <span className="text-gray3 text-body-16-regular">
-                        {importance}
-                      </span>
-                    </div>
-                  </>
+                  <div className="flex items-center gap-1">
+                    <img
+                      src={starIcon}
+                      alt="star"
+                      className="w-4 h-4 sm:w-5 sm:h-5"
+                    />
+                    <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums">
+                      {importance}
+                    </span>
+                  </div>
                 )}
 
-                {/* 좋아요 + 댓글 수 */}
+                {/* 좋아요 + 댓글 수 (내 글이 아닐 때만) */}
                 {!isMine &&
                   (likeCount !== undefined || commentCount !== undefined) && (
-                    <div className="flex items-center gap-[12px]">
+                    <div className="flex items-center gap-3">
                       {likeCount !== undefined && (
-                        <div className="flex items-center gap-[4px]">
+                        <div className="flex items-center gap-1">
                           <img
                             src={heartIcon}
                             alt="likes"
-                            className="w-[20px] h-[20px]"
+                            className="w-4 h-4 sm:w-5 sm:h-5"
                           />
-                          <span className="text-gray3 text-body-16-regular">
+                          <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums">
                             {likeCount}
                           </span>
                         </div>
                       )}
                       {commentCount !== undefined && (
-                        <div className="flex items-center gap-[4px]">
+                        <div className="flex items-center gap-1">
                           <img
                             src={commentIcon}
                             alt="comments"
-                            className="w-[20px] h-[20px]"
+                            className="w-4 h-4 sm:w-5 sm:h-5"
                           />
-                          <span className="text-gray3 text-body-16-regular">
+                          <span className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums">
                             {commentCount}
                           </span>
                         </div>
                       )}
                     </div>
                   )}
-                <div className="text-gray3 text-body-16-regular">·</div>
-                <div className="text-gray3 text-body-16-regular">
+                <div className="text-gray3 text-body-14-regular sm:text-body-16-regular">
+                  ·
+                </div>
+                <div className="text-gray3 text-body-14-regular sm:text-body-16-regular tabular-nums">
                   {createdAt}
                 </div>
               </div>
             </div>
           </div>
+
           {/* 트러블로그 썸네일 */}
           <div className="w-full md:w-[240px] h-[144px] rounded-[16px] bg-[#ECECEC] overflow-hidden">
             {thumbnailUrl && (

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -38,24 +38,20 @@ const TroubleShootingList = () => {
   const selectedStatus = useMyPageStore((state) => state.selectedStatus);
   const selectedTag = useMyPageStore((state) => state.selectedTag);
 
-  // 작성 중일 땐 정렬 옵션 숨김
   const shouldShowSort = isMyPage && selectedStatus !== "inProgress";
 
-  // 작성 중으로 전환되면 정렬을 최신순으로 강제 맞춤(혼란 방지)
   useEffect(() => {
     if (isMyPage && selectedStatus === "inProgress" && sortBy !== "latest") {
       setSortBy("latest");
     }
   }, [isMyPage, selectedStatus, sortBy, setSortBy]);
 
-  // 내 마이페이지면 내 카드만, 아니면 다른 사람 카드만
   const base = useMemo(
     () =>
       isMyPage ? cards.filter((c) => c.isMine) : cards.filter((c) => !c.isMine),
     [cards, isMyPage]
   );
 
-  // 태그 필터 (다른 사용자 마이페이지만 해당)
   const tagFiltered = useMemo(
     () =>
       !isMyPage && selectedTag
@@ -64,7 +60,6 @@ const TroubleShootingList = () => {
     [base, isMyPage, selectedTag]
   );
 
-  // 상태 필터 (내 마이페이지만 해당)
   const statusFiltered = useMemo(
     () =>
       isMyPage && selectedStatus !== "all"
@@ -75,7 +70,6 @@ const TroubleShootingList = () => {
 
   const sortedCards = statusFiltered;
 
-  // 빈 상태 메시지
   const emptyMessage = useMemo(() => {
     if (isLoading) return null;
     if (sortedCards.length > 0) return null;
@@ -83,21 +77,15 @@ const TroubleShootingList = () => {
     const sortLabel = sortBy === "latest" ? "최신순" : "중요도순";
 
     if (isMyPage) {
-      if (selectedStatus === "inProgress") {
+      if (selectedStatus === "inProgress")
         return "작성 중인 트러블슈팅이 없어요.";
-      }
-      if (selectedStatus === "complete") {
+      if (selectedStatus === "complete")
         return `작성 완료된 트러블슈팅이 없어요. (${sortLabel})`;
-      }
-      if (selectedStatus === "created") {
+      if (selectedStatus === "created")
         return `작성+요약 완료된 트러블슈팅이 없어요. (${sortLabel})`;
-      }
       return `조건에 맞는 트러블슈팅이 없어요. (${sortLabel})`;
     } else {
-      // 다른 사용자 페이지
-      if (selectedTag) {
-        return `선택한 태그에 해당하는 트러블슈팅이 없어요.`;
-      }
+      if (selectedTag) return `선택한 태그에 해당하는 트러블슈팅이 없어요.`;
       return `아직 공개된 트러블슈팅이 없어요. (${sortLabel})`;
     }
   }, [
@@ -118,21 +106,29 @@ const TroubleShootingList = () => {
   };
 
   return (
-    <div className="flex flex-col items-end gap-[40px] w-[948px] pb-[78px]">
-      {/* 정렬 기준 선택 */}
+    <div className="w-full max-w-[948px] mx-auto px-4 sm:px-0 flex flex-col gap-6 sm:gap-10 pb-16 sm:pb-[78px]">
+      {/* 정렬 기준 선택 (우측 정렬 유지) */}
       {shouldShowSort && (
-        <SortButtonGroup selected={sortBy} onSelect={setSortBy} />
+        <div className="self-end">
+          <SortButtonGroup selected={sortBy} onSelect={setSortBy} />
+        </div>
       )}
 
       {/* 에러/로딩 */}
-      {error && <div className="text-red-600 self-start">{error}</div>}
+      {error && (
+        <div className="text-red-600 self-start text-body-14-regular sm:text-body-16-regular">
+          {error}
+        </div>
+      )}
 
       {/* 트러블로그 목록 */}
       <div className="flex flex-col items-start self-stretch">
         {/* 빈 상태 안내 */}
         {!error && !isLoading && sortedCards.length === 0 && emptyMessage && (
-          <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white mb-3">
-            <span className="text-body-20-regular">{emptyMessage}</span>
+          <div className="w-full flex h-[180px] sm:h-[220px] justify-center items-center rounded-[16px] bg-white mb-3">
+            <span className="text-body-16-regular sm:text-body-20-regular">
+              {emptyMessage}
+            </span>
           </div>
         )}
 
@@ -143,14 +139,12 @@ const TroubleShootingList = () => {
             onDeleted={handleDeleted}
             onClick={() => {
               const { goCombined, summaryId } = decideCombined(card, viewerId);
-
               if (goCombined && summaryId != null) {
                 navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
                   state: { from: "mypage", ownerId: viewerId ?? undefined },
                 });
                 return;
               }
-
               const qs = new URLSearchParams({ from: "mypage" });
               if (isMyPage && viewerId != null)
                 qs.set("ownerId", String(viewerId));
@@ -164,8 +158,8 @@ const TroubleShootingList = () => {
         {/* 로딩 스켈레톤 */}
         {isLoading && (
           <>
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-24 sm:h-30 bg-gray-100 rounded mb-3" />
+            <div className="w-full h-24 sm:h-30 bg-gray-100 rounded mb-3" />
           </>
         )}
 

--- a/src/components/Notification/NotificationToaster.tsx
+++ b/src/components/Notification/NotificationToaster.tsx
@@ -36,11 +36,16 @@ export default function NotificationToaster() {
   const handleClick = (link?: string) => {
     if (!link) return;
     try {
-      const url = new URL(link);
-      if (url.origin === window.location.origin)
+      const url = new URL(link, window.location.origin); // 상대경로도 파싱
+      const isHttp = url.protocol === "http:" || url.protocol === "https:";
+      if (!isHttp) return; // 위험 스킴 차단
+      if (url.origin === window.location.origin) {
         navigate(url.pathname + url.search + url.hash);
-      else window.location.href = link;
+      } else {
+        window.open(url.href, "_blank", "noopener,noreferrer"); // 외부는 새 탭
+      }
     } catch {
+      // SPA 상대 경로 등
       navigate(link);
     }
   };

--- a/src/components/Notification/NotificationToaster.tsx
+++ b/src/components/Notification/NotificationToaster.tsx
@@ -1,4 +1,3 @@
-// components/Notification/NotificationToaster.tsx
 import { useEffect, useRef } from "react";
 import { useNotificationStore } from "@/store/notification";
 import { useNavigate } from "react-router-dom";
@@ -7,12 +6,9 @@ export default function NotificationToaster() {
   const toasts = useNotificationStore((s) => s.toasts);
   const popToast = useNotificationStore((s) => s.popToast);
   const navigate = useNavigate();
-
-  // 이미 예약된 타이머 중복 방지 (리렌더 시 중복 등록을 막기 위해)
   const scheduledRef = useRef<Record<number, number>>({});
 
   useEffect(() => {
-    // 새로 생긴 토스트만 타이머 등록
     for (const t of toasts) {
       if (scheduledRef.current[t.id]) continue;
       const tid = window.setTimeout(() => {
@@ -21,8 +17,6 @@ export default function NotificationToaster() {
       }, 2500);
       scheduledRef.current[t.id] = tid;
     }
-
-    // 사라진 토스트의 타이머 정리
     const liveIds = new Set(toasts.map((t) => t.id));
     for (const id in scheduledRef.current) {
       const num = Number(id);
@@ -31,13 +25,11 @@ export default function NotificationToaster() {
         delete scheduledRef.current[num];
       }
     }
-
-    // 언마운트 안전 장치
     return () => {
       for (const id in scheduledRef.current) {
         clearTimeout(scheduledRef.current[Number(id)]);
       }
-      scheduledRef.current = {};
+      scheduledRef.current = {} as Record<number, number>;
     };
   }, [toasts, popToast]);
 
@@ -45,13 +37,10 @@ export default function NotificationToaster() {
     if (!link) return;
     try {
       const url = new URL(link);
-      if (url.origin === window.location.origin) {
+      if (url.origin === window.location.origin)
         navigate(url.pathname + url.search + url.hash);
-      } else {
-        window.location.href = link;
-      }
+      else window.location.href = link;
     } catch {
-      // 절대 URL이 아니면 내부 경로로 가정
       navigate(link);
     }
   };
@@ -59,12 +48,12 @@ export default function NotificationToaster() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[9999] flex flex-col gap-2">
+    <div className="fixed z-[9999] left-1/2 -translate-x-1/2 bottom-[calc(2rem+env(safe-area-inset-bottom))] flex flex-col gap-2 px-2 w-full max-w-screen-sm">
       {toasts.map((t) => (
         <button
           key={t.id}
           onClick={() => handleClick(t.link)}
-          className="px-4 py-2 rounded-full bg-black/90 text-white shadow-card hover:bg-black transition"
+          className="px-4 py-2 rounded-full bg-black/90 text-white shadow-card hover:bg-black transition text-left whitespace-normal break-words max-w-full"
           title={t.title}
         >
           <span className="font-semibold">{t.title}</span>

--- a/src/components/Project/SortButtonGroup.tsx
+++ b/src/components/Project/SortButtonGroup.tsx
@@ -8,7 +8,7 @@ export default function SortButtonGroup({
   onSelect,
 }: SortButtonGroupProps) {
   return (
-    <div className="flex items-center gap-[24px] sm:gap-[40px]">
+    <div className="flex items-center gap-4 sm:gap-6 md:gap-10">
       <button onClick={() => onSelect("latest")}>
         <span
           className={

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -6,7 +6,8 @@ export default function MainLayout() {
   return (
     <div className="min-h-screen flex flex-col bg-white w-full">
       <Header />
-      <main className="flex-1 max-w-screen-[1920px] px-4 sm:px-6 md:px-8">
+      {/* center content with a sane max width + responsive padding */}
+      <main className="flex-1 w-full max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8">
         <Outlet />
         <NotificationToaster />
       </main>

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -17,34 +17,28 @@ const MyPageLayout = () => {
   const myUserId = typeof window !== "undefined" ? myUserIdStr : null;
   const isMyPage = !!myUserId && id === myUserId;
 
-  // 정렬 상태
   const [sortBy, setSortBy] = useState<"latest" | "important">("latest");
 
-  // userId 숫자 파싱 (없거나 잘못된 경우 NaN)
   const userIdNum = useMemo(() => {
     const n = Number(id);
     return Number.isFinite(n) ? n : NaN;
   }, [id]);
 
-  // URL에서 tag 쿼리 읽기 (없으면 null)
   const selectedTag = useMemo(() => {
     const sp = new URLSearchParams(location.search);
     const t = sp.get("tag");
     return t && t.trim() ? t : null;
   }, [location.search]);
 
-  // 서브메뉴(팔로잉/팔로워 등) 어디에서든 태그 클릭 시 메인 마이페이지로 이동
   const handleSelectTag = (tag: string | null) => {
     if (!id) return;
     const url = tag
       ? `${PATH.MYPAGE(id)}?tag=${encodeURIComponent(tag)}`
       : PATH.MYPAGE(id);
     navigate(url);
-    // 상단으로 스크롤
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  // 훅에 넘길 source를 미리 계산
   const source = useMemo(
     () =>
       isMyPage
@@ -57,7 +51,6 @@ const MyPageLayout = () => {
     [isMyPage, userIdNum, selectedTag]
   );
 
-  // user 페이지인데 id가 유효하지 않으면 로딩을 막아두기
   const enabled = isMyPage || Number.isFinite(userIdNum);
 
   const { cards, isLoading, error, hasNext, sentinelRef, reload } =
@@ -68,18 +61,15 @@ const MyPageLayout = () => {
       enabled,
     });
 
-  // 공개글 판정 (여러 형태 대비)
   const isPublicCard = (c: any) =>
     c?.isVisible === true ||
     c?.visibility === "public" ||
     c?.raw?.isVisible === true;
 
-  // 다른 사람 마이페이지면 공개글만 사용
   const cardsForView = useMemo(() => {
     return isMyPage ? cards : cards.filter(isPublicCard);
   }, [cards, isMyPage]);
 
-  // 클라이언트 필터 적용
   const visibleCards = useMemo(() => {
     if (!selectedTag) return cardsForView;
     return cardsForView.filter((c) =>
@@ -87,7 +77,6 @@ const MyPageLayout = () => {
     );
   }, [cardsForView, selectedTag]);
 
-  // 작성 상태별 트러블슈팅 개수 계산
   const counts = useMemo(() => {
     const mine = cards.filter((c) => c.isMine);
     return {
@@ -98,7 +87,6 @@ const MyPageLayout = () => {
     };
   }, [cards]);
 
-  // 다른 사용자의 마이페이지용 태그 분석
   const sortedTags = useMemo<[string, number][]>(() => {
     if (cardsForView.length === 0) return [];
     const counter = new Map<string, number>();
@@ -116,33 +104,37 @@ const MyPageLayout = () => {
   }, [cardsForView]);
 
   return (
-    <div className="flex items-start gap-[68px] pt-20 justify-center">
-      <MyPageSideBar
-        {...(isMyPage
-          ? { isMyPage: true as const, counts }
-          : {
-              isMyPage: false as const,
-              sortedTags,
-              selectedTag,
-              onSelectTag: handleSelectTag,
-            })}
-      />
+    <div className="w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 sm:pt-20">
+      <div className="flex flex-col md:flex-row items-start gap-6 md:gap-10 xl:gap-[68px]">
+        <aside className="w-full md:w-[296px] flex-shrink-0">
+          <MyPageSideBar
+            {...(isMyPage
+              ? { isMyPage: true as const, counts }
+              : {
+                  isMyPage: false as const,
+                  sortedTags,
+                  selectedTag,
+                  onSelectTag: handleSelectTag,
+                })}
+          />
+        </aside>
 
-      <div className="flex flex-col items-start">
-        <Outlet
-          context={{
-            isMyPage,
-            cards: visibleCards,
-            isLoading,
-            error,
-            hasNext,
-            sentinelRef,
-            reload,
-            sortBy,
-            setSortBy,
-            selectedTag,
-          }}
-        />
+        <section className="flex-1 min-w-0 flex flex-col items-start">
+          <Outlet
+            context={{
+              isMyPage,
+              cards: visibleCards,
+              isLoading,
+              error,
+              hasNext,
+              sentinelRef,
+              reload,
+              sortBy,
+              setSortBy,
+              selectedTag,
+            }}
+          />
+        </section>
       </div>
     </div>
   );

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -29,8 +29,8 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     commentCount: t.commentCount ?? undefined,
     introduction: t.introduction ?? undefined,
 
-    summaryId: pickLatestSummaryId(t),
-    postSummaryId: t.postSummaryId ?? null,
+    summaryId: pickLatestSummaryId(t) ?? undefined,
+    postSummaryId: t.postSummaryId ?? undefined,
     summaries: t.summaries ?? [],
   };
 };

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -24,8 +24,7 @@ export default function CommunityPage() {
   // UI 라벨 -> API sort 파라미터 매핑
   const sortBy: CommunitySort = useMemo(() => {
     if (selectedSort === "최신순" || selectedSort === "전체") return "latest";
-    // "추천순" / "좋아요순" 모두 likes에 매핑
-    return "likes";
+    return "likes"; // "추천순" / "좋아요순" 모두 likes에 매핑
   }, [selectedSort]);
 
   // 커뮤니티 목록 불러오기 (기본 목록)
@@ -35,33 +34,32 @@ export default function CommunityPage() {
     pageSize: 12,
     infinite: true,
     rootMargin: "400px 0px",
-    sourceKey: "community", // 기본값이라 생략 가능
+    sourceKey: "community",
   });
 
   // 최근 읽은 포스트 목록
   const recentFetcher = useCallback<CommunityCardsFetcher>(
-    (page, size) => getCommunityRecentList(page, size), // sort 미사용
+    (page, size) => getCommunityRecentList(page, size),
     []
   );
 
   const recent = useCommunityCards({
     enabled: selectedTab === "recent",
-    sortBy: "latest", // 정렬 옵션 미사용이지만 시그니처 맞춤
+    sortBy: "latest",
     pageSize: 12,
     infinite: true,
     rootMargin: "400px 0px",
     fetcher: recentFetcher,
-    sourceKey: "community_recent", // 캐시/리셋 구분용
+    sourceKey: "community_recent",
   });
 
-  // 활성 데이터셋 선택
   const active = selectedTab === "trouble" ? trouble : recent;
 
   return (
-    <div className="flex flex-col mt-[79px] mb-[104px] max-w-[1600px] w-full mx-auto px-4 gap-[50px]">
-      <div className="flex w-full justify-between">
+    <div className="flex flex-col mt-10 sm:mt-[79px] mb-16 sm:mb-[104px] max-w-[1600px] w-full mx-auto px-4 gap-8 sm:gap-[50px]">
+      <div className="flex w-full flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-0">
         {/* 옵션 탭 */}
-        <div className="flex gap-[40px]">
+        <div className="flex gap-3 sm:gap-[40px] w-full sm:w-auto">
           {/* 트러블 슈팅 둘러보기 탭*/}
           <button onClick={() => setSelectedTab("trouble")}>
             <div className="flex flex-col items-start gap-[8px]">
@@ -101,21 +99,25 @@ export default function CommunityPage() {
 
         {/* 정렬 옵션 드롭다운 */}
         {selectedTab === "trouble" && (
-          <GenericDropdown<SortOption>
-            options={sortOptions}
-            selected={selectedSort}
-            onSelect={setSelectedSort}
-          />
+          <div className="self-start sm:self-auto mt-2 sm:mt-0">
+            <GenericDropdown<SortOption>
+              options={sortOptions}
+              selected={selectedSort}
+              onSelect={setSelectedSort}
+            />
+          </div>
         )}
       </div>
 
       {/* 에러 */}
       {active.error && (
-        <div className="text-red-600 text-body-16-regular">{active.error}</div>
+        <div className="text-red-600 text-body-14-regular sm:text-body-16-regular">
+          {active.error}
+        </div>
       )}
 
       {/* 트러블로그 카드 */}
-      <div className="w-full mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-[24px] gap-y-[60px]">
+      <div className="w-full mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 sm:gap-x-6 gap-y-8 sm:gap-y-[60px]">
         {active.cards.map((card) => (
           <div key={card.id} className="cursor-pointer">
             <TroublogCard
@@ -147,15 +149,19 @@ export default function CommunityPage() {
         {/* 로딩 스켈레톤 */}
         {active.isLoading && (
           <>
-            <div className="w-full h-[300px] bg-gray-100 rounded-2xl" />
-            <div className="w-full h-[300px] bg-gray-100 rounded-2xl" />
-            <div className="w-full h-[300px] bg-gray-100 rounded-2xl" />
+            <div className="w-full h-[220px] sm:h-[300px] bg-gray-100 rounded-2xl" />
+            <div className="w-full h-[220px] sm:h-[300px] bg-gray-100 rounded-2xl" />
+            <div className="w-full h-[220px] sm:h-[300px] bg-gray-100 rounded-2xl" />
           </>
         )}
 
         {/* 무한스크롤 센티널 */}
         {active.hasNext && (
-          <div ref={active.sentinelRef} style={{ height: 1 }} />
+          <div
+            ref={active.sentinelRef}
+            className="col-span-full"
+            style={{ height: 1 }}
+          />
         )}
       </div>
     </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -58,7 +58,11 @@ export interface CommunityPostDetailProps {
 }
 
 export default function CommunityPostDetail() {
-  const HEADER_OFFSET = 520;
+  const HEADER_OFFSET = 100;
+
+  // 고정 폭(상단 콘텐츠/본문 공통)
+  const CONTENT_WIDTH_CLASS =
+    "w-full sm:w-[600px] md:w-[720px] lg:w-[920px] xl:w-[1200px]";
 
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
@@ -91,7 +95,47 @@ export default function CommunityPostDetail() {
 
   // 섹션 추적
   const [currentSection, setCurrentSection] = useState<number>(0);
-  const sectionRefs = useRef<(HTMLElement | null)[]>([]);
+  // 본문 컬럼과 첫 섹션 기준 측정
+  const contentColRef = useRef<HTMLDivElement | null>(null);
+  const [asideOffset, setAsideOffset] = useState(0);
+  // 섹션 refs는 HTMLDivElement로 구체화
+  const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  useEffect(() => {
+    const updateAsideOffset = () => {
+      const first = sectionRefs.current[0];
+      const col = contentColRef.current;
+      if (!first || !col) {
+        setAsideOffset(0);
+        return;
+      }
+      const firstTop = first.getBoundingClientRect().top + window.scrollY;
+      const colTop = col.getBoundingClientRect().top + window.scrollY;
+      const gap = Math.max(0, Math.round(firstTop - colTop));
+      setAsideOffset(gap);
+    };
+
+    // 초기에 한 번, 레이아웃 안정화 직후 한 번
+    requestAnimationFrame(updateAsideOffset);
+
+    // 리사이즈/폰트/이미지 로딩 등 레이아웃 변화에 대응
+    const onResize = () => updateAsideOffset();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("load", onResize);
+
+    // 본문 컬럼 변화를 관찰(높이/폭 변동)
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined" && contentColRef.current) {
+      ro = new ResizeObserver(updateAsideOffset);
+      ro.observe(contentColRef.current);
+    }
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("load", onResize);
+      ro?.disconnect();
+    };
+  }, [post]); // post가 로드된 뒤에 계산
 
   // 이어서 작성 안내 경고창
   const resumePromptShownRef = useRef<Record<number, boolean>>({});
@@ -802,147 +846,157 @@ export default function CommunityPostDetail() {
   // 로딩/에러 처리
   if (loading) {
     return (
-      <div className="flex justify-center">
-        <div className="flex flex-col items-start max-w-[1200px] ml-[360px] mr-[36px] gap-[24px] w-full pt-[180px]">
-          <div className="w-full h-[120px] bg-gray-100 rounded" />
-          <div className="w-full h-[400px] bg-gray-100 rounded" />
+      <div className="w-full px-4 sm:px-6 md:px-8">
+        <div className="mx-auto flex justify-center">
+          <div
+            className={`${CONTENT_WIDTH_CLASS} flex flex-col gap-6 sm:gap-[24px] pt-24 sm:pt-[180px]`}
+          >
+            <div className="w-full h-[120px] bg-gray-100 rounded" />
+            <div className="w-full h-[400px] bg-gray-100 rounded" />
+          </div>
         </div>
       </div>
     );
   }
   if (loadError || !post) {
     return (
-      <div className="flex justify-center">
-        <div className="max-w-[1200px] w-full pt-[180px] text-red-600">
-          {loadError ?? "포스트를 찾을 수 없습니다."}
+      <div className="w-full px-4 sm:px-6 md:px-8">
+        <div className="mx-auto flex justify-center">
+          <div
+            className={`${CONTENT_WIDTH_CLASS} pt-24 sm:pt-[180px] text-red-600`}
+          >
+            {loadError ?? "포스트를 찾을 수 없습니다."}
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex justify-center">
-      {/* 포스트 영역 */}
-      <div className="flex flex-col items-start max-w-[1200px] ml-[360px] mr-[36px] gap-[56px] mb-[224px]">
-        {/* 상단 영역 */}
-        <div className="flex w-full pt-[180px] pb-[18px] items-center border-b border-gray1">
-          <div className="flex flex-col items-start gap-[44px]">
-            <div className="flex flex-col items-start gap-[53px]">
-              <div className="flex flex-col items-start gap-[10px]">
-                {/* 에러 종류 & (케밥 버튼) */}
-                <div className="flex w-[1200px] justify-between items-start">
-                  <span className="text-head-20-semibold">
-                    {post.errorType}
-                  </span>
-                  {post.isMine && (
-                    <div className="relative" ref={menuRef}>
-                      <KebabMenuButton onClick={() => setShowMenu(!showMenu)} />
-                      {showMenu && (
-                        <KebabDropdown
-                          options={[
-                            {
-                              label: "포스트 수정",
-                              onClick: () => {
-                                void goEditWithPrefill();
-                              },
-                            },
-                            {
-                              label: deleting ? "삭제 중..." : "삭제",
-                              onClick: () => !deleting && handleDeletePost(),
-                            },
-                          ]}
+    <div className="w-full px-4 sm:px-6 md:px-8">
+      {/* 전체(본문+TOC) 그룹을 가로 중앙 정렬 */}
+      <div className="mx-auto flex items-start justify-center gap-6">
+        {/* 본문 컬럼: 상단/본문/댓글이 모두 동일한 고정 폭을 사용 */}
+        <div
+          ref={contentColRef}
+          className={`${CONTENT_WIDTH_CLASS} flex flex-col items-start gap-8 sm:gap-[56px] mb-24 sm:mb-[224px]`}
+        >
+          {/* 상단 영역 */}
+          <div className="flex w-full pt-20 sm:pt-[180px] pb-[18px] items-center border-b border-gray1">
+            <div className="flex flex-col items-start gap-8 sm:gap-[44px] w-full">
+              <div className="flex flex-col items-start gap-8 sm:gap-[53px] w-full">
+                <div className="flex flex-col items-start gap-[10px] w-full">
+                  {/* 에러 종류 & (케밥 버튼) */}
+                  <div className="flex w-full justify-between items-start">
+                    <span className="text-head-20-semibold">
+                      {post.errorType}
+                    </span>
+                    {post.isMine && (
+                      <div className="relative" ref={menuRef}>
+                        <KebabMenuButton
+                          onClick={() => setShowMenu(!showMenu)}
                         />
-                      )}
-                    </div>
-                  )}
+                        {showMenu && (
+                          <KebabDropdown
+                            options={[
+                              {
+                                label: "포스트 수정",
+                                onClick: () => void goEditWithPrefill(),
+                              },
+                              {
+                                label: deleting ? "삭제 중..." : "삭제",
+                                onClick: () => !deleting && handleDeletePost(),
+                              },
+                            ]}
+                          />
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 포스트 제목 */}
+                  <div className="text-head-48 break-words">{post.title}</div>
                 </div>
 
-                {/* 포스트 제목 */}
-                <div className="text-head-48">{post.title}</div>
-              </div>
-
-              {/* 태그 & 작성일 */}
-              <div className="flex items-center gap-[16px]">
-                <TagList tags={post.tags} variant="post" />
-                <div className="text-body-16-regular text-gray3">·</div>
-                <div className="text-body-20-regular text-gray3">
-                  {post.date}
-                </div>
-              </div>
-            </div>
-
-            {/* 작성자 정보 & 중요도 */}
-            <div className="flex w-full items-center justify-between">
-              <div
-                className="flex items-center gap-[20px] cursor-pointer"
-                onClick={() => navigate(PATH.MYPAGE(String(post.authorId)))}
-              >
-                <img
-                  src={post.authorProfile || imageIcon}
-                  onError={(e) => {
-                    e.currentTarget.src = imageIcon;
-                  }}
-                  alt="profile"
-                  className="w-[66px] h-[66px]"
-                />
-                <div className="text-head-24-bold">{post.authorName}</div>
-              </div>
-
-              {post.isMine && post.importance !== 0 && (
-                <div className="flex items-center gap-[8px]">
-                  <img
-                    src={starIcon}
-                    alt="importance"
-                    className="w-[24px] h-[24px]"
-                  />
+                {/* 태그 & 작성일 */}
+                <div className="flex flex-wrap items-center gap-[12px] sm:gap-[16px]">
+                  <TagList tags={post.tags} variant="post" />
+                  <div className="text-body-16-regular text-gray3">·</div>
                   <div className="text-body-20-regular text-gray3">
-                    {post.importance}
+                    {post.date}
                   </div>
                 </div>
-              )}
-            </div>
-          </div>
-        </div>
+              </div>
 
-        {/* 하단 영역 */}
-        <div className="flex w-full flex-col items-start gap-[8px]">
-          {/* 메인 */}
-          <div className="flex flex-col items-start gap-[36px] self-stretch">
-            {/* 포스트 내용 & 작성자 정보 */}
-            <div className="flex flex-col items-start self-stretch">
-              <div className="flex flex-col items-start gap-[48px] self-stretch">
-                {/* 포스트 내용 */}
-                <div className="flex flex-col items-start gap-[48px] self-stretch">
-                  {post.questions.map((q, idx) => (
-                    <div
-                      id={`section-${idx}`}
-                      key={idx}
-                      ref={(el) => {
-                        sectionRefs.current[idx] = el;
-                      }}
-                      className="scroll-mt-[520px]"
-                    >
-                      <PostGuideMd question={q} content={post.contents[idx]} />
-                    </div>
-                  ))}
+              {/* 작성자 정보 & 중요도 */}
+              <div className="flex w-full flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+                <div
+                  className="flex items-center gap-[14px] sm:gap-[20px] cursor-pointer"
+                  onClick={() => navigate(PATH.MYPAGE(String(post.authorId)))}
+                >
+                  <img
+                    src={post.authorProfile || imageIcon}
+                    onError={(e) => (e.currentTarget.src = imageIcon)}
+                    alt="profile"
+                    className="w-12 h-12 sm:w-[66px] sm:h-[66px] rounded-full object-cover"
+                  />
+                  <div className="text-head-24-bold">{post.authorName}</div>
                 </div>
 
-                {/* 작성자 정보 */}
-                <div className="flex py-[32px] px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[36px] bg-[#F2F2F2]">
-                  <div className="flex justify-between items-center self-stretch">
+                {post.isMine && post.importance !== 0 && (
+                  <div className="flex items-center gap-[8px]">
+                    <img
+                      src={starIcon}
+                      alt="importance"
+                      className="w-5 h-5 sm:w-[24px] sm:h-[24px]"
+                    />
+                    <div className="text-body-20-regular text-gray3">
+                      {post.importance}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 하단 영역 */}
+          <div className="flex w-full flex-col items-start gap-[8px]">
+            {/* 메인 */}
+            <div className="flex flex-col items-start gap-[36px] self-stretch">
+              {/* 포스트 내용 */}
+              <div className="flex flex-col items-start gap-[48px] self-stretch">
+                {post.questions.map((q, idx) => (
+                  <div
+                    id={`section-${idx}`}
+                    key={idx}
+                    ref={(el) => {
+                      sectionRefs.current[idx] = el;
+                    }}
+                    style={{ scrollMarginTop: HEADER_OFFSET + 1 }}
+                    className="scroll-mt-28 md:scroll-mt-[520px]"
+                  >
+                    <PostGuideMd
+                      question={q}
+                      content={post.contents[idx]}
+                      widthClass={CONTENT_WIDTH_CLASS}
+                    />
+                  </div>
+                ))}
+
+                {/* 작성자 정보 카드 */}
+                <div className="flex py-[24px] sm:py-[32px] px-5 sm:px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[24px] sm:rounded-[36px] bg-[#F2F2F2]">
+                  <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center self-stretch gap-4">
                     <div
-                      className="flex items-center gap-[28px] cursor-pointer"
+                      className="flex items-center gap-4 sm:gap-[28px] cursor-pointer"
                       onClick={handleProfileClick}
                     >
                       <img
                         src={post.authorProfile || imageIcon}
-                        onError={(e) => {
-                          e.currentTarget.src = imageIcon;
-                        }}
+                        onError={(e) => (e.currentTarget.src = imageIcon)}
                         alt="profile"
-                        className="w-[131px] h-[131px]"
+                        className="w-20 h-20 sm:w-[131px] sm:h-[131px] rounded-full object-cover"
                       />
-                      <div className="flex flex-col items-start gap-[13px]">
+                      <div className="flex flex-col items-start gap-[10px] sm:gap-[13px]">
                         <div className="flex flex-col items-start gap-[2px]">
                           <div className="text-head-24-bold">
                             {post.authorName}
@@ -951,190 +1005,180 @@ export default function CommunityPostDetail() {
                             {post.authorFollowers} 팔로워
                           </div>
                         </div>
-                        <div className="text-body-18-regular">
+                        <div className="text-body-20-regular">
                           {post.authorBio}
                         </div>
                       </div>
                     </div>
 
-                    {/* 팔로우 버튼 */}
-                    {!post.isMine && (
-                      <>
-                        {post.isFollowed ? (
-                          <button
-                            onClick={() => handleUnfollow()}
-                            className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-subColor1 text-head-20-semibold text-white cursor-pointer"
-                          >
-                            팔로잉
-                          </button>
-                        ) : (
-                          <button
-                            onClick={() => handleFollow()}
-                            className="flex py-[18px] pl-[41px] pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white cursor-pointer"
-                          >
-                            팔로우
-                          </button>
-                        )}
-                      </>
-                    )}
+                    {!post.isMine &&
+                      (post.isFollowed ? (
+                        <button
+                          onClick={() => handleUnfollow()}
+                          className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-subColor1 text-head-20-semibold text-white"
+                        >
+                          팔로잉
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => handleFollow()}
+                          className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white"
+                        >
+                          팔로우
+                        </button>
+                      ))}
                   </div>
                 </div>
               </div>
-            </div>
 
-            {/* 좋아요, 공유 (커뮤니티 글에서만 노출) */}
-            {isCommunitySource && (
-              <div className="flex pt-[52px] pb-[20px] items-center self-stretch border-b border-gray1">
-                <div className="flex items-center gap-[20px]">
+              {/* 좋아요/공유 */}
+              {isCommunitySource && (
+                <div className="flex pt-8 sm:pt-[52px] pb-5 sm:pb-[20px] items-center self-stretch border-b border-gray1">
+                  <div className="flex items-center gap-4 sm:gap-[20px]">
+                    <button
+                      type="button"
+                      aria-pressed={isLiked}
+                      aria-busy={isLiking}
+                      disabled={isLiking}
+                      onClick={handleToggleLike}
+                      className={`flex items-center gap-2 sm:gap-[8px] ${
+                        isLiking
+                          ? "opacity-60 cursor-not-allowed"
+                          : "cursor-pointer"
+                      }`}
+                    >
+                      <img
+                        src={isLiked ? heartIcon : likeEmptyIcon}
+                        alt="like"
+                        className="w-8 h-8 sm:w-10 sm:h-10"
+                      />
+                      <div className="text-body-20-regular text-gray3">
+                        {likeCounts}
+                      </div>
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={handleCopyLink}
+                      className="cursor-pointer"
+                      aria-label="현재 페이지 링크 복사"
+                    >
+                      <img
+                        src={shareIcon}
+                        alt="share"
+                        className="w-8 h-8 sm:w-10 sm:h-10"
+                      />
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* 댓글 작성 */}
+              {isCommunitySource && (
+                <div className="flex flex-col items-end gap-[12px] self-stretch">
+                  <div className="flex flex-col items-start gap-6 sm:gap-[36px] self-stretch">
+                    <div className="text-head-32-semibold">
+                      {post.commentCounts}개의 댓글
+                    </div>
+                    <textarea
+                      value={commentInput}
+                      onChange={(e) => setCommentInput(e.target.value)}
+                      placeholder="댓글을 작성해주세요."
+                      className="flex p-4 sm:pt-[28px] sm:pl-[32px] pb-24 sm:pb-[130px] w-full resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
+                    />
+                  </div>
+
                   <button
-                    type="button"
-                    aria-pressed={isLiked}
-                    aria-busy={isLiking}
-                    disabled={isLiking}
-                    onClick={handleToggleLike}
-                    className={`flex items-center gap-[8px] ${
-                      isLiking
-                        ? "opacity-60 cursor-not-allowed"
-                        : "cursor-pointer"
+                    disabled={!commentInput.trim() || isCommentPosting}
+                    onClick={handleSubmitComment}
+                    className={`flex px-6 sm:pl-[32px] sm:pr-[31px] py-2 sm:pt-[8px] sm:pb-[12px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
+                      commentInput.trim() && !isCommentPosting
+                        ? "bg-primary"
+                        : "bg-subColor1"
                     }`}
                   >
-                    <img
-                      src={isLiked ? heartIcon : likeEmptyIcon}
-                      alt="like"
-                      className="w-[40px] h-[40px]"
-                    />
-                    <div className="text-body-20-regular text-gray3">
-                      {likeCounts}
-                    </div>
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={handleCopyLink}
-                    className="cursor-pointer"
-                    aria-label="현재 페이지 링크 복사"
-                  >
-                    <img
-                      src={shareIcon}
-                      alt="share"
-                      className="w-[40px] h-[40px]"
-                    />
+                    {isCommentPosting ? "작성 중…" : "작성하기"}
                   </button>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
 
-            {/* 댓글 작성 창 (커뮤니티 글에서만) */}
+            {/* 댓글 목록 */}
             {isCommunitySource && (
-              <div className="flex flex-col items-end gap-[12px] self-stretch">
-                <div className="flex flex-col items-start gap-[36px] self-stretch">
-                  <div className="text-head-32-semibold">
-                    {post.commentCounts}개의 댓글
-                  </div>
-                  <textarea
-                    value={commentInput}
-                    onChange={(e) => setCommentInput(e.target.value)}
-                    placeholder="댓글을 작성해주세요."
-                    className="flex pt-[28px] pl-[32px] pb-[130px] w-full items-start self-stretch resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
-                  ></textarea>
-                </div>
+              <div className="flex flex-col items-end self-stretch">
+                {comments
+                  .filter((c) => !c.isReply)
+                  .map((parent) => (
+                    <div key={parent.id} className="w-full">
+                      <PostComment
+                        {...parent}
+                        onEdit={(newContent) =>
+                          handleEdit(parent.id, newContent)
+                        }
+                        onDelete={() => handleDelete(parent.id)}
+                        onReply={(replyContent) =>
+                          handleReply(parent.id, replyContent)
+                        }
+                      />
+                      {comments
+                        .filter((c) => c.parentId === parent.id)
+                        .map((reply) => (
+                          <PostComment
+                            key={reply.id}
+                            {...reply}
+                            onEdit={(newContent) =>
+                              handleEdit(reply.id, newContent)
+                            }
+                            onDelete={() => handleDelete(reply.id)}
+                          />
+                        ))}
+                    </div>
+                  ))}
 
-                <button
-                  disabled={!commentInput.trim() || isCommentPosting}
-                  onClick={handleSubmitComment}
-                  className={`flex pt-[8px] pl-[32px] pb-[12px] pr-[31px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
-                    commentInput.trim() && !isCommentPosting
-                      ? "bg-primary"
-                      : "bg-subColor1"
-                  }`}
-                >
-                  {isCommentPosting ? "작성 중…" : "작성하기"}
-                </button>
+                {cHasNext && postId && (
+                  <button
+                    disabled={cLoading}
+                    onClick={() =>
+                      loadComments(
+                        Number(postId),
+                        cPage,
+                        detailCtx.viewerId ?? null
+                      )
+                    }
+                    className={`mt-4 px-6 py-2 rounded-full text-white ${
+                      cLoading ? "bg-gray-300" : "bg-primary"
+                    }`}
+                  >
+                    {cLoading ? "불러오는 중…" : "댓글 더 보기"}
+                  </button>
+                )}
               </div>
             )}
           </div>
-
-          {/* 댓글 목록 (커뮤니티 글에서만) */}
-          {isCommunitySource && (
-            <div className="flex flex-col items-end self-stretch">
-              {comments
-                .filter((c) => !c.isReply)
-                .map((parent) => (
-                  <div key={parent.id} className="w-full">
-                    <PostComment
-                      {...parent}
-                      onEdit={(newContent) => handleEdit(parent.id, newContent)}
-                      onDelete={() => handleDelete(parent.id)}
-                      onReply={(replyContent) =>
-                        handleReply(parent.id, replyContent)
-                      }
-                    />
-                    {comments
-                      .filter((c) => c.parentId === parent.id)
-                      .map((reply) => (
-                        <PostComment
-                          key={reply.id}
-                          {...reply}
-                          onEdit={(newContent) =>
-                            handleEdit(reply.id, newContent)
-                          }
-                          onDelete={() => handleDelete(reply.id)}
-                        />
-                      ))}
-                  </div>
-                ))}
-
-              {cHasNext && postId && (
-                <button
-                  disabled={cLoading}
-                  onClick={() =>
-                    loadComments(
-                      Number(postId),
-                      cPage,
-                      detailCtx.viewerId ?? null
-                    )
-                  }
-                  className={`mt-4 px-6 py-2 rounded-full text-white ${
-                    cLoading ? "bg-gray-300" : "bg-primary"
-                  }`}
-                >
-                  {cLoading ? "불러오는 중…" : "댓글 더 보기"}
-                </button>
-              )}
-            </div>
-          )}
         </div>
-      </div>
 
-      {/* 목차 */}
-      <div
-        className="inline-flex items-start mt-[588px] mr-[89px]
-        sticky top-[588px] h-fit
-        w-[220px] sm:w-[240px] md:w-[280px] lg:w-[320px]
-        flex-shrink-0"
-      >
-        <div
-          className=" flex flex-col items-start gap-[16px]
-          border-l border-gray3
-          pl-[12px] pr-[8px]  
-          text-body-20-regular text-gray3
-          w-full"
+        {/* 목차(TOC): 큰 화면에서만 보이되, 본문과 함께 중앙 정렬 그룹에 포함 */}
+        <aside
+          className="hidden xl:block h-fit w-[260px] 2xl:w-[320px] sticky"
+          style={{ top: HEADER_OFFSET, marginTop: asideOffset }}
         >
-          {post.questions.map((q, idx) => (
-            <button
-              key={idx}
-              onClick={() => scrollToSection(idx)}
-              className={`text-left ${
-                currentSection === idx ? "text-black" : ""
-              }`}
-            >
-              {idx + 1}. {q}
-            </button>
-          ))}
-        </div>
+          <div className="flex flex-col items-start gap-[16px] border-l border-gray3 pl-[12px] pr-[8px] text-body-20-regular text-gray3 w-full">
+            {post.questions.map((q, idx) => (
+              <button
+                key={idx}
+                onClick={() => scrollToSection(idx)}
+                className={`text-left ${
+                  currentSection === idx ? "text-black" : ""
+                }`}
+              >
+                {idx + 1}. {q}
+              </button>
+            ))}
+          </div>
+        </aside>
       </div>
 
-      {/* 토스트 UI (공유 관련) */}
+      {/* 공유 토스트 */}
       {toast.open && (
         <div
           role="status"

--- a/src/pages/Error/AuthGuardPage.tsx
+++ b/src/pages/Error/AuthGuardPage.tsx
@@ -36,7 +36,7 @@ export default function AuthGuardPage() {
   };
 
   return (
-    <main className="w-full flex items-center justify-center py-24 px-6">
+    <section className="w-full flex items-center justify-center py-24 px-6">
       <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
         <div className="flex flex-col items-center text-center gap-6">
           <div className="flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
@@ -78,6 +78,6 @@ export default function AuthGuardPage() {
           </div>
         </div>
       </section>
-    </main>
+    </section>
   );
 }

--- a/src/pages/Error/NotFoundPage.tsx
+++ b/src/pages/Error/NotFoundPage.tsx
@@ -26,7 +26,7 @@ export default function NotFoundPage() {
   };
 
   return (
-    <main className="w-full flex items-center justify-center py-24 px-6">
+    <section className="w-full flex items-center justify-center py-24 px-6">
       <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
         <div className="flex flex-col items-center text-center gap-6">
           <div className="flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
@@ -64,6 +64,6 @@ export default function NotFoundPage() {
           </div>
         </div>
       </section>
-    </main>
+    </section>
   );
 }

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -20,7 +20,6 @@ import { decideCombined } from "@/utils/combinedRoute";
 
 const PAGE_SIZE = 10;
 
-// StrictMode 중복/동시 호출 방지: 페이지별 in-flight Promise 공유
 type ProjectPageResp = {
   content: ProjectListItem[];
   hasNext?: boolean;
@@ -53,7 +52,6 @@ export default function HomePage() {
   );
 
   const navigate = useNavigate();
-
   const viewerId = useViewerId();
 
   const goGuide = useCallback(
@@ -72,7 +70,6 @@ export default function HomePage() {
     [navigate]
   );
 
-  // 글쓰기 드롭다운 버튼 클릭 핸들러
   const handleGoGuideTemplate = () => goGuide();
   const handleGoFreeformTemplate = () => goFreeform();
 
@@ -83,11 +80,10 @@ export default function HomePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<unknown>(null);
 
-  // 최신 상태를 콜백에서 안전히 읽기 위한 ref들
   const isLoadingRef = useRef(false);
   const hasNextRef = useRef(false);
   const pageRef = useRef(1);
-  const fetchingRef = useRef(false); // 중복 실행 락
+  const fetchingRef = useRef(false);
 
   useEffect(() => {
     isLoadingRef.current = isLoading;
@@ -99,7 +95,6 @@ export default function HomePage() {
     pageRef.current = page;
   }, [page]);
 
-  // 트러블슈팅 목록 불러오기
   const {
     cards: recentCards,
     isLoading: isLoadingRecents,
@@ -112,17 +107,13 @@ export default function HomePage() {
     { infinite: true, pageSize: 10, sortBy: "latest" }
   );
 
-  // 센티널(관찰 대상) 참조
   const sentinelRef = useRef<HTMLDivElement | null>(null);
-
-  // 중복 추가 방지용 id 집합(옵션)
   const idSetRef = useRef<Set<number>>(new Set());
 
-  // 페이지 로딩 함수(append)
   const loadPage = useCallback(
     async (nextPage: number, { append = true, useOnce = true } = {}) => {
-      if (isLoadingRef.current) return; // 직전 로딩 중이면 무시
-      if (!hasNextRef.current && nextPage !== 1) return; // 더 없는데 추가 요청이면 무시
+      if (isLoadingRef.current) return;
+      if (!hasNextRef.current && nextPage !== 1) return;
 
       setIsLoading(true);
       setLoadError(null);
@@ -139,11 +130,9 @@ export default function HomePage() {
         setPage(nextPage);
 
         if (!append || nextPage === 1) {
-          // 전체 초기화
           idSetRef.current = new Set(list.map((x) => x.id));
           setProjects(list);
         } else {
-          // 중복 방지하며 이어 붙이기
           const acc: ProjectListItem[] = [];
           for (const item of list) {
             if (!idSetRef.current.has(item.id)) {
@@ -162,13 +151,11 @@ export default function HomePage() {
     []
   );
 
-  // 최초 1페이지 로딩
   useEffect(() => {
     loadPage(1, { append: false, useOnce: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // 의도적으로 초기 로드만 수행
+  }, []);
 
-  // IntersectionObserver로 다음 페이지 자동 로드
   useEffect(() => {
     if (!sentinelRef.current) return;
     const el = sentinelRef.current;
@@ -191,18 +178,16 @@ export default function HomePage() {
       },
       {
         root: null,
-        rootMargin: "300px 0px", // 너무 일찍 당기면 연속 호출됨 → 300px 정도 권장
+        rootMargin: "300px 0px",
         threshold: 0,
       }
     );
 
     io.observe(el);
     return () => io.disconnect();
-    // 의존성 없음: 최초 한 번만
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 새 프로젝트 생성 후 목록 리셋(1페이지부터 다시)
   const handleCreateProject = async (data: CreateProjectRequest) => {
     try {
       setCreating(true);
@@ -217,7 +202,6 @@ export default function HomePage() {
 
       await postCreateProject(payload);
 
-      // 목록 초기화 후 1페이지 재조회
       setProjects([]);
       idSetRef.current = new Set();
       setPage(1);
@@ -247,28 +231,22 @@ export default function HomePage() {
   const handleCloseModal = useCallback(() => setIsModalOpen(false), []);
   const dropdownRef = useClickOutside(() => setShowDropdown(false));
 
-  // 프로젝트 폴더 카드 수정/삭제 후 현재 목록 갱신(1페이지부터 새로)
   const handleCardUpdated = useCallback(() => {
     void loadPage(1, { append: false, useOnce: false });
   }, [loadPage]);
 
-  // 프로젝트 폴더 삭제 후 목록 갱신
   const handleCardDeleted = useCallback(() => {
     (async () => {
-      // 프로젝트 목록 갱신
       await loadPage(1, { append: false, useOnce: false });
-      // Recents 갱신
       try {
         await recentsReload?.();
       } catch (e) {
         console.error("Recents reload failed", e);
       }
-      // 삭제 필터 상태 초기화
       setRemovedRecentIds(new Set());
     })();
   }, [loadPage, recentsReload]);
 
-  // 트러블슈팅 카드 삭제 후 목록 갱신
   const handleRecentDeleted = useCallback((postId: number) => {
     setRemovedRecentIds((prev) => {
       const next = new Set(prev);
@@ -278,35 +256,33 @@ export default function HomePage() {
   }, []);
 
   return (
-    <div className="flex px-[156px] pt-[79px] pb-[158px] flex-col items-start gap-[40px]">
+    <div className="mx-auto w-full max-w-screen-2xl px-4 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 pt-16 pb-40 flex flex-col gap-10">
       {/* 상단 영역 */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 w-full">
         <span className="text-head-32-regular">나의 프로젝트</span>
-        <div className="relative">
-          {/* 폴더가 없을 경우 */}
+        <div className="relative self-stretch sm:self-auto">
           {showSnackbar && (
-            <div className="absolute top-[-60px] right-0">
+            <div className="absolute -top-14 right-0">
               <Snackbar message="프로젝트 폴더를 먼저 생성해주세요." />
             </div>
           )}
           <PostButton onClick={handlePostClick} />
-          {/* 글쓰기 템플릿 선택 (폴더 있는 경우) */}
           {showDropdown && (
             <div
               ref={dropdownRef}
-              className="absolute top-full left-1/2 translate-x-[-50%] mt-[8px] w-[184px] rounded-[8px] shadow-card bg-subColor2"
+              className="absolute top-full right-0 mt-2 w-[184px] rounded-[8px] shadow-card bg-subColor2"
             >
               <button
                 type="button"
                 onClick={handleGoGuideTemplate}
-                className="flex w-full pt-[8px] pb-[9px] justify-center items-center border-0.5px border-b border-gray2 text-body-16-regular"
+                className="flex w-full py-2.5 justify-center items-center border-0.5px border-b border-gray2 text-body-16-regular"
               >
                 가이드 템플릿
               </button>
               <button
                 type="button"
                 onClick={handleGoFreeformTemplate}
-                className="flex w-full pt-[8px] pb-[9px] justify-center items-center border-0.5px border-b border-gray2 text-body-16-regular"
+                className="flex w-full py-2.5 justify-center items-center text-body-16-regular"
               >
                 자유 템플릿
               </button>
@@ -325,11 +301,10 @@ export default function HomePage() {
             onClick={handleOpenModal}
             aria-label="새 폴더 추가"
           >
-            <img src={plusIcon} alt="plus" className="w-[36px] h-[36px]" />
+            <img src={plusIcon} alt="plus" className="w-9 h-9" />
           </button>
         }
       >
-        {/* 목록/로딩/에러 */}
         {isLoading && projects.length === 0 ? (
           <div className="w-full flex h-[132px] justify-center items-center rounded-[8px] bg-white shadow-card">
             <span className="text-body-20-regular">불러오는 중...</span>
@@ -348,7 +323,8 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap items-center gap-[24px] self-stretch">
+            {/* 1 / 2 / 3 / 4 컬럼 그리드 */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 w-full">
               {projects.map((p) => (
                 <ProjectFolderCard
                   key={p.id}
@@ -401,7 +377,8 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap gap-[24px]">
+            {/* 1 / 2 / 3 / 4 컬럼 그리드 (카드 4개 한 줄 기준) */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 w-full">
               {recentCards
                 .filter((c) => !removedRecentIds.has(c.id))
                 .map((card) => (
@@ -448,7 +425,6 @@ export default function HomePage() {
         )}
       </ProjectAccordion>
 
-      {/* 모달 표시 */}
       {isModalOpen && (
         <FolderModal
           mode="new"

--- a/src/pages/MyPage/LikedPostsPage.tsx
+++ b/src/pages/MyPage/LikedPostsPage.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from "react-router-dom";
 const LikedPostsPage = () => {
   const { items, loading, error, hasNext, sentinelRef, removeById } =
     useLikedCommunityPosts(10);
-
   const navigate = useNavigate();
 
   const handleDeleted = (postId: number) => {
@@ -18,9 +17,13 @@ const LikedPostsPage = () => {
   };
 
   return (
-    <div className="flex flex-col items-end gap-[40px] w-[948px] pb-[78px]">
+    <div className="w-full max-w-[948px] mx-auto px-4 sm:px-0 flex flex-col gap-6 sm:gap-10 pb-16 sm:pb-[78px]">
       {/* 에러/로딩 */}
-      {error && <div className="text-red-600 self-start">{error}</div>}
+      {error && (
+        <div className="text-red-600 self-start text-body-14-regular sm:text-body-16-regular">
+          {error}
+        </div>
+      )}
 
       <div className="flex flex-col items-start self-stretch">
         {items.map((card) => (
@@ -35,8 +38,8 @@ const LikedPostsPage = () => {
         {/* 로딩 스켈레톤 */}
         {loading && (
           <>
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-[96px] sm:h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-[96px] sm:h-[120px] bg-gray-100 rounded mb-3" />
           </>
         )}
 

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -28,12 +28,10 @@ export default function ProjectDetailPage() {
   const isInvalid = Number.isNaN(projectId);
   const viewerId = useViewerId();
 
-  // 트러블슈팅 문서 삭제 상태
   const [removedRecentIds, setRemovedRecentIds] = useState<Set<number>>(
     new Set()
   );
 
-  // 라우팅 시 폴더 카드에서 넘겨준 이름 사용, 없으면 api로 조회
   const location = useLocation() as { state?: { projectName?: string } };
   const [projectName, setProjectName] = useState<string>(
     location.state?.projectName ?? "프로젝트"
@@ -44,7 +42,6 @@ export default function ProjectDetailPage() {
 
   const hasProjectName = Boolean(location.state?.projectName);
 
-  // 글쓰기 버튼 드롭다운
   const [showDropdown, setShowDropdown] = useState(false);
   const navigate = useNavigate();
   const dropdownRef = useClickOutside(() => setShowDropdown(false));
@@ -65,7 +62,6 @@ export default function ProjectDetailPage() {
     [navigate]
   );
 
-  // 글쓰기 드롭다운 버튼 클릭 핸들러
   const handleGoGuideTemplate = () => goGuide();
   const handleGoFreeformTemplate = () => goFreeform();
   const handlePostClick = useCallback(() => {
@@ -79,16 +75,12 @@ export default function ProjectDetailPage() {
         setTitleLoading(true);
         const detail = await getProjectDetail(projectId);
         if (detail?.name) setProjectName(detail.name);
-        //  const { content } = await getProjectList();
-        // const found = content.find((p) => p.id === projectId);
-        // if (found) setProjectName(found.name);
       } finally {
         setTitleLoading(false);
       }
     })();
   }, [projectId, isInvalid, hasProjectName]);
 
-  // UI 필터 상태
   const visibilityOptions: VisibilityOption[] = ["전체", "공개", "비공개"];
   const [selectedStatus, setSelectedStatus] = useState<StatusType>("complete");
   const [selectedSort, setSelectedSort] = useState<SortUI>("latest");
@@ -97,7 +89,6 @@ export default function ProjectDetailPage() {
   const [selectedSummaryType, setSelectedSummaryType] =
     useState<ProjectTroubleSummaryType | null>(null);
 
-  // UI-서버 파라미터 매핑
   const toApiStatus = (s: StatusType) =>
     s === "complete" ? "COMPLETED" : ("SUMMARIZED" as const);
   const toApiSort = (s: SortUI) =>
@@ -105,22 +96,16 @@ export default function ProjectDetailPage() {
   const toApiVisibility = (v: VisibilityOption) =>
     v === "공개" ? "PUBLIC" : v === "비공개" ? "PRIVATE" : "ALL";
 
-  // 서버 쿼리 결정 (상태/정렬은 항상 포함)
   const query: ProjectTroubleQuery = useMemo(() => {
     const base: ProjectTroubleQuery = {
       status: toApiStatus(selectedStatus),
       sort: toApiSort(selectedSort),
     };
     if (selectedStatus === "complete") {
-      // 작성 완료 → 공개 범위 사용 (전체/공개/비공개)
-      if (selectedVisibility !== "전체") {
+      if (selectedVisibility !== "전체")
         base.visibility = toApiVisibility(selectedVisibility);
-      }
     } else {
-      // 요약 유형만
-      if (selectedSummaryType) {
-        base.summaryType = selectedSummaryType; // 바로 enum 값
-      }
+      if (selectedSummaryType) base.summaryType = selectedSummaryType;
     }
     return base;
   }, [selectedStatus, selectedSort, selectedVisibility, selectedSummaryType]);
@@ -129,16 +114,13 @@ export default function ProjectDetailPage() {
     () => ({ type: "project" as const, projectId, query }),
     [projectId, query]
   );
-
   const troubleOpts = useMemo(() => ({ enabled: !isInvalid }), [isInvalid]);
 
-  // 프로젝트별 트러블슈팅 목록 로드
   const { cards, isLoading, error } = useTroubleCards(
     troubleParams,
     troubleOpts
   );
 
-  // 트러블슈팅 카드 삭제 후 목록 갱신
   const handleRecentDeleted = useCallback((postId: number) => {
     setRemovedRecentIds((prev) => {
       const next = new Set(prev);
@@ -148,8 +130,8 @@ export default function ProjectDetailPage() {
   }, []);
 
   return (
-    <div className="flex w-full px-[156px] pt-[79px] pb-[158px] flex-col items-start gap-[36px]">
-      {/* 상단 나의 프로젝트 텍스트 및 글쓰기 버튼 */}
+    <div className="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-12 xl:px-[156px] pt-14 sm:pt-[79px] pb-24 sm:pb-[158px] flex flex-col items-start gap-6 sm:gap-[36px]">
+      {/* 상단 타이틀 + 글쓰기 버튼 */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 w-full">
         <span className="text-head-32-regular">나의 프로젝트</span>
         <div ref={dropdownRef} className="relative">
@@ -175,7 +157,8 @@ export default function ProjectDetailPage() {
           )}
         </div>
       </div>
-      {/* 프로젝트 아코디언 영역 */}
+
+      {/* 프로젝트 아코디언 */}
       {isInvalid ? (
         <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
           <span className="text-body-20-regular">
@@ -187,17 +170,15 @@ export default function ProjectDetailPage() {
           title={titleLoading ? "불러오는 중…" : projectName}
           persistKey={`project:${projectId}`}
         >
-          <div className="flex flex-col sm:flex-row justify-between gap-4 w-full">
-            {/* 작성 상태 필터 버튼 */}
-            <div className="flex items-center gap-[24px] self-stretch">
-              {/* 작성 완료 필터 버튼 */}
+          <div className="flex flex-col md:flex-row md:items-center justify-between gap-3 sm:gap-4 w-full md:flex-nowrap">
+            {/* 상태 필터 */}
+            <div className="flex items-center gap-3 sm:gap-6 self-stretch">
               <StatusFilterButton
                 label="작성 완료"
                 statusKey="complete"
                 isSelected={selectedStatus === "complete"}
                 onClick={() => setSelectedStatus("complete")}
               />
-              {/* 요약 완료 필터 버튼 */}
               <StatusFilterButton
                 label="요약 완료"
                 statusKey="created"
@@ -206,8 +187,8 @@ export default function ProjectDetailPage() {
               />
             </div>
 
-            {/* 정렬 기준 버튼 (최신순/중요도순) 및 공개/비공개 필터 드롭다운 or 요약 유형 필터 드롭다운 */}
-            <div className="inline-flex items-center gap-[40px]">
+            {/* 정렬 + 공개/요약유형 드롭다운 */}
+            <div className="flex flex-wrap items-center gap-3 sm:gap-6 md:gap-10">
               <SortButtonGroup
                 selected={selectedSort}
                 onSelect={setSelectedSort}
@@ -227,25 +208,25 @@ export default function ProjectDetailPage() {
             </div>
           </div>
 
-          {/* 트러블로그 카드 목록 (조건부) */}
+          {/* 카드 목록 */}
           {isLoading ? (
-            <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
+            <div className="w-full flex h-[200px] sm:h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
               <span className="text-body-20-regular">불러오는 중…</span>
             </div>
           ) : error ? (
-            <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
+            <div className="w-full flex h-[200px] sm:h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
               <span className="text-body-20-regular text-red-500">
                 목록 로드 실패
               </span>
             </div>
           ) : cards.length === 0 ? (
-            <div className="w-full flex h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
+            <div className="w-full flex h-[200px] sm:h-[220px] justify-center items-center rounded-[16px] bg-white shadow-card">
               <span className="text-body-20-regular">
                 아직 작성된 트러블슈팅이 없어요.
               </span>
             </div>
           ) : (
-            <div className="flex flex-wrap justify-center sm:justify-start gap-[24px] w-full">
+            <div className="grid w-full gap-[16px] sm:gap-[24px] grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {cards
                 .filter((c) => !removedRecentIds.has(c.id))
                 .map((card) => (

--- a/src/pages/Search/SearchResultPage.tsx
+++ b/src/pages/Search/SearchResultPage.tsx
@@ -39,23 +39,17 @@ const SearchResultPage = () => {
   const isUserScope = scope === "user" && !!userId;
   const isCommunityScope = scope === "community";
 
-  // 현재 로그인한 사용자
   const viewerId = useViewerId();
 
-  // 상세 페이지에서 사용할 검색범위 키로 변환
-  // - my / mypage  => "my"
-  // - user / community => "community"
   const scopeForDetail: "my" | "community" = isMyScope ? "my" : "community";
 
-  // 접근 제한 여부(표시만)
   const isBlocked = (card: any) => {
-    const vis = String(card.visibility ?? "").toUpperCase(); // "PUBLIC" | "PRIVATE"
-    const st = String(card.status ?? "").toUpperCase(); // "INPROGRESS" 등
+    const vis = String(card.visibility ?? "").toUpperCase();
+    const st = String(card.status ?? "").toUpperCase();
     const mine = !!card.isMine;
     return vis === "PRIVATE" || (st === "INPROGRESS" && !mine);
   };
 
-  // 내 검색
   const my = useInfiniteMyTroubleSearch(
     isMyScope ? query : "",
     size,
@@ -63,14 +57,12 @@ const SearchResultPage = () => {
     { enabled: isMyScope }
   );
 
-  // 특정 사용자 검색
   const other = useInfiniteUserTroubleSearch(
     isUserScope ? query : "",
     userId,
     size
   );
 
-  // 커뮤니티 검색
   const community = useInfiniteCommunityTroubleSearch(
     isCommunityScope ? query : "",
     size
@@ -124,84 +116,88 @@ const SearchResultPage = () => {
   }, [hasNext, activeKey, query, size]);
 
   return (
-    <div className="mt-[179px] mb-[68px] flex w-[1200px] flex-col items-start gap-[56px] mx-auto">
-      <span className="text-head-32-regular self-stretch">
+    <div className="mt-24 sm:mt-32 lg:mt-[179px] mb-10 sm:mb-14 lg:mb-[68px] w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-start gap-6 sm:gap-10">
+      <span className="text-head-28-regular sm:text-head-32-regular self-stretch">
         {loadingInitial
           ? "검색 중…"
           : `총 ${displayTotal}개의 포스트를 찾았어요.`}
       </span>
 
       {error && (
-        <div className="text-red-600 text-body-16-regular">{error}</div>
+        <div className="text-red-600 text-body-14-regular sm:text-body-16-regular">
+          {error}
+        </div>
       )}
 
       <div className="flex flex-col items-start self-stretch">
         {loadingInitial && items.length === 0 ? (
           <>
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-[96px] sm:h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-[96px] sm:h-[120px] bg-gray-100 rounded mb-3" />
           </>
         ) : items.length === 0 ? (
-          <div className="text-gray-500 text-body-16-regular mt-4">
+          <div className="text-gray-500 text-body-14-regular sm:text-body-16-regular mt-4">
             검색 결과가 없습니다.
           </div>
         ) : (
-          items.map((card) => {
-            const blocked = isBlocked(card);
-            const idNum =
-              typeof card.id === "number"
-                ? card.id
-                : Number.parseInt(String(card.id), 10);
-            const idValid = Number.isFinite(idNum);
+          <div className="w-full flex flex-col gap-3 sm:gap-4">
+            {items.map((card) => {
+              const blocked = isBlocked(card);
+              const idNum =
+                typeof card.id === "number"
+                  ? card.id
+                  : Number.parseInt(String(card.id), 10);
+              const idValid = Number.isFinite(idNum);
 
-            return (
-              <TroubleShootingCard
-                key={card.id}
-                {...card}
-                onClick={
-                  blocked || !idValid
-                    ? undefined
-                    : () => {
-                        const { goCombined, summaryId } = decideCombined(
-                          card,
-                          viewerId
-                        );
-                        const ownerIdForState =
-                          card.isMine && viewerId != null
-                            ? Number(viewerId)
-                            : undefined;
+              return (
+                <TroubleShootingCard
+                  key={card.id}
+                  {...card}
+                  onClick={
+                    blocked || !idValid
+                      ? undefined
+                      : () => {
+                          const { goCombined, summaryId } = decideCombined(
+                            card,
+                            viewerId
+                          );
+                          const ownerIdForState =
+                            card.isMine && viewerId != null
+                              ? Number(viewerId)
+                              : undefined;
 
-                        if (goCombined && summaryId != null) {
-                          navigate(PATH.COMBINED_DETAIL(idNum, summaryId), {
-                            state: {
-                              from: "search",
-                              searchScope: scopeForDetail,
-                              ownerId: ownerIdForState,
-                            },
-                          });
-                        } else {
-                          const url = `${PATH.COMMUNITY_POST(
-                            idNum
-                          )}?from=search&scope=${scopeForDetail}`;
-                          navigate(url, {
-                            state: {
-                              from: "search",
-                              searchScope: scopeForDetail,
-                              ownerId: ownerIdForState,
-                            },
-                          });
+                          if (goCombined && summaryId != null) {
+                            navigate(PATH.COMBINED_DETAIL(idNum, summaryId), {
+                              state: {
+                                from: "search",
+                                searchScope: scopeForDetail,
+                                ownerId: ownerIdForState,
+                              },
+                            });
+                          } else {
+                            const url = `${PATH.COMMUNITY_POST(
+                              idNum
+                            )}?from=search&scope=${scopeForDetail}`;
+                            navigate(url, {
+                              state: {
+                                from: "search",
+                                searchScope: scopeForDetail,
+                                ownerId: ownerIdForState,
+                              },
+                            });
+                          }
                         }
-                      }
-                }
-                disabled={blocked || !idValid}
-              />
-            );
-          })
+                  }
+                  disabled={blocked || !idValid}
+                />
+              );
+            })}
+          </div>
         )}
 
         <div className="w-full flex flex-col items-center mt-4">
           {loadingMore && (
-            <div className="w-full h-[120px] bg-gray-100 rounded mb-3" />
+            <div className="w-full h-[96px] sm:h-[120px] bg-gray-100 rounded mb-3" />
           )}
           {hasNext && <div ref={sentinelRef} style={{ height: 1 }} />}
         </div>


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ] 홈 화면 내부 컴포넌트 UI 반응형으로 수정
- [ ] 프로젝트 상세 화면 내부 컴포넌트 UI 반응형으로 수정
- [ ] 커뮤니티 홈, 커뮤니티 포스트 상세 화면 내부 컴포넌트 UI 반응형으로 수정
- [ ] 마이페이지 내부 컴포넌트 UI 반응형으로 수정
- [ ] 헤더 내부 컴포넌트 UI 반응형으로 수정 

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 커뮤니티 게시글에 우측 목차(TOC) 추가 및 댓글 “더 보기” 지원
  - 삭제 확인 모달(확인/취소 UI) 추가 및 개선된 모달 레이아웃/반투명 배경/스크롤 지원
  - 외부 알림 링크는 새 탭으로 열기 처리

- Bug Fixes
  - 홈 무한 스크롤 중복 호출 방지로 로딩 안정성 향상

- Refactor
  - 버튼·카드·헤더·레이아웃 전반 반응형 조정, 툴팁·줄바꿈·숫자 정렬 등 가독성 개선
  - 키보드 포커스 링 및 접근성 향상 (포커스 표시, aria 레이블 등)
  - 버튼의 disabled 스타일 및 저장 버튼 상태/진행 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->