### PR TITLE
FIX: 카카오 회원가입 시 닉네임 입력 로직 수정 및 일부 UI 수정

### DIFF
--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -159,7 +159,8 @@ export default function ProjectFolderCard({
   );
 
   const ContainerClasses =
-    "flex w-full max-w-[384px] p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card overflow-hidden";
+    "flex flex-none p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card " +
+    "w-[300px] sm:w-[332px] md:w-[360px] lg:w-[384px]";
 
   return (
     <>

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -66,6 +66,7 @@ export interface EmailCheckResponse {
 
 export interface OauthRegisterRequest {
   userId: number;
+  kakaoNickname: string;
   nickname: string;
   field: string;
   bio: string;

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -323,8 +323,7 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            {/* 유연한 컬럼: 화면에 맞춰 자동으로 1~N열, 각 셀 최소 320px */}
-            <div className="grid w-full gap-6 grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
+            <div className="flex flex-wrap gap-6">
               {projects.map((p) => (
                 <ProjectFolderCard
                   key={p.id}

--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -9,11 +9,19 @@ import { PATH } from "@/constants/paths";
 const SignPageOauth = () => {
   const navigate = useNavigate();
   const location = useLocation() as any;
-  const stateUserId = location?.state?.userId as number | undefined;
-  const stateNickname = location?.state?.nickname as string | undefined;
 
+  // location.state에서 넘어온 값 (카카오 인증 직후)
+  const stateUserId = location?.state?.userId as number | undefined;
+  const stateKakaoNickname = location?.state?.nickname as string | undefined;
+
+  // 카카오 원본 정보 (읽기 전용)
   const [userId, setUserId] = useState<number | null>(stateUserId ?? null);
-  const [nickname, setNickname] = useState(stateNickname ?? "");
+  const [kakaoNickname, setKakaoNickname] = useState<string>(
+    stateKakaoNickname ?? ""
+  );
+
+  // 사용자 입력용
+  const [nickname, setNickname] = useState<string>(""); // 서비스에서 사용할 닉네임
   const [field, setField] = useState("");
   const [bio, setBio] = useState("");
   const [githubad, setGithubad] = useState("");
@@ -26,18 +34,25 @@ const SignPageOauth = () => {
 
   // 새로고침 폴백
   useEffect(() => {
-    if (userId != null && nickname) return;
+    if (userId != null && kakaoNickname) return;
     try {
       const raw = sessionStorage.getItem("oauth_payload");
       if (raw) {
         const p = JSON.parse(raw) as { userId?: number; nickname?: string };
         if (p?.userId && !userId) setUserId(p.userId);
-        if (p?.nickname && !nickname) setNickname(p.nickname);
+        if (p?.nickname && !kakaoNickname) setKakaoNickname(p.nickname);
       }
     } catch (err) {
       console.debug("oauth_payload parse failed:", err);
     }
-  }, [userId, nickname]);
+  }, [userId, kakaoNickname]);
+
+  // UX: 사용자 입력 닉네임이 비어있다면, 카카오 닉네임을 기본값으로 채워줌
+  useEffect(() => {
+    if (!nickname && kakaoNickname) {
+      setNickname(kakaoNickname);
+    }
+  }, [kakaoNickname, nickname]);
 
   const validateForm = () => {
     let valid = true;
@@ -76,6 +91,7 @@ const SignPageOauth = () => {
     try {
       const payload: OauthRegisterRequest = {
         userId: userId!, // 카카오로 받은 ID
+        kakaoNickname: kakaoNickname.trim(),
         nickname: nickname.trim(),
         field: field.trim(),
         bio: bio.trim(),
@@ -139,15 +155,31 @@ const SignPageOauth = () => {
             className="flex flex-col items-start w-full"
           >
             <div className="flex flex-col items-start w-full">
+              {/* 카카오 닉네임 */}
+              <Input
+                label="카카오 닉네임"
+                type="text"
+                value={kakaoNickname}
+                onChange={() => {}}
+                placeholder="카카오에서 전달된 닉네임"
+                error={""}
+                name="kakaoNickname"
+              />
+              <p className="text-xs text-gray-500 -mt-2 mb-3">
+                카카오에서 받은 닉네임이며, 계정 식별을 위해 그대로 저장됩니다.
+              </p>
+
+              {/* 서비스에서 사용할 닉네임 (사용자 입력) */}
               <Input
                 label="닉네임"
                 type="text"
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
-                placeholder="닉네임을 입력해주세요."
+                placeholder="서비스에서 사용할 닉네임을 입력해주세요."
                 error={nicknameError}
                 name="nickname"
               />
+
               <Input
                 label="분야"
                 type="text"
@@ -180,7 +212,7 @@ const SignPageOauth = () => {
             <div className="flex flex-col items-start gap-4 w-full">
               <button
                 type="submit"
-                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center"
+                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-60"
                 disabled={submitting}
               >
                 <span className="text-white text-[20px] font-semibold font-pretendard">


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ]  한 일

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * OAuth 가입 화면에 카카오 닉네임 읽기 전용 표시 추가 및 서비스용 닉네임을 별도 입력하도록 분리. 서비스 닉네임이 비어 있으면 카카오 닉네임으로 자동 채움. 제출 버튼 비활성 시 시각적 피드백 개선.
* Style
  * 홈 프로젝트 목록을 그리드에서 플렉스(감싸기)로 변경하고 카드 간 6px 간격 적용.
  * 프로젝트 폴더 카드 너비를 반응형 고정폭(기본 300px, sm 332px, md 360px, lg 384px)으로 조정하고 내용 잘림을 줄이도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->