### PR TITLE
FEAT: 이미지 관련 수정

### DIFF
--- a/src/components/Card/CardPreviewArea.tsx
+++ b/src/components/Card/CardPreviewArea.tsx
@@ -9,6 +9,7 @@ interface CardPreviewAreaProps {
   onAvatarClick?: () => void;
   onRequestDelete?: () => void;
   deleting?: boolean;
+  imageUrl?: string;
 }
 
 export default function CardPreviewArea({
@@ -19,9 +20,21 @@ export default function CardPreviewArea({
   onAvatarClick,
   onRequestDelete,
   deleting,
+  imageUrl,
 }: CardPreviewAreaProps) {
+  const hasImage = !!imageUrl;
+
   return (
-    <div className="bg-gray1 rounded-2xl h-[170px] sm:h-[200px] md:h-[210px] xl:h-[220px] flex flex-col p-3 sm:p-4">
+    <div
+      className={[
+        // 공통 스타일
+        "rounded-2xl h-[170px] sm:h-[200px] md:h-[210px] xl:h-[220px] flex flex-col p-3 sm:p-4",
+        // 이미지 유무에 따라 배경 클래스 분기
+        hasImage ? "bg-center bg-cover bg-no-repeat" : "bg-gray1",
+      ].join(" ")}
+      // 이미지가 있을 때만 backgroundImage 적용
+      style={hasImage ? { backgroundImage: `url(${imageUrl})` } : undefined}
+    >
       <div className="flex justify-between items-start gap-2 min-w-0">
         <span
           className="text-body-16-semibold truncate max-w-[65%] sm:max-w-[70%]"

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -116,6 +116,7 @@ export default function TroublogCard({
           onAvatarClick={onAvatarClick}
           onRequestDelete={handleRequestDelete}
           deleting={deleting}
+          imageUrl={imageUrl}
         />
       </div>
 

--- a/src/components/Card/TroublogCard.tsx
+++ b/src/components/Card/TroublogCard.tsx
@@ -30,6 +30,7 @@ export interface TroublogCardProps {
   summaryId?: number;
   postSummaryId?: number;
   summaries?: object[];
+  imageUrl?: string;
 }
 
 export default function TroublogCard({
@@ -49,6 +50,7 @@ export default function TroublogCard({
   onClick,
   onAvatarClick,
   onDeleted,
+  imageUrl,
 }: TroublogCardProps) {
   const navigate = useNavigate();
   const [deleting, setDeleting] = useState(false);
@@ -111,6 +113,7 @@ export default function TroublogCard({
         onAvatarClick={onAvatarClick}
         onRequestDelete={handleRequestDelete}
         deleting={deleting}
+        imageUrl={imageUrl}
       />
 
       {/* 제목, 날짜, 태그 영역 */}

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -9,13 +9,8 @@ import userIcon from "@/assets/icons/user.svg";
 import circleYIcon from "@/assets/icons/circle_y.svg";
 import circleGIcon from "@/assets/icons/circle_g.svg";
 import circleBIcon from "@/assets/icons/circle_b.svg";
-import {
-  getUserInfo,
-  postFollow,
-  postUnfollow,
-  getMyProfile,
-} from "@/api/user.api";
-import type { ProfileData, UserInfoData } from "@/models/user.model";
+import { getUserInfo, postFollow, postUnfollow } from "@/api/user.api";
+import type { UserInfoData } from "@/models/user.model";
 import githubIcon from "@/assets/icons/githubIcon.svg";
 
 type MyPageSideBarProps =
@@ -67,32 +62,20 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
 
   const refetch = useCallback(async () => {
     try {
-      if (props.isMyPage) {
-        const me: ProfileData = await getMyProfile();
-        setUserInfo({
-          userId: me.userId,
-          nickname: me.nickname,
-          bio: me.bio,
-          githubUrl: me.githubUrl,
-          profileUrl: (me as any).profileUrl, // ProfileData에 존재한다면 정확한 타입으로 교체
-          followerNum: (me as any).followerNum,
-          followingNum: (me as any).followingNum,
-        });
-        setViewedUser({ id: me.userId, nickname: me.nickname ?? null });
-      } else {
-        if (!id) return;
-        const other: UserInfoData = await getUserInfo(Number(id));
-        setUserInfo({
-          userId: other.userId,
-          nickname: other.nickname,
-          bio: other.bio,
-          profileUrl: other.profileUrl,
-          followerNum: other.followerNum,
-          followingNum: other.followingNum,
-          isFollowed: other.isFollowed,
-        });
-        setViewedUser({ id: other.userId, nickname: other.nickname ?? null });
-      }
+      if (!id) return;
+      // 내 페이지든 남의 페이지든 동일 API 사용
+      const data: UserInfoData = await getUserInfo(Number(id));
+      setUserInfo({
+        userId: data.userId,
+        nickname: data.nickname,
+        bio: data.bio,
+        githubUrl: data.githubUrl, // 서버가 제공하면 표시(아래 UI는 isMyPage일 때만 노출)
+        profileUrl: data.profileUrl,
+        followerNum: data.followerNum,
+        followingNum: data.followingNum,
+        isFollowed: data.isFollowed,
+      });
+      setViewedUser({ id: data.userId, nickname: data.nickname ?? null });
     } catch (error) {
       console.error("사용자 정보 불러오기 실패:", error);
     }
@@ -201,7 +184,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
       {/* 상단 프로필 영역 */}
       <div className="flex flex-col items-center gap-3 self-stretch">
         <img
-          src={props.isMyPage ? userIcon : userInfo?.profileUrl || userIcon}
+          src={userInfo?.profileUrl || userIcon}
           alt="user"
           className="w-28 h-28 sm:w-36 sm:h-36 md:w-56 md:h-56 xl:w-[288px] xl:h-[288px] object-cover rounded-full md:rounded-none"
         />

--- a/src/components/TemplateWrite/EditorBlock.tsx
+++ b/src/components/TemplateWrite/EditorBlock.tsx
@@ -1,4 +1,4 @@
-import MDEditor from "@uiw/react-md-editor";
+import MDEditor, { type ICommand } from "@uiw/react-md-editor";
 import alertIcon from "@/assets/icons/alerticon.svg";
 import checkBoxIcon from "@/assets/icons/checkedbox.svg";
 import nonCheckBoxIcon from "@/assets/icons/noncheckedbox.svg";
@@ -31,6 +31,17 @@ export type EditorBlockProps = {
   isSaving?: boolean;
   canSave?: boolean;
   onActivate: (index: number) => void;
+
+  onPasteImage?: (
+    blockId: number,
+    e: React.ClipboardEvent<HTMLTextAreaElement>
+  ) => void;
+  onDropImage?: (
+    blockId: number,
+    e: React.DragEvent<HTMLTextAreaElement>
+  ) => void;
+
+  commandsFilter?: (command: ICommand, isExtra: boolean) => false | ICommand;
 };
 
 const MIN_H = 200;
@@ -53,6 +64,9 @@ const EditorBlock = ({
   onSave,
   isSaving,
   canSave,
+  onPasteImage,
+  onDropImage,
+  commandsFilter,
 }: EditorBlockProps) => {
   const [editorHeight, setEditorHeight] = useState<number>(MIN_H);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -173,6 +187,16 @@ const EditorBlock = ({
               preview={isActive ? "edit" : "preview"}
               style={{ width: "1200px", border: "none" }}
               autoFocus={isActive}
+              commandsFilter={commandsFilter}
+              textareaProps={{
+                onPaste: (e) => onPasteImage?.(block.id, e),
+                onDrop: (e) => onDropImage?.(block.id, e),
+                onDragOver: (e) => {
+                  // 드래그 파일 드롭 허용
+                  if (e.dataTransfer?.types?.includes("Files"))
+                    e.preventDefault();
+                },
+              }}
             />
           </div>
         </div>

--- a/src/mappers/cardMapper.ts
+++ b/src/mappers/cardMapper.ts
@@ -12,7 +12,7 @@ export const mapToTroubleShootingCard = (
   tags: card.tags,
   importance: card.importance,
   createdAt: card.createdAt,
-  thumbnailUrl: undefined,
+  thumbnailUrl: card.imageUrl,
   visibility: card.visibility,
   summaryType: card.summaryType,
   status: card.status,

--- a/src/mappers/communityCard.mapper.ts
+++ b/src/mappers/communityCard.mapper.ts
@@ -14,6 +14,7 @@ export const toCommunityCard = (s: CommunityServerCard): TroublogCardProps => ({
   authorId: s.postCardUserInfoResDto?.userId,
   likeCount: s.likeCount ?? 0,
   commentCount: s.commentCount ?? 0,
+  imageUrl: s.thumbnailUrl ?? "",
 });
 
 export const toCommunityCards = (list: CommunityServerCard[]) =>

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -24,7 +24,7 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     tags: Array.isArray(t.techs) ? t.techs : [],
     importance: t.starRating ?? 0,
     summaryType: mapSummaryType(t.summaryType),
-    imageUrl: t.imageUrl ?? undefined,
+    imageUrl: t.imageUrl ?? "",
     likeCount: t.likeCount ?? undefined,
     commentCount: t.commentCount ?? undefined,
     introduction: t.introduction ?? undefined,

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -24,7 +24,7 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     tags: Array.isArray(t.techs) ? t.techs : [],
     importance: t.starRating ?? 0,
     summaryType: mapSummaryType(t.summaryType),
-    // thumbnailUrl: t.imageUrl ?? undefined,
+    imageUrl: t.imageUrl ?? undefined,
     likeCount: t.likeCount ?? undefined,
     commentCount: t.commentCount ?? undefined,
     introduction: t.introduction ?? undefined,

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -8,7 +8,12 @@ import { useNavigate, useParams } from "react-router-dom";
 import ConfirmDeleteModal from "@/components/Modal/ConfirmDeleteModal";
 import WithdrawCompleteModal from "@/components/Modal/WithdrawCompleteModal";
 import type { ProfileData, UpdatedProfileData } from "@/models/user.model";
-import { deleteUser, getMyProfile, patchProfile } from "@/api/user.api";
+import {
+  deleteUser,
+  getMyProfile,
+  getUserInfo,
+  patchProfile,
+} from "@/api/user.api";
 import { PATH } from "@/constants/paths";
 import userIcon from "@/assets/icons/user.svg";
 import useImageUpload from "@/utils/useImageUpload";
@@ -31,12 +36,17 @@ const EditProfile = () => {
   const [profileImage, setProfileImage] = useState<string>(userIcon);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // 이미지 삭제 가능 여부 판단
+  const canDeleteImage =
+    !!profile.profileUrl || (profileImage && profileImage !== userIcon);
+
   const handleImageUpload = () => {
     fileInputRef.current?.click();
   };
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    e.target.value = "";
     if (!file) return;
 
     try {
@@ -99,24 +109,44 @@ const EditProfile = () => {
 
   // 프로필 불러오기
   useEffect(() => {
+    let alive = true;
+
     const fetchProfile = async () => {
       try {
-        const data = await getMyProfile();
+        const [me, userInfo] = await Promise.all([
+          getMyProfile(),
+          id ? getUserInfo(Number(id)) : Promise.resolve(null as any),
+        ]);
+
+        // 사용자 정보 API가 제공하는 profileUrl 우선 사용
+        const serverProfileUrl =
+          (userInfo && userInfo.profileUrl) ||
+          (me as any)?.profileUrl || // 혹시 백엔드가 주는 경우
+          "";
+
+        if (!alive) return;
+
         setProfile({
-          userId: data.userId,
-          nickname: data.nickname,
-          field: data.field,
-          bio: data.bio,
-          githubUrl: data.githubUrl,
-          profileUrl: profile.profileUrl,
+          userId: me.userId,
+          nickname: me.nickname,
+          field: me.field,
+          bio: me.bio,
+          githubUrl: me.githubUrl,
+          profileUrl: serverProfileUrl,
         });
+
+        // 미리보기에도 반영
+        setProfileImage(serverProfileUrl || userIcon);
       } catch (error) {
         console.error("정보를 불러오는 데 실패했습니다", error);
       }
     };
 
     fetchProfile();
-  }, []);
+    return () => {
+      alive = false;
+    };
+  }, [id]);
 
   const handleChange =
     (field: keyof ProfileData) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,8 +209,12 @@ const EditProfile = () => {
               />
               <FollowButton
                 label="이미지 삭제"
-                colorClass="bg-subColor1"
-                onClick={handleImageDelete}
+                colorClass={
+                  canDeleteImage
+                    ? "bg-primary"
+                    : "bg-subColor1 cursor-not-allowed"
+                }
+                onClick={canDeleteImage ? handleImageDelete : undefined}
               />
             </div>
           </div>

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import HeaderWoSearch from "@/components/Header/HeaderWoSearch";
 import DropDownButton from "@/components/Button/DropDownButton";
 import CategoryTag from "@/components/TemplateWrite/CategoryTag";
-import MDEditor from "@uiw/react-md-editor";
+import MDEditor, {
+  commands,
+  TextAreaTextApi,
+  type ICommand,
+  type TextState,
+} from "@uiw/react-md-editor";
 import PostSaveModal, {
   type PostSavePayload,
 } from "@/pages/TempWrite/PostSaveModal";
@@ -27,6 +32,7 @@ import {
   getTagsByKeyword,
   getPostDetail,
 } from "@/api/post.api";
+import { uploadImage } from "@/api/image.api";
 
 // ---------- 타입 ----------
 export type BlockData = {
@@ -691,6 +697,93 @@ export default function FreeFormWritePage() {
     );
   };
 
+  // 이미지 업로드 - 드래그 앤 드롭
+  const insertImageMarkdown = (blockId: number, url: string) => {
+    setBlocks((prev) =>
+      prev.map((b) =>
+        b.id === blockId
+          ? { ...b, content: `${b.content?.trim()}\n\n![image](${url})` }
+          : b
+      )
+    );
+  };
+
+  const handlePasteImage = async (
+    blockId: number,
+    e: React.ClipboardEvent<HTMLTextAreaElement>
+  ) => {
+    const files = e.clipboardData?.files;
+    const file = files && files[0];
+    if (file && file.type.startsWith("image/")) {
+      e.preventDefault();
+      try {
+        const url = await uploadImage(file); // onProgress 필요하면 2번째 인자 사용 가능
+        insertImageMarkdown(blockId, url);
+      } catch {
+        setStatusMessage("이미지 업로드에 실패했어요.");
+      }
+    }
+  };
+
+  const handleDropImage = async (
+    blockId: number,
+    e: React.DragEvent<HTMLTextAreaElement>
+  ) => {
+    const file = e.dataTransfer?.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      e.preventDefault();
+      try {
+        const url = await uploadImage(file);
+        insertImageMarkdown(blockId, url);
+      } catch {
+        setStatusMessage("이미지 업로드에 실패했어요.");
+      }
+    }
+  };
+
+  // 이미지 업로드 - 파일 선택
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  // 선택 텍스트를 alt로 쓰고, 없으면 기본 "image" 사용
+  const insertImage = (state: TextState, api: TextAreaTextApi, url: string) => {
+    const alt = state.selectedText?.trim() || "image";
+    const md = `![${alt}](${url})`;
+    api.replaceSelection(md);
+
+    const pos = state.selection.start + md.length;
+    api.setSelectionRange({ start: pos, end: pos });
+  };
+
+  const imageUploadCmd: ICommand = {
+    name: "imageUpload",
+    keyCommand: "image",
+    icon: commands.image.icon, // 기본 이미지 아이콘 재사용
+    buttonProps: { "aria-label": "이미지 업로드" },
+    execute: (state, api) => {
+      const input = fileRef.current;
+      if (!input) return;
+
+      const onPick = async (e: Event) => {
+        input.removeEventListener("change", onPick);
+        const file = (e.target as HTMLInputElement).files?.[0];
+        (e.target as HTMLInputElement).value = ""; // 같은 파일 재선택 허용
+        if (!file) return;
+
+        try {
+          const url = await uploadImage(file);
+          insertImage(state, api, url);
+        } catch {
+          // 필요시 상태 메시지/토스트 처리
+          // setStatusMessage("이미지 업로드에 실패했어요.");
+        }
+      };
+
+      input.accept = "image/*";
+      input.addEventListener("change", onPick, { once: true });
+      input.click();
+    },
+  };
+
   // ------------ UI ------------
   return (
     <div>
@@ -813,6 +906,13 @@ export default function FreeFormWritePage() {
                   handleChangeBlock(block.id, "content", val || "")
                 }
                 preview="edit"
+                textareaProps={{
+                  onPaste: (e) => handlePasteImage(block.id, e),
+                  onDrop: (e) => handleDropImage(block.id, e),
+                }}
+                commandsFilter={(cmd) =>
+                  cmd.keyCommand === "image" ? imageUploadCmd : cmd
+                }
               />
             </div>
           ))}
@@ -892,6 +992,8 @@ export default function FreeFormWritePage() {
           )}
         </div>
       </div>
+
+      <input ref={fileRef} type="file" hidden />
     </div>
   );
 }

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -909,6 +909,12 @@ export default function FreeFormWritePage() {
                 textareaProps={{
                   onPaste: (e) => handlePasteImage(block.id, e),
                   onDrop: (e) => handleDropImage(block.id, e),
+                  onDragOver: (e) => {
+                    if (e.dataTransfer?.types?.includes("Files")) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }
+                  },
                 }}
                 commandsFilter={(cmd) =>
                   cmd.keyCommand === "image" ? imageUploadCmd : cmd

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -25,6 +25,13 @@ import {
   editPost,
   getTagsByKeyword,
 } from "@/api/post.api";
+import { uploadImage } from "@/api/image.api";
+import {
+  commands,
+  TextAreaTextApi,
+  type ICommand,
+  type TextState,
+} from "@uiw/react-md-editor";
 
 // ---------- 상태 타입 ----------
 type IncomingTemplateState = {
@@ -669,6 +676,93 @@ const TempWritePage = () => {
     });
   }, []);
 
+  // 이미지 업로드 - 드래그 앤 드롭
+  const insertImageMarkdown = (blockId: number, url: string) => {
+    setBlocks((prev) =>
+      prev.map((b) =>
+        b.id === blockId
+          ? { ...b, content: `${b.content?.trim()}\n\n![image](${url})` }
+          : b
+      )
+    );
+  };
+
+  const handlePasteImage = async (
+    blockId: number,
+    e: React.ClipboardEvent<HTMLTextAreaElement>
+  ) => {
+    const files = e.clipboardData?.files;
+    const file = files && files[0];
+    if (file && file.type.startsWith("image/")) {
+      e.preventDefault();
+      try {
+        const url = await uploadImage(file); // onProgress 필요하면 2번째 인자 사용 가능
+        insertImageMarkdown(blockId, url);
+      } catch {
+        setStatusMessage("이미지 업로드에 실패했어요.");
+      }
+    }
+  };
+
+  const handleDropImage = async (
+    blockId: number,
+    e: React.DragEvent<HTMLTextAreaElement>
+  ) => {
+    const file = e.dataTransfer?.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      e.preventDefault();
+      try {
+        const url = await uploadImage(file);
+        insertImageMarkdown(blockId, url);
+      } catch {
+        setStatusMessage("이미지 업로드에 실패했어요.");
+      }
+    }
+  };
+
+  // 이미지 업로드 - 파일 선택
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  // 선택 텍스트를 alt로 쓰고, 없으면 기본 "image" 사용
+  const insertImage = (state: TextState, api: TextAreaTextApi, url: string) => {
+    const alt = state.selectedText?.trim() || "image";
+    const md = `![${alt}](${url})`;
+    api.replaceSelection(md);
+
+    const pos = state.selection.start + md.length;
+    api.setSelectionRange({ start: pos, end: pos });
+  };
+
+  const imageUploadCmd: ICommand = {
+    name: "imageUpload",
+    keyCommand: "image",
+    icon: commands.image.icon, // 기본 이미지 아이콘 재사용
+    buttonProps: { "aria-label": "이미지 업로드" },
+    execute: (state, api) => {
+      const input = fileRef.current;
+      if (!input) return;
+
+      const onPick = async (e: Event) => {
+        input.removeEventListener("change", onPick);
+        const file = (e.target as HTMLInputElement).files?.[0];
+        (e.target as HTMLInputElement).value = ""; // 같은 파일 재선택 허용
+        if (!file) return;
+
+        try {
+          const url = await uploadImage(file);
+          insertImage(state, api, url);
+        } catch {
+          // 필요시 상태 메시지/토스트 처리
+          // setStatusMessage("이미지 업로드에 실패했어요.");
+        }
+      };
+
+      input.accept = "image/*";
+      input.addEventListener("change", onPick, { once: true });
+      input.click();
+    },
+  };
+
   // ---------- UI ----------
   return (
     <div>
@@ -765,6 +859,11 @@ const TempWritePage = () => {
                   isSaving={isSaving}
                   canSave={canSave}
                   onActivate={(i) => setActiveIndex(i)}
+                  onPasteImage={handlePasteImage}
+                  onDropImage={handleDropImage}
+                  commandsFilter={(cmd) =>
+                    cmd.keyCommand === "image" ? imageUploadCmd : cmd
+                  }
                 />
               );
             })}
@@ -838,6 +937,8 @@ const TempWritePage = () => {
           )}
         </div>
       </div>
+
+      <input ref={fileRef} type="file" accept="image/*" hidden />
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ] 트러블슈팅 문서 썸네일 이미지 띄울 수 있도록 수정
- [ ] 글 작성 페이지에서 이미지 업로드 로직 연결
- [ ] 마이페이지에서 사용자 정보 조회 API 호출 분기 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 에디터 이미지 업로드 지원 확대: 붙여넣기, 드래그앤드롭, 파일 선택으로 마크다운에 이미지 삽입 및 커스텀 이미지 명령 추가.
  - 카드 미리보기에서 배경 이미지 표시 지원(이미지 제공 시 자동 적용).

- 개선
  - 카드/커뮤니티/트러블 카드에 imageUrl 전파로 썸네일/이미지 노출 향상.
  - 마이페이지 사이드바에서 프로필 이미지·정보 로딩을 일관되게 표시.
  - 프로필 편집에서 서버·선택 이미지 우선순위에 따른 미리보기 개선.

- 리팩터
  - 마이페이지 사이드바 사용자 데이터 로딩을 단일 경로로 통합.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->