### PR TITLE
REFACTOR: 트러블로그 카드 UI 수정 및 카카오 로그인 수정 중

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,6 +2,9 @@ import axios, { AxiosError } from "axios";
 import { router } from "@/routes/Router";
 import { PATH } from "@/constants/paths";
 
+const isAuthCallbackPath = (p: string) =>
+  p.startsWith(PATH.OAUTH_REGISTER) || p.startsWith(PATH.OAUTH_POPUP);
+
 export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").replace(
   /\/+$/,
   ""
@@ -145,6 +148,11 @@ const resId = api.interceptors.response.use(
     const notJson = !!ct && !ct.includes("application/json");
     const tokenExists = !!localStorage.getItem("accessToken");
 
+    // 콜백 라우트에서는 어떤 전역 네비게이션도 하지 않음
+    if (isAuthCallbackPath(window.location.pathname)) {
+      return res;
+    }
+
     if ((redirectedToKakao || notJson) && !tokenExists) {
       void navigateToAuthGuardOnce(401);
     }
@@ -162,6 +170,11 @@ const resId = api.interceptors.response.use(
     const reqOrigin = isAbsolute ? getOriginSafely(String(reqUrl)) : API_ORIGIN;
     const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
     if (isExternalAbsolute) return Promise.reject(error);
+
+    // 콜백 라우트에서는 전역 404/401/403 처리 및 리프레시 무시
+    if (isAuthCallbackPath(window.location.pathname)) {
+      return Promise.reject(error);
+    }
 
     // 404 → /404 (기존)
     const isGET = (cfg.method ?? "get").toUpperCase() === "GET";

--- a/src/components/Card/CardTitleSection.tsx
+++ b/src/components/Card/CardTitleSection.tsx
@@ -21,8 +21,12 @@ export default function CardTitleSection({
   return (
     <div className="gap-2">
       {/* 제목 + 공개 여부 아이콘 or 요약 유형 */}
-      <div className="flex items-start gap-1 sm:gap-2">
-        <div className="truncate overflow-hidden whitespace-nowrap max-w-[160px] sm:max-w-[250px] text-head-20-semibold">
+      <div className="flex items-start gap-1 sm:gap-2 min-w-0">
+        {/* 고정 max-w 제거하고 부모 폭을 최대로 사용해 한 줄 말줄임 */}
+        <div
+          className="flex-1 min-w-0 text-head-20-semibold whitespace-nowrap overflow-hidden text-ellipsis"
+          title={title}
+        >
           {title}
         </div>
 
@@ -34,11 +38,12 @@ export default function CardTitleSection({
           ) : (
             <img
               src={visibility === "public" ? publicIcon : privateIcon}
-              className="w-[24px] h-[24px]"
+              className="w-[24px] h-[24px] shrink-0"
               alt={visibility === "public" ? "공개" : "비공개"}
             />
           ))}
       </div>
+
       {/* 작성일 */}
       <div className="text-body-14-regular text-gray3">{createdAt}</div>
     </div>

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -54,11 +54,8 @@ export default function TroublogCard({
   const [deleting, setDeleting] = useState(false);
 
   const handleRootClick = () => {
-    if (typeof onClick === "function") {
-      onClick(id);
-    } else {
-      navigate(PATH.COMMUNITY_POST(id));
-    }
+    if (typeof onClick === "function") onClick(id);
+    else navigate(PATH.COMMUNITY_POST(id));
   };
 
   const handleRootKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
@@ -68,7 +65,6 @@ export default function TroublogCard({
     }
   };
 
-  // 케밥 > 삭제
   const handleRequestDelete = useCallback(async () => {
     if (!isMine) return;
     if (
@@ -81,7 +77,7 @@ export default function TroublogCard({
     try {
       setDeleting(true);
       await hardDeletePost(id);
-      onDeleted?.(id); // 부모에 알림(목록 갱신)
+      onDeleted?.(id);
     } catch (err: any) {
       console.error(err);
       alert(
@@ -95,45 +91,64 @@ export default function TroublogCard({
 
   return (
     <div
-      className="w-full max-w-[384px] h-[300px] sm:h-[330px] shrink-0 rounded-2xl bg-white shadow-card cursor-pointer transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary/50"
-      onClick={handleRootClick}
-      onKeyDown={handleRootKeyDown}
       role="button"
       tabIndex={0}
       aria-label={`${title} 상세 페이지로 이동`}
+      onClick={handleRootClick}
+      onKeyDown={handleRootKeyDown}
+      className="
+      group w-full max-w-[384px] h-[300px] sm:h-[330px]
+      shrink-0 rounded-2xl bg-white shadow-card cursor-pointer
+      transition-shadow hover:shadow-lg
+      focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50
+      overflow-hidden flex flex-col
+    "
     >
-      {/* 프리뷰 영역 */}
-      <CardPreviewArea
-        errorCategory={errorCategory}
-        isMine={isMine}
-        status={status}
-        authorProfileImageUrl={authorProfileImageUrl}
-        onAvatarClick={onAvatarClick}
-        onRequestDelete={handleRequestDelete}
-        deleting={deleting}
-      />
-
-      {/* 제목, 날짜, 태그 영역 */}
-      <div className="flex justify-between items-end p-3">
-        <div className="flex flex-col items-start gap-[14px]">
-          <CardTitleSection
-            title={title}
-            visibility={visibility}
-            createdAt={createdAt}
-            isMine={isMine}
-            status={status}
-            summaryType={summaryType}
-          />
-          <TagList tags={tags} />
-        </div>
-        <CardFooterInfo
+      {/* 프리뷰 영역: 기존 크기 유지 */}
+      <div className="relative rounded-t-2xl overflow-hidden">
+        <CardPreviewArea
+          errorCategory={errorCategory}
           isMine={isMine}
           status={status}
-          visibility={visibility}
-          likeCount={likeCount}
-          commentCount={commentCount}
-          importance={importance}
+          authorProfileImageUrl={authorProfileImageUrl}
+          onAvatarClick={onAvatarClick}
+          onRequestDelete={handleRequestDelete}
+          deleting={deleting}
         />
+      </div>
+
+      {/* 하단 섹션: 오른쪽 패딩을 줄여 제목이 쓸 수 있는 폭 확대 */}
+      <div className="mt-auto flex justify-between items-end p-3 pr-2 gap-3 min-w-0">
+        <div className="flex-1 min-w-0 flex flex-col items-start gap-[14px]">
+          {/* 제목/메타: 폭 제한을 부모에게 맡기고 한 줄 말줄임 */}
+          <div className="w-full min-w-0">
+            <CardTitleSection
+              title={title}
+              visibility={visibility}
+              createdAt={createdAt}
+              isMine={isMine}
+              status={status}
+              summaryType={summaryType}
+            />
+          </div>
+
+          {/* 태그: 넘침 방지 */}
+          <div className="w-full min-w-0 overflow-hidden">
+            <TagList tags={tags} />
+          </div>
+        </div>
+
+        {/* 우측 푸터는 눌리지 않도록 */}
+        <div className="shrink-0">
+          <CardFooterInfo
+            isMine={isMine}
+            status={status}
+            visibility={visibility as any}
+            likeCount={likeCount}
+            commentCount={commentCount}
+            importance={importance}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -6,6 +6,7 @@ export const PATH = {
   SIGNUP_OAUTH: "/signup/oauth",
   OAUTH: "/oauth",
   OAUTH_POPUP: "/oauth/popup/kakao",
+  OAUTH_REGISTER: "/auth/oauth-register",
 
   USER: "/user",
   HOME: "/user/home",

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -5,6 +5,7 @@ export const PATH = {
   SIGNUP_DETAIL: "/signup/detail",
   SIGNUP_OAUTH: "/signup/oauth",
   OAUTH: "/oauth",
+  OAUTH_POPUP: "/oauth/popup/kakao",
 
   USER: "/user",
   HOME: "/user/home",

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -4,9 +4,8 @@ import { PATH } from "@/constants/paths";
 import { openOAuthPopup } from "@/utils/openOAuthPopup";
 import { applyAuth } from "@/utils/applyAuth";
 
-const API_BASE = "https://troublog.shop".replace(/\/+$/, "");
-const FRONT_CALLBACK = `${window.location.origin}/oauth/popup/kakao`;
-const AUTH_START_URL = `${API_BASE}/oauth2/authorization/kakao?return_to=${encodeURIComponent(
+const FRONT_CALLBACK = `${window.location.origin}${PATH.OAUTH_REGISTER}`; // 👉 /auth/oauth-register
+const AUTH_START_URL = `https://troublog.shop/oauth2/authorization/kakao?return_to=${encodeURIComponent(
   FRONT_CALLBACK
 )}`;
 
@@ -14,35 +13,29 @@ export default function KakaoLoginButton() {
   const navigate = useNavigate();
 
   const handleClick = async () => {
-    try {
-      const payload = await openOAuthPopup(
-        AUTH_START_URL,
-        window.location.origin
-      );
-      // 서버 약속:
-      // - 추가가입 필요: userId, nickname, loginType, userStatus
-      // - 이미 가입:     userId, accessToken (refreshToken은 Set-Cookie)
+    console.debug("[KakaoLoginButton] FRONT_CALLBACK:", FRONT_CALLBACK);
+    console.debug("[KakaoLoginButton] AUTH_START_URL:", AUTH_START_URL);
 
-      if (payload?.accessToken) {
-        // 이미 가입 → 바로 로그인 상태
-        applyAuth(payload.accessToken);
+    try {
+      const p = await openOAuthPopup(AUTH_START_URL, window.location.origin);
+      console.debug("[KakaoLoginButton] payload:", p);
+
+      if (p?.accessToken) {
+        applyAuth(p.accessToken);
         navigate(PATH.HOME, { replace: true });
         return;
       }
-
-      if (payload?.userStatus === "INCOMPLETE" && payload?.userId) {
+      const status = p?.userStatus ?? p?.status;
+      if (status === "INCOMPLETE" && p?.userId) {
         navigate(PATH.SIGNUP_OAUTH, {
           replace: true,
-          state: { userId: payload.userId, nickname: payload.nickname ?? "" },
+          state: { userId: p.userId, nickname: p.nickname ?? "" },
         });
         return;
       }
-
-      // 예외 처리: 기대값이 없으면 로그인 화면 유지/에러 토스트 등
-      console.warn("Unexpected OAuth payload:", payload);
+      console.warn("[KakaoLoginButton] Unexpected payload:", p);
     } catch (e) {
-      console.error(e);
-      // 팝업 차단/취소 등 처리
+      console.error("[KakaoLoginButton] popup failed:", e);
     }
   };
 
@@ -53,9 +46,7 @@ export default function KakaoLoginButton() {
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
       <img src={kakaoLogoIcon} className="w-[18px] h-[18px]" alt="kakao" />
-      <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
-        카카오 로그인
-      </span>
+      <span className="text-[20px] font-semibold">카카오 로그인</span>
     </button>
   );
 }

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -1,13 +1,50 @@
 import kakaoLogoIcon from "@/assets/icons/kakaologo.svg";
-import { KAKAO_REDIRECT_URI } from "../../config";
 import { useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+import { openOAuthPopup } from "@/utils/openOAuthPopup";
+import { applyAuth } from "@/utils/applyAuth";
 
-const KakaoLoginButton = () => {
+const API_BASE = "https://troublog.shop".replace(/\/+$/, "");
+const FRONT_CALLBACK = `${window.location.origin}/oauth/popup/kakao`;
+const AUTH_START_URL = `${API_BASE}/oauth2/authorization/kakao?return_to=${encodeURIComponent(
+  FRONT_CALLBACK
+)}`;
 
-  const redirectUri = KAKAO_REDIRECT_URI; // 재현님 만드신 링크
+export default function KakaoLoginButton() {
   const navigate = useNavigate();
 
-  const handleClick = () => navigate(redirectUri);
+  const handleClick = async () => {
+    try {
+      const payload = await openOAuthPopup(
+        AUTH_START_URL,
+        window.location.origin
+      );
+      // 서버 약속:
+      // - 추가가입 필요: userId, nickname, loginType, userStatus
+      // - 이미 가입:     userId, accessToken (refreshToken은 Set-Cookie)
+
+      if (payload?.accessToken) {
+        // 이미 가입 → 바로 로그인 상태
+        applyAuth(payload.accessToken);
+        navigate(PATH.HOME, { replace: true });
+        return;
+      }
+
+      if (payload?.userStatus === "INCOMPLETE" && payload?.userId) {
+        navigate(PATH.SIGNUP_OAUTH, {
+          replace: true,
+          state: { userId: payload.userId, nickname: payload.nickname ?? "" },
+        });
+        return;
+      }
+
+      // 예외 처리: 기대값이 없으면 로그인 화면 유지/에러 토스트 등
+      console.warn("Unexpected OAuth payload:", payload);
+    } catch (e) {
+      console.error(e);
+      // 팝업 차단/취소 등 처리
+    }
+  };
 
   return (
     <button
@@ -16,9 +53,9 @@ const KakaoLoginButton = () => {
       className="flex items-center justify-center gap-2 py-3 px-[208px] rounded-lg bg-[#FEE500] w-full"
     >
       <img src={kakaoLogoIcon} className="w-[18px] h-[18px]" alt="kakao" />
-      <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard"></span>
+      <span className="text-[20px] font-semibold leading-normal text-[rgba(0,0,0,0.85)] font-pretendard">
+        카카오 로그인
+      </span>
     </button>
   );
-};
-
-export default KakaoLoginButton;
+}

--- a/src/pages/Login/KakaoLoginButton.tsx
+++ b/src/pages/Login/KakaoLoginButton.tsx
@@ -4,15 +4,17 @@ import { PATH } from "@/constants/paths";
 import { openOAuthPopup } from "@/utils/openOAuthPopup";
 import { applyAuth } from "@/utils/applyAuth";
 
-const FRONT_CALLBACK = `${window.location.origin}${PATH.OAUTH_REGISTER}`; // 👉 /auth/oauth-register
+const BASE = (import.meta.env.BASE_URL || "/").replace(/\/$/, ""); // "" 또는 "/app"
+const FRONT_CALLBACK = `${window.location.origin}${BASE}${PATH.OAUTH_REGISTER}`;
 const AUTH_START_URL = `https://troublog.shop/oauth2/authorization/kakao?return_to=${encodeURIComponent(
   FRONT_CALLBACK
 )}`;
 
 export default function KakaoLoginButton() {
   const navigate = useNavigate();
-
   const handleClick = async () => {
+    console.debug("[KakaoLoginButton] BASE_URL:", import.meta.env.BASE_URL);
+    console.debug("[KakaoLoginButton] ORIGIN:", window.location.origin);
     console.debug("[KakaoLoginButton] FRONT_CALLBACK:", FRONT_CALLBACK);
     console.debug("[KakaoLoginButton] AUTH_START_URL:", AUTH_START_URL);
 

--- a/src/pages/Login/OAuthPopupKakao.tsx
+++ b/src/pages/Login/OAuthPopupKakao.tsx
@@ -1,55 +1,57 @@
 import { useEffect } from "react";
 
-type SocialPayload = {
-  email?: string;
-  status?: string; // "INCOMPLETE" 등
-  id?: number;
+type Payload = {
+  userId?: number;
   nickname?: string;
-  loginType?: string; // "KAKAO"
+  loginType?: string;
+  userStatus?: string; // "INCOMPLETE" 등
+  accessToken?: string; // 이미 가입 케이스에서 존재
 };
+
+function getParam(name: string) {
+  const qs = new URLSearchParams(window.location.search);
+  const hs = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  return qs.get(name) ?? hs.get(name) ?? undefined;
+}
 
 export default function OAuthPopupKakao() {
   useEffect(() => {
-    const sp = new URLSearchParams(window.location.search);
-
-    const idStr = sp.get("id");
-    const idNum = idStr !== null ? Number(idStr) : undefined;
-    const payloadFromQuery: SocialPayload = {
-      email: sp.get("email") ?? undefined,
-      status: sp.get("status") ?? undefined,
-      nickname: sp.get("nickname") ?? undefined,
-      loginType: sp.get("loginType") ?? undefined,
-      id: typeof idNum === "number" && !Number.isNaN(idNum) ? idNum : undefined,
+    const userIdStr = getParam("userId");
+    const payload: Payload = {
+      userId: userIdStr ? Number(userIdStr) : undefined,
+      nickname: getParam("nickname"),
+      loginType: getParam("loginType"),
+      userStatus: getParam("userStatus") ?? getParam("status"),
+      accessToken: getParam("accessToken"),
     };
 
-    const error = sp.get("error");
-    const opener = window.opener;
-
-    // 보안: 정확한 오리진으로만 전송
-    const TARGET = window.location.origin;
-
-    if (opener) {
-      opener.postMessage(
-        {
-          type: "SOCIAL_LOGIN_DONE",
-          payload: error
-            ? { error, ok: false }
-            : { ...payloadFromQuery, ok: true },
-        },
-        TARGET
-      );
+    // 새로고침 대비 저장(옵션)
+    try {
+      sessionStorage.setItem("oauth_payload", JSON.stringify(payload));
+    } catch (err) {
+      console.debug("sessionStorage set failed:", err);
     }
 
-    // 주소 정리
+    try {
+      const TARGET = window.location.origin;
+      if (window.opener) {
+        window.opener.postMessage(
+          { type: "SOCIAL_LOGIN_DONE", payload },
+          TARGET
+        );
+      }
+    } catch (err) {
+      console.debug("postMessage failed:", err);
+    }
+
     try {
       if ("replaceState" in window.history) {
         window.history.replaceState(null, "", "/");
       }
     } catch (err) {
-      console.debug("replaceState failed in popup:", err);
+      console.debug("replaceState failed:", err);
     }
 
-    // 팝업 닫기
     window.close();
   }, []);
 

--- a/src/pages/Login/OAuthPopupKakao.tsx
+++ b/src/pages/Login/OAuthPopupKakao.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+import { applyAuth } from "@/utils/applyAuth";
 
 type SocialPayload = {
   userId?: number;
   nickname?: string;
   loginType?: string;
   userStatus?: string; // 또는 status
-  accessToken?: string; // 바로 로그인 케이스에서만 존재
+  accessToken?: string; // 바로 로그인 케이스
 };
 
 const getParam = (name: string) => {
@@ -15,11 +18,15 @@ const getParam = (name: string) => {
 };
 
 export default function OAuthPopupKakao() {
-  useEffect(() => {
-    // 👉 이 로그가 팝업 콘솔에 안 찍히면 "라우트 미매칭"입니다.
-    console.debug("[OAuthPopupKakao] mounted:", window.location.href);
+  const navigate = useNavigate();
 
-    const uid = getParam("userId") ?? getParam("userid"); // 서버가 소문자 보낼 대비
+  useEffect(() => {
+    const href = window.location.href;
+    const isPopup = !!window.opener && !window.opener.closed;
+    console.debug("[OAuthPopupKakao] mounted @", href, "isPopup:", isPopup);
+
+    // payload 파싱
+    const uid = getParam("userId") ?? getParam("userid");
     const payload: SocialPayload = {
       userId: uid ? Number(uid) : undefined,
       nickname: getParam("nickname") ?? undefined,
@@ -29,42 +36,64 @@ export default function OAuthPopupKakao() {
     };
     console.debug("[OAuthPopupKakao] parsed payload:", payload);
 
+    // 임시 저장(새로고침 대비)
     try {
       sessionStorage.setItem("oauth_payload", JSON.stringify(payload));
-      console.debug("[OAuthPopupKakao] sessionStorage saved");
+      console.debug("[OAuthPopupKakao] session saved");
     } catch (err) {
-      console.debug("[OAuthPopupKakao] sessionStorage save failed:", err);
+      console.debug("[OAuthPopupKakao] session save failed:", err);
     }
 
-    try {
-      const TARGET = window.location.origin;
-      if (window.opener) {
-        window.opener.postMessage(
+    if (isPopup) {
+      // ✅ 팝업일 때만 postMessage/close/replaceState 수행
+      try {
+        const TARGET = window.location.origin;
+        window.opener?.postMessage(
           { type: "SOCIAL_LOGIN_DONE", payload },
           TARGET
         );
-        console.debug("[OAuthPopupKakao] postMessage sent to", TARGET);
-      } else {
-        console.debug(
-          "[OAuthPopupKakao] window.opener is null (opened directly?)"
-        );
+        console.debug("[OAuthPopupKakao] postMessage sent →", TARGET);
+      } catch (err) {
+        console.debug("[OAuthPopupKakao] postMessage failed:", err);
       }
-    } catch (err) {
-      console.debug("[OAuthPopupKakao] postMessage failed:", err);
-    }
 
-    try {
-      if ("replaceState" in window.history) {
-        window.history.replaceState(null, "", "/");
-        console.debug("[OAuthPopupKakao] URL cleaned");
+      try {
+        if ("replaceState" in window.history) {
+          window.history.replaceState(null, "", "/");
+          console.debug("[OAuthPopupKakao] URL cleaned");
+        }
+      } catch (err) {
+        console.debug("[OAuthPopupKakao] replaceState failed:", err);
       }
-    } catch (err) {
-      console.debug("[OAuthPopupKakao] replaceState failed:", err);
-    }
 
-    console.debug("[OAuthPopupKakao] closing popup");
-    window.close();
-  }, []);
+      try {
+        console.debug("[OAuthPopupKakao] closing popup");
+        window.close();
+      } catch (err) {
+        console.debug("[OAuthPopupKakao] window.close failed:", err);
+      }
+    } else {
+      // 🧩 직접 진입(새 탭/리다이렉트로 열림) 처리: SPA 내에서 마무리
+      console.debug("[OAuthPopupKakao] opened directly — handling in-page");
+
+      const status = payload.userStatus ?? getParam("status") ?? undefined;
+      if (payload.accessToken) {
+        // 이미 가입 → 바로 로그인 처리
+        applyAuth(payload.accessToken);
+        navigate(PATH.HOME, { replace: true });
+        return;
+      }
+      if (status === "INCOMPLETE" && payload.userId) {
+        navigate(PATH.SIGNUP_OAUTH, {
+          replace: true,
+          state: { userId: payload.userId, nickname: payload.nickname ?? "" },
+        });
+        return;
+      }
+      // 그래도 조건이 안 맞으면 루트로
+      navigate(PATH.LOGIN, { replace: true });
+    }
+  }, [navigate]);
 
   return null;
 }

--- a/src/pages/Login/OAuthPopupKakao.tsx
+++ b/src/pages/Login/OAuthPopupKakao.tsx
@@ -1,35 +1,39 @@
 import { useEffect } from "react";
 
-type Payload = {
+type SocialPayload = {
   userId?: number;
   nickname?: string;
   loginType?: string;
-  userStatus?: string; // "INCOMPLETE" 등
-  accessToken?: string; // 이미 가입 케이스에서 존재
+  userStatus?: string; // 또는 status
+  accessToken?: string; // 바로 로그인 케이스에서만 존재
 };
 
-function getParam(name: string) {
+const getParam = (name: string) => {
   const qs = new URLSearchParams(window.location.search);
   const hs = new URLSearchParams(window.location.hash.replace(/^#/, ""));
   return qs.get(name) ?? hs.get(name) ?? undefined;
-}
+};
 
 export default function OAuthPopupKakao() {
   useEffect(() => {
-    const userIdStr = getParam("userId");
-    const payload: Payload = {
-      userId: userIdStr ? Number(userIdStr) : undefined,
-      nickname: getParam("nickname"),
-      loginType: getParam("loginType"),
-      userStatus: getParam("userStatus") ?? getParam("status"),
-      accessToken: getParam("accessToken"),
-    };
+    // 👉 이 로그가 팝업 콘솔에 안 찍히면 "라우트 미매칭"입니다.
+    console.debug("[OAuthPopupKakao] mounted:", window.location.href);
 
-    // 새로고침 대비 저장(옵션)
+    const uid = getParam("userId") ?? getParam("userid"); // 서버가 소문자 보낼 대비
+    const payload: SocialPayload = {
+      userId: uid ? Number(uid) : undefined,
+      nickname: getParam("nickname") ?? undefined,
+      loginType: getParam("loginType") ?? undefined,
+      userStatus: getParam("userStatus") ?? getParam("status") ?? undefined,
+      accessToken: getParam("accessToken") ?? undefined,
+    };
+    console.debug("[OAuthPopupKakao] parsed payload:", payload);
+
     try {
       sessionStorage.setItem("oauth_payload", JSON.stringify(payload));
+      console.debug("[OAuthPopupKakao] sessionStorage saved");
     } catch (err) {
-      console.debug("sessionStorage set failed:", err);
+      console.debug("[OAuthPopupKakao] sessionStorage save failed:", err);
     }
 
     try {
@@ -39,19 +43,26 @@ export default function OAuthPopupKakao() {
           { type: "SOCIAL_LOGIN_DONE", payload },
           TARGET
         );
+        console.debug("[OAuthPopupKakao] postMessage sent to", TARGET);
+      } else {
+        console.debug(
+          "[OAuthPopupKakao] window.opener is null (opened directly?)"
+        );
       }
     } catch (err) {
-      console.debug("postMessage failed:", err);
+      console.debug("[OAuthPopupKakao] postMessage failed:", err);
     }
 
     try {
       if ("replaceState" in window.history) {
         window.history.replaceState(null, "", "/");
+        console.debug("[OAuthPopupKakao] URL cleaned");
       }
     } catch (err) {
-      console.debug("replaceState failed:", err);
+      console.debug("[OAuthPopupKakao] replaceState failed:", err);
     }
 
+    console.debug("[OAuthPopupKakao] closing popup");
     window.close();
   }, []);
 

--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -1,15 +1,19 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Input from "./Input";
 import mockimg from "../../assets/images/mockimg.jpg";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { postOauthRegister } from "@/api/auth.api";
 import type { OauthRegisterRequest } from "@/models/auth.model";
 import { PATH } from "@/constants/paths";
 
 const SignPageOauth = () => {
   const navigate = useNavigate();
+  const location = useLocation() as any;
+  const stateUserId = location?.state?.userId as number | undefined;
+  const stateNickname = location?.state?.nickname as string | undefined;
 
-  const [nickname, setNickname] = useState("");
+  const [userId, setUserId] = useState<number | null>(stateUserId ?? null);
+  const [nickname, setNickname] = useState(stateNickname ?? "");
   const [field, setField] = useState("");
   const [bio, setBio] = useState("");
   const [githubad, setGithubad] = useState("");
@@ -18,6 +22,21 @@ const SignPageOauth = () => {
   const [fieldError, setFieldError] = useState("");
   const [bioError, setBioError] = useState("");
   const [formError, setFormError] = useState("");
+
+  // 새로고침 폴백: 콜백에서 저장한 세션 값 복구
+  useEffect(() => {
+    if (userId != null && nickname) return;
+    try {
+      const raw = sessionStorage.getItem("oauth_payload");
+      if (raw) {
+        const p = JSON.parse(raw) as { userId?: number; nickname?: string };
+        if (p?.userId && !userId) setUserId(p.userId);
+        if (p?.nickname && !nickname) setNickname(p.nickname);
+      }
+    } catch (err) {
+      console.debug("oauth_payload sessionStorage get/parse failed:", err);
+    }
+  }, [userId, nickname]);
 
   const validateForm = () => {
     let valid = true;
@@ -48,7 +67,7 @@ const SignPageOauth = () => {
 
     try {
       const payload: OauthRegisterRequest = {
-        userId: 0, // 수정 필요
+        userId: userId!, // 🔹 서버가 URL로 준 userId 사용
         nickname,
         field,
         bio,
@@ -56,7 +75,7 @@ const SignPageOauth = () => {
       };
 
       await postOauthRegister(payload);
-      navigate(PATH.LOGIN);
+      navigate(PATH.HOME, { replace: true });
     } catch (error: any) {
       console.error("회원가입 실패:", error);
       if (error.response?.data?.message) {

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -4,7 +4,6 @@ import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
 import api from "@/api/axios";
 import { useNotificationStore } from "@/store/notification";
 import type { AlertServerItem } from "@/types/alert.model";
-import { useLocation } from "react-router-dom";
 import { PATH } from "@/constants/paths";
 
 // 콜백 라우트 감지 (팝업/직접접속 모두)
@@ -32,7 +31,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const isLoggedIn = useIsLoggedIn();
   const viewerId = useViewerId();
   const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
-  const { pathname } = useLocation();
+  // const { pathname } = useLocation();
 
   const esCloseRef = useRef<null | (() => void)>(null);
   const connectedRef = useRef(false);
@@ -48,6 +47,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
     if (!hydrated) return;
 
     // OAuth 콜백 라우트에서는 SSE/리프레시 로직 전부 비활성화
+    const pathname = window.location.pathname;
     if (isAuthCallbackPath(pathname)) {
       // 정리만 하고 즉시 반환
       stopRef.current = true;
@@ -158,7 +158,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       esCloseRef.current = null;
       connectedRef.current = false;
     };
-  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs, pathname]);
+  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs]);
 
   return <>{children}</>;
 }

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -4,17 +4,26 @@ import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
 import api from "@/api/axios";
 import { useNotificationStore } from "@/store/notification";
 import type { AlertServerItem } from "@/types/alert.model";
+import { useLocation } from "react-router-dom";
+import { PATH } from "@/constants/paths";
+
+// 콜백 라우트 감지 (팝업/직접접속 모두)
+const isAuthCallbackPath = (p: string) =>
+  p.startsWith(PATH.OAUTH_REGISTER) || p.startsWith(PATH.OAUTH_POPUP);
 
 async function tryRefreshOnce() {
   try {
-    await api.get("/auth/refresh");
+    await api.post(
+      "/auth/refresh",
+      undefined,
+      { __skipGlobalAuthGuard: true, __skipGlobal404: true } // 전역 가드/404 네비게이션 방지
+    );
     return true;
   } catch {
     return false;
   }
 }
 
-// 타입 가드
 function isAlertPayload(x: any): x is AlertServerItem {
   return x && typeof x === "object" && "title" in x && "message" in x;
 }
@@ -23,6 +32,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const isLoggedIn = useIsLoggedIn();
   const viewerId = useViewerId();
   const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
+  const { pathname } = useLocation();
 
   const esCloseRef = useRef<null | (() => void)>(null);
   const connectedRef = useRef(false);
@@ -37,6 +47,24 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     if (!hydrated) return;
 
+    // OAuth 콜백 라우트에서는 SSE/리프레시 로직 전부 비활성화
+    if (isAuthCallbackPath(pathname)) {
+      // 정리만 하고 즉시 반환
+      stopRef.current = true;
+      esCloseRef.current?.();
+      esCloseRef.current = null;
+      connectedRef.current = false;
+      prevViewerRef.current = null;
+      if (connectTimerRef.current != null) {
+        clearTimeout(connectTimerRef.current);
+        connectTimerRef.current = null;
+      }
+      if (import.meta.env.DEV) {
+        console.debug("[SSE] skipped on auth callback:", pathname);
+      }
+      return;
+    }
+
     const token = localStorage.getItem("accessToken") ?? "";
     if (!isLoggedIn || !token) {
       stopRef.current = true;
@@ -44,7 +72,6 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       esCloseRef.current = null;
       connectedRef.current = false;
       prevViewerRef.current = null;
-      // 예약된 연결 시도도 취소
       if (connectTimerRef.current != null) {
         clearTimeout(connectTimerRef.current);
         connectTimerRef.current = null;
@@ -52,13 +79,11 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       return;
     }
 
-    // 계정 전환 시 재연결
     if (connectedRef.current && prevViewerRef.current !== viewerId) {
       esCloseRef.current?.();
       esCloseRef.current = null;
       connectedRef.current = false;
     }
-
     if (connectedRef.current) return;
 
     stopRef.current = false;
@@ -75,30 +100,22 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
         {
           onOpen: () => console.log("[SSE] connected"),
           onMessage: (payload) => {
-            if (!isAlertPayload(payload)) {
-              return;
-            }
+            if (!isAlertPayload(payload)) return;
             useNotificationStore.getState().pushFromSSE(payload);
           },
           onError: (e) => console.warn("[SSE] error", e),
           onUnauthorized: async () => {
-            // 401/403/302 → 재연결 루프 STOP 후 토큰 갱신 1회 시도
+            // 콜백 라우트면 무시
+            if (isAuthCallbackPath(window.location.pathname)) return;
             if (refreshingRef.current) return;
             refreshingRef.current = true;
-
             const ok = await tryRefreshOnce();
             refreshingRef.current = false;
-
             if (stopRef.current) return;
-            if (!ok) {
-              // 갱신 실패 → 연결 유지하지 않음 (사용자가 재로그인하면 effect가 다시 트리거)
-              return;
-            }
-            // 갱신 성공 → 새 토큰으로 재연결
+            if (!ok) return;
             esCloseRef.current?.();
             esCloseRef.current = null;
             connectedRef.current = false;
-            // 약간의 딜레이 후 재시도(토큰 저장/동기화 여유)
             connectTimerRef.current = window.setTimeout(start, 200);
           },
         },
@@ -112,10 +129,8 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       connectedRef.current = true;
     };
 
-    // StrictMode 2회 실행 방지: 첫 사이클은 예약-즉시-해제되어 네트워크 요청 X
     connectTimerRef.current = window.setTimeout(start, 0);
 
-    // 포커스/온라인 복귀 시 재연결 보조 (dev에서도 활성화)
     const onFocusOrOnline = () => {
       if (stopRef.current) return;
       if (!connectedRef.current) {
@@ -132,21 +147,18 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
 
     return () => {
       stopRef.current = true;
-
       if (connectTimerRef.current != null) {
         clearTimeout(connectTimerRef.current);
         connectTimerRef.current = null;
       }
-
       window.removeEventListener("focus", onFocusOrOnline);
       window.removeEventListener("online", onFocusOrOnline);
       window.removeEventListener("beforeunload", onBeforeUnload);
-
       esCloseRef.current?.();
       esCloseRef.current = null;
       connectedRef.current = false;
     };
-  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs]);
+  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs, pathname]);
 
   return <>{children}</>;
 }

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -36,6 +36,7 @@ export const router = createBrowserRouter(
     { path: PATH.SIGNUP_DETAIL, element: <SignPageTwo /> },
     { path: PATH.SIGNUP_OAUTH, element: <SignPageOauth /> },
     { path: PATH.OAUTH_POPUP, element: <OAuthPopupKakao /> },
+    { path: PATH.OAUTH_REGISTER, element: <OAuthPopupKakao /> },
 
     // 보호 구역 (메인 레이아웃)
     {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -127,7 +127,8 @@ export const router = createBrowserRouter(
     },
   ],
   {
-    basename: import.meta.env.BASE_URL,
+    // basename: import.meta.env.BASE_URL,
+    basename: "/",
   }
 );
 

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -26,6 +26,7 @@ import NotFoundPage from "@/pages/Error/NotFoundPage";
 import AuthGuardPage from "@/pages/Error/AuthGuardPage";
 import SignPageOauth from "@/pages/Login/SignPageOauth";
 import CombinedDetailPage from "@/pages/MyPage/CombinedDetailPage";
+import OAuthPopupKakao from "@/pages/Login/OAuthPopupKakao";
 export const router = createBrowserRouter(
   [
     // 로그인/회원가입
@@ -34,6 +35,7 @@ export const router = createBrowserRouter(
     { path: PATH.SIGNUP, element: <SignPageOne /> },
     { path: PATH.SIGNUP_DETAIL, element: <SignPageTwo /> },
     { path: PATH.SIGNUP_OAUTH, element: <SignPageOauth /> },
+    { path: PATH.OAUTH_POPUP, element: <OAuthPopupKakao /> },
 
     // 보호 구역 (메인 레이아웃)
     {

--- a/src/utils/applyAuth.ts
+++ b/src/utils/applyAuth.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export function applyAuth(accessToken?: string) {
+  const envType = import.meta.env.VITE_ENV_TYPE || "dev"; // 너희 서버 요구값
+
+  // 공통 EnvType 헤더
+  axios.defaults.headers.common["EnvType"] = envType;
+
+  if (accessToken) {
+    localStorage.setItem("accessToken", accessToken);
+    axios.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+  }
+}

--- a/src/utils/openOAuthPopup.ts
+++ b/src/utils/openOAuthPopup.ts
@@ -1,21 +1,7 @@
-import axios from "axios";
-
-type Options = {
-  eventType?: string; // 콜백 페이지가 보낼 postMessage 타입
-  pollIntervalMs?: number; // 세션 폴링 주기
-  pollTimeoutMs?: number; // 세션 폴링 타임아웃
-  meEndpoint?: string; // 세션 조회 API
-};
-
 export function openOAuthPopup(
   authUrl: string,
   targetOrigin: string,
-  {
-    eventType = "SOCIAL_LOGIN_DONE",
-    pollIntervalMs = 800,
-    pollTimeoutMs = 90_000,
-    meEndpoint = "/api/users/me",
-  }: Options = {}
+  { eventType = "SOCIAL_LOGIN_DONE", timeoutMs = 120_000 } = {}
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     const w = 480,
@@ -38,11 +24,10 @@ export function openOAuthPopup(
     const cleanup = () => {
       done = true;
       window.removeEventListener("message", onMessage);
-      clearInterval(pollTimer);
+      clearInterval(closeWatch);
       clearTimeout(timeoutTimer);
     };
 
-    // postMessage 경로 (백엔드가 콜백/HTML 준비 후 적용될 때)
     function onMessage(e: MessageEvent) {
       if (done) return;
       if (e.origin !== targetOrigin) return;
@@ -53,46 +38,30 @@ export function openOAuthPopup(
       try {
         if (!popup.closed) popup.close();
       } catch (err) {
-        console.debug(err);
+        console.debug("popup.close failed:", err);
       }
       resolve(msg.payload);
     }
-    window.addEventListener("message", onMessage);
 
-    // 세션 폴링 경로 (백엔드 수정 없이도 동작)
-    const pollTimer = setInterval(async () => {
-      if (done) return;
-      if (popup.closed) {
+    const closeWatch = setInterval(() => {
+      if (popup.closed && !done) {
         cleanup();
-        reject(new Error("사용자가 팝업을 닫았습니다."));
-        return;
+        reject(new Error("팝업이 닫혔습니다."));
       }
-      try {
-        const res = await axios.get(meEndpoint, { withCredentials: true });
-        // 로그인 성공 판단: 프로젝트 규칙에 맞게 조정
-        if (res?.data) {
-          cleanup();
-          try {
-            if (!popup.closed) popup.close();
-          } catch (err) {
-            console.debug(err);
-          }
-          resolve(res.data); // ex) { email, status, id, nickname, loginType }
-        }
-      } catch {
-        // 아직 로그인 안 됨 → 다음 폴링으로
-      }
-    }, pollIntervalMs);
+    }, 400);
 
     const timeoutTimer = setTimeout(() => {
-      if (done) return;
-      cleanup();
-      try {
-        if (!popup.closed) popup.close();
-      } catch (err) {
-        console.debug(err);
+      if (!done) {
+        cleanup();
+        try {
+          if (!popup.closed) popup.close();
+        } catch {
+          //
+        }
+        reject(new Error("로그인 시간이 초과되었습니다."));
       }
-      reject(new Error("로그인 시간이 초과되었습니다."));
-    }, pollTimeoutMs);
+    }, timeoutMs);
+
+    window.addEventListener("message", onMessage);
   });
 }

--- a/src/utils/openOAuthPopup.ts
+++ b/src/utils/openOAuthPopup.ts
@@ -4,18 +4,22 @@ export function openOAuthPopup(
   { eventType = "SOCIAL_LOGIN_DONE", timeoutMs = 120_000 } = {}
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    const w = 480,
-      h = 640;
+    const w = 520,
+      h = 700;
     const left = window.screenX + (window.outerWidth - w) / 2;
     const top = window.screenY + (window.outerHeight - h) / 2;
 
+    console.debug("[openOAuthPopup] opening:", authUrl);
     const opened = window.open(
       authUrl,
       "oauth_popup",
       `width=${w},height=${h},left=${left},top=${top}`
     );
+
     if (!opened) {
-      reject(new Error("팝업이 차단되었습니다."));
+      const err = new Error("팝업 차단");
+      console.error("[openOAuthPopup]", err);
+      reject(err);
       return;
     }
     const popup: Window = opened;
@@ -26,27 +30,33 @@ export function openOAuthPopup(
       window.removeEventListener("message", onMessage);
       clearInterval(closeWatch);
       clearTimeout(timeoutTimer);
+      console.debug("[openOAuthPopup] cleaned up");
     };
 
     function onMessage(e: MessageEvent) {
+      console.debug("[openOAuthPopup] message:", {
+        origin: e.origin,
+        data: e.data,
+      });
       if (done) return;
       if (e.origin !== targetOrigin) return;
-      const msg = e.data;
-      if (!msg || msg.type !== eventType) return;
+      if (!e.data || e.data.type !== eventType) return;
 
       cleanup();
       try {
         if (!popup.closed) popup.close();
-      } catch (err) {
-        console.debug("popup.close failed:", err);
+      } catch {
+        //
       }
-      resolve(msg.payload);
+      resolve(e.data.payload);
     }
 
     const closeWatch = setInterval(() => {
       if (popup.closed && !done) {
         cleanup();
-        reject(new Error("팝업이 닫혔습니다."));
+        const err = new Error("팝업이 닫힘");
+        console.warn("[openOAuthPopup]", err);
+        reject(err);
       }
     }, 400);
 
@@ -58,7 +68,9 @@ export function openOAuthPopup(
         } catch {
           //
         }
-        reject(new Error("로그인 시간이 초과되었습니다."));
+        const err = new Error("로그인 타임아웃");
+        console.error("[openOAuthPopup]", err);
+        reject(err);
       }
     }, timeoutMs);
 


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 트러블로그 카드 UI 수정
- [x] 카카오 로그인 수정 진행 중 (배포 환경에서 테스트 필요)

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 카카오 OAuth 팝업 흐름 추가: 팝업에서 메시지로 인증 페이로드 수신 후 자동 로그인 또는 추가 가입 유도.
  - 팝업/등록 라우트 및 팝업 열기/메시지 기반 통신 등록.

- 스타일
  - 카드 제목을 한 줄 말줄임으로 처리하고 호버 시 전체 제목 툴팁 표시.
  - 카드 하단 레이아웃 재구성, 아이콘 크기 고정 및 키보드 접근성 유지.

- 개선
  - 인증 토큰 적용 자동화: 토큰 저장 및 전역 요청 헤더 설정.
  - 소셜 가입 페이지에 세션/상태 기반 정보 자동 채움 및 성공 시 홈 리다이렉트.
  - 팝업 통신 타임아웃/닫힘 처리 및 관련 예외 처리 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->