### PR TITLE
FEAT: 일부 UI 수정

### DIFF
--- a/src/components/Card/CardTitleSection.tsx
+++ b/src/components/Card/CardTitleSection.tsx
@@ -20,25 +20,23 @@ export default function CardTitleSection({
 }: CardTitleSectionProps) {
   return (
     <div className="gap-2">
-      {/* 제목 + 공개 여부 아이콘 or 요약 유형 */}
-      <div className="flex items-start gap-1 sm:gap-2 min-w-0">
-        {/* 고정 max-w 제거하고 부모 폭을 최대로 사용해 한 줄 말줄임 */}
-        <div
-          className="flex-1 min-w-0 text-head-20-semibold whitespace-nowrap overflow-hidden text-ellipsis"
-          title={title}
-        >
+      {/* 제목 + 공개/비공개 아이콘(or 요약 유형) */}
+      <div className="flex items-center min-w-0">
+        {/* 제목: 컨테이너 제약 내에서만 잘림/말줄임 */}
+        <span className="min-w-0 truncate text-head-20-semibold" title={title}>
           {title}
-        </div>
+        </span>
 
+        {/* 바로 옆(작은 여백) */}
         {isMine &&
           (status === "created" && summaryType ? (
-            <span className="text-body-16-regular text-gray3">
+            <span className="ml-1 sm:ml-2 text-body-16-regular text-gray3 shrink-0">
               {summaryType}
             </span>
           ) : (
             <img
               src={visibility === "public" ? publicIcon : privateIcon}
-              className="w-[24px] h-[24px] shrink-0"
+              className="ml-1 sm:ml-2 w-[20px] h-[20px] sm:w-[24px] sm:h-[24px] shrink-0"
               alt={visibility === "public" ? "공개" : "비공개"}
             />
           ))}

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -21,9 +21,17 @@ export default function NotificationModal() {
   const navigate = useNavigate();
 
   return (
-    <div className="w-[600px] h-[262px] rounded-[20px] bg-white shadow-card p-0 overflow-hidden flex flex-col">
-      {/* 카테고리 탭 */}
-      <div className="flex gap-[28px] mt-[24px] ml-[36px] mb-[15px]">
+    <div
+      className="
+        w-[92vw] sm:w-[520px] md:w-[560px] lg:w-[600px]
+        max-w-[92vw]
+        h-[262px]
+        rounded-[20px] bg-white shadow-card p-0
+        overflow-hidden flex flex-col
+      "
+    >
+      {/* 카테고리 탭 (기존 gap/마진 유지, xs에서만 좌여백 살짝 축소) */}
+      <div className="flex gap-[28px] mt-[24px] ml-4 sm:ml-[36px] mb-[15px]">
         {tabs.map((tab) => (
           <span
             key={tab}
@@ -38,11 +46,11 @@ export default function NotificationModal() {
         ))}
       </div>
 
-      {/* 구분선 */}
+      {/* 구분선 (기존 간격 유지) */}
       <div className="w-full h-[1px] bg-gray1 mb-[28px]" />
 
-      {/* 알림 영역 */}
-      <div className="flex-1 overflow-y-auto px-[38px] pb-[46px]">
+      {/* 알림 영역 (기존 여백/간격 유지) */}
+      <div className="flex-1 overflow-y-auto px-4 sm:px-[38px] pb-[46px]">
         {loading ? (
           <div className="w-full h-full flex items-center justify-center text-head-20-semibold">
             불러오는 중…
@@ -65,7 +73,7 @@ export default function NotificationModal() {
                 <div
                   onClick={() => {
                     const internal = toInternalSpaPath(item.link);
-                    if (!internal) return; // 스킴이 이상하면 무시
+                    if (!internal) return;
                     navigate(internal);
                   }}
                   className={clsx(

--- a/src/pages/TempWrite/PostSuccessModal.tsx
+++ b/src/pages/TempWrite/PostSuccessModal.tsx
@@ -1,30 +1,64 @@
 import BaseModal from "../../components/Modal/BaseModal";
+import { useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/paths";
 import exitIcon from "@/assets/icons/exiticon.svg";
+import postSuccessIcon from "@/assets/icons/postsuccess.svg";
 
-type Props = {
+export default function PostSuccessModal({
+  onClose,
+  summaryId,
+  postId,
+}: {
   onClose: () => void;
   summaryId?: number;
   postId?: number;
-};
+}) {
+  const navigate = useNavigate();
 
-export default function PostSuccessModal({ onClose }: Props) {
+  const canGo = summaryId != null && postId != null;
+
+  const goCombined = () => {
+    if (!canGo) {
+      alert("요약 상세로 이동할 수 없어요. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+    navigate(PATH.COMBINED_DETAIL(postId!, summaryId!));
+  };
+
   return (
     <BaseModal
       onClose={onClose}
-      width="w-full max-w-[520px]"
+      /* 작은 화면에서는 가득, 데스크톱은 기존 최대폭 유지 */
+      width="w-full max-w-[580px]"
       className="bg-white rounded-[12px] px-4 sm:px-6 py-6 sm:py-8"
     >
+      {/* 닫기 버튼: 우측 상단 고정 정렬 */}
       <div className="flex w-full justify-end">
         <button onClick={onClose} className="w-6 h-6">
           <img src={exitIcon} alt="닫기" className="w-full h-full" />
         </button>
       </div>
 
-      <div className="mx-auto max-w-[460px] text-center space-y-3">
-        <h2 className="text-head-24-bold">요약 준비가 완료됐어요!</h2>
-        <p className="text-body-18-regular text-gray-500">
-          저장 또는 공유 메뉴에서 다음 작업을 진행해 주세요.
-        </p>
+      {/* 본문 */}
+      <div className="mx-auto max-w-[420px] flex flex-col items-center text-center gap-6 sm:gap-10">
+        <img
+          src={postSuccessIcon}
+          alt=""
+          aria-hidden
+          className="w-16 h-16 sm:w-[88px] sm:h-[86px]"
+        />
+        <h2 className="text-head-32-bold">양식 요약이 완료되었습니다!</h2>
+
+        <button
+          onClick={goCombined}
+          disabled={!canGo}
+          className={`rounded-[50px] h-11 sm:h-[46px] px-6 sm:px-[25px] 
+            bg-purple-500 text-white font-semibold
+            w-full sm:w-[184px]
+            ${!canGo ? "opacity-60 cursor-not-allowed" : ""}`}
+        >
+          완성 페이지로 이동
+        </button>
       </div>
     </BaseModal>
   );

--- a/src/pages/TempWrite/TemplateSelectModal.tsx
+++ b/src/pages/TempWrite/TemplateSelectModal.tsx
@@ -36,32 +36,33 @@ export default function TemplateSelectModal({
   return (
     <BaseModal
       onClose={onClose}
-      width="w-[1334px]"
-      className="bg-white rounded-[12px] px-[36px]"
+      /* 데스크톱은 기존 최대폭 유지, 작은 화면은 화면 너비에 맞춤 */
+      width="w-full max-w-[1334px]"
+      className="bg-white rounded-[12px] px-4 sm:px-6 md:px-8"
     >
-      {/* 헤더 */}
+      {/* 안내 토스트 (작은 화면에선 상단 여백 조정) */}
       {hasTriedSubmit && selectedIndex === null && (
-        <div className="fixed top-[100px] left-1/2 transform -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded shadow">
+        <div className="fixed top-20 sm:top-[100px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded shadow">
           템플릿을 선택해주세요.
         </div>
       )}
 
-      <div className="flex w-full mt-[36px] mb-[24px] pl-[500px]">
-        <div className="flex w-[763px] justify-between items-center">
-          <span className="text-head-32-bold ">어떤 방식으로 요약할까요?</span>
-          <button onClick={onClose} className="w-6 h-6">
-            <img src={exitIcon} alt="닫기" className="w-full h-full" />
-          </button>
-        </div>
+      {/* 헤더: 좌 타이틀 / 우 닫기 버튼 */}
+      <div className="flex w-full items-center justify-between mt-6 mb-4 sm:mt-8 sm:mb-6">
+        <span className="text-head-32-bold">어떤 방식으로 요약할까요?</span>
+        <button onClick={onClose} className="w-6 h-6">
+          <img src={exitIcon} alt="닫기" className="w-full h-full" />
+        </button>
       </div>
-      {/*헤더아래*/}
-      <div className="flex flex-col pt-[48px] px-[78px] gap-[28px]">
-        {/* 템플릿 아이콘 */}
-        <div className="flex gap-[20px]">
+
+      {/* 본문 */}
+      <div className="flex flex-col pt-8 sm:pt-10 md:pt-12 gap-[28px]">
+        {/* 템플릿 그리드: 모바일 2열 → md 이상 4열 */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-[20px] place-items-center">
           {templates.map((label, index) => (
             <div
               key={index}
-              className="flex flex-col items-center gap-[20px] w-[282px]"
+              className="flex flex-col items-center gap-[20px] w-full max-w-[282px]"
             >
               <span
                 className={`text-head-20-semibold ${
@@ -72,12 +73,16 @@ export default function TemplateSelectModal({
               </span>
 
               <button
-                className={`w-[282px] h-[218px] flex items-center justify-center overflow-hidden rounded-[12px] border-[3px] shadow-[1px_1px_6px_0px_rgba(0,0,0,0.2)] ${
-                  selectedIndex === index
-                    ? "border-dashed border-purple-500"
-                    : ""
-                }`}
                 onClick={() => setSelectedIndex(index)}
+                className={`w-full sm:w-[240px] md:w-[282px] h-[160px] sm:h-[190px] md:h-[218px]
+                  flex items-center justify-center overflow-hidden
+                  rounded-[12px] border-[3px] shadow-[1px_1px_6px_0px_rgba(0,0,0,0.2)]
+                  ${
+                    selectedIndex === index
+                      ? "border-dashed border-purple-500"
+                      : "border-transparent"
+                  }
+                `}
               >
                 <img
                   src={
@@ -85,7 +90,7 @@ export default function TemplateSelectModal({
                       ? `/icons/tempimg${index + 1}purple.svg`
                       : `/icons/tempimg${index + 1}gray.svg`
                   }
-                  className="w-[82px] h-[82px] object-cover"
+                  className="w-12 h-12 sm:w-16 sm:h-16 md:w-[82px] md:h-[82px] object-contain"
                   alt={label}
                 />
               </button>
@@ -93,10 +98,12 @@ export default function TemplateSelectModal({
           ))}
         </div>
 
-        {/* 버튼 */}
-        <div className="flex items-center justify-between pt-[12px] pb-[32px]">
-          <div>{onPrev && <CancelButton onClick={onPrev} label="이전" />}</div>
-          <div className="flex gap-[16px]">
+        {/* 버튼 영역: 모바일에선 세로 스택, md 이상 가로 정렬 */}
+        <div className="flex flex-col md:flex-row items-stretch md:items-center justify-between gap-3 md:gap-0 pt-3 pb-6">
+          <div className="order-2 md:order-1">
+            {onPrev && <CancelButton onClick={onPrev} label="이전" />}
+          </div>
+          <div className="order-1 md:order-2 flex justify-end gap-[16px]">
             <CancelButton onClick={onLater} label="다음에" />
             <SaveButton onClick={handleConfirm} label="요약" />
           </div>


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ]  한 일

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게시 완료 모달에 완료 일러스트, 닫기 버튼, “완성 페이지로 이동” 버튼 추가. 조건 충족 시 상세 페이지로 이동, 미충족 시 알림 표시.

- Style
  - 카드 제목과 상태/아이콘을 한 줄로 정렬하고 줄임 처리 일관성 개선.
  - 알림 모달 폭·패딩을 반응형으로 조정해 작은 화면 가독성 향상.
  - 템플릿 선택 모달의 헤더, 그리드, 버튼 영역을 반응형으로 재구성하고 타일 선택 경계선 표시 개선.
  - 토스트 위치를 화면 크기에 맞게 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->