### PR TITLE
FIX: 수정사항 반영 

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -264,7 +264,7 @@ const resId = api.interceptors.response.use(
       }
       const newToken = await p;
 
-      if (newToken) {
+      if (newToken && !cfg._retry) {
         cfg._retry = true;
         cfg.headers = cfg.headers ?? {};
         (cfg.headers as any).Authorization = `Bearer ${newToken}`;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -85,6 +85,26 @@ const navigateToAuthGuardOnce = (status: 401 | 403, rawNext?: string) => {
   return authNavigationPromise;
 };
 
+const REFRESH_OK_KEY = "auth:lastRefreshOkAt";
+const setRecentRefreshOk = () => {
+  try {
+    localStorage.setItem(REFRESH_OK_KEY, String(Date.now()));
+  } catch {
+    //
+  }
+};
+const hasRecentRefreshOk = (ms = 10_000) => {
+  try {
+    const raw =
+      localStorage.getItem(REFRESH_OK_KEY) ??
+      sessionStorage.getItem(REFRESH_OK_KEY);
+    const ts = raw ? Number(raw) : NaN;
+    return Number.isFinite(ts) && Date.now() - ts < ms;
+  } catch {
+    return false;
+  }
+};
+
 // ----- 요청 인터셉터: 토큰/헤더 부착, 외부 절대 URL은 스킵 -----
 const reqId = api.interceptors.request.use((config) => {
   const url = config.url ?? "";
@@ -116,6 +136,8 @@ export const startRefresh = async (): Promise<string | null> => {
       return null;
     }
     localStorage.setItem("accessToken", newToken);
+
+    setRecentRefreshOk(); // NEW: 갱신 성공 신호
     return newToken;
   } catch {
     return null;
@@ -130,7 +152,30 @@ const resId = api.interceptors.response.use(
 
     // (안전망) 토큰 없이 HTML/리디렉트 비JSON 응답이면 로그인 요구
     const ct = res.headers?.["content-type"] as string | undefined;
-    const url: string | undefined = (res as any)?.request?.responseURL;
+    const url: string = (res as any)?.request?.responseURL || "";
+
+    // 서버가 302 → /login으로 돌린 뒤 브라우저가 따라가서 받은 HTML 응답
+    //    => 이 경우는 "인증 상실"로 보고 401 에러처럼 처리(에러 핸들러로 보냄)
+    const isLoginFollowed =
+      /\/login(\?|$)/.test(url) && (!ct || /text\/html/i.test(ct));
+
+    if (isLoginFollowed) {
+      const err = new AxiosError(
+        "Redirected to login",
+        "ERR_UNAUTHORIZED",
+        res.config,
+        (res as any).request,
+        {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: res.headers,
+          config: res.config,
+          data: res.data,
+        } as any
+      );
+      return Promise.reject(err);
+    }
+
     const redirectedToKakao =
       !!url && url.includes("/oauth2/authorization/kakao");
     const notJson = !!ct && !ct.includes("application/json");
@@ -194,6 +239,16 @@ const resId = api.interceptors.response.use(
 
     // 401 → 리프레시 시도 (SSE/스킵 요청 제외)
     if (status === 401 && !skipAuth && !isSSEAuth) {
+      // NEW: 다른 요청/탭에서 이미 갱신 성공한 경우 → 현재 토큰으로 즉시 1회 재시도
+      const latestToken = localStorage.getItem("accessToken");
+      if (hasRecentRefreshOk() && latestToken && !cfg._retry) {
+        cfg._retry = true;
+        cfg.headers = cfg.headers ?? {};
+        (cfg.headers as any).Authorization = `Bearer ${latestToken}`;
+        return api(cfg);
+      }
+
+      // 기존 로직: 리프레시 시도 (중복 방지)
       if (cfg._retry) {
         localStorage.removeItem("accessToken");
         await navigateToAuthGuardOnce(401);
@@ -223,6 +278,28 @@ const resId = api.interceptors.response.use(
 
     // 403 → 접근권한 없음 화면
     if (status === 403 && !skipAuth && !isSSEAuth) {
+      // NEW 1) 리프레시가 "진행 중"이라면 완료까지 기다렸다가 성공 시 재시도
+      const inflight = getRefreshPromise();
+      if (inflight && !cfg._retry) {
+        const t = await inflight;
+        if (t) {
+          cfg._retry = true;
+          cfg.headers = cfg.headers ?? {};
+          (cfg.headers as any).Authorization = `Bearer ${t}`;
+          return api(cfg);
+        }
+      }
+
+      // NEW 2) 직전에 갱신 성공한 토큰이 있으면 1회 재시도
+      const latestToken = localStorage.getItem("accessToken");
+      if (hasRecentRefreshOk() && latestToken && !cfg._retry) {
+        cfg._retry = true;
+        cfg.headers = cfg.headers ?? {};
+        (cfg.headers as any).Authorization = `Bearer ${latestToken}`;
+        return api(cfg);
+      }
+
+      // 기존 동작: 접근 권한 없음 화면
       await navigateToAuthGuardOnce(403);
       return Promise.reject(error);
     }

--- a/src/api/post.api.ts
+++ b/src/api/post.api.ts
@@ -21,6 +21,7 @@ import type {
 } from "@/models/post.model";
 import getAPIResponseData from "@/utils/getAPIResponseData";
 import api from "./axios";
+import type { AxiosRequestConfig } from "axios";
 
 const inflightMineDetail = new Map<number, Promise<any>>();
 
@@ -83,10 +84,16 @@ export const startSummary = (postId: number, summaryType: SummaryTypeParam) =>
   });
 
 // 요약 작업 상태
-export const getSummaryStatus = (postId: number, taskId: string) =>
+export const getSummaryStatus = (
+  postId: number,
+  taskId: string,
+  cfg?: AxiosRequestConfig
+) =>
   getAPIResponseData<WaitLoadingResponse>({
     url: `/troubles/${postId}/summary/${taskId}`,
     method: "GET",
+    __skipGlobalAuthGuard: true,
+    ...(cfg || {}),
   });
 
 // 요약 작업 취소

--- a/src/components/Card/CardHeaderRight.tsx
+++ b/src/components/Card/CardHeaderRight.tsx
@@ -58,25 +58,23 @@ export default function CardHeaderRight({
   return (
     <div className="relative flex items-center gap-1 sm:gap-2" ref={menuRef}>
       <StatusDot status={status} />
-      {status !== "inProgress" && (
-        <div className="relative" {...stopCardClick}>
-          <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
-          {showMenu && (
-            <div {...stopCardClick}>
-              <KebabDropdown
-                options={[
-                  {
-                    label: deleting ? "삭제 중..." : "삭제",
-                    onClick: () => {
-                      if (!deleting) onDelete?.();
-                    },
+      <div className="relative" {...stopCardClick}>
+        <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
+        {showMenu && (
+          <div {...stopCardClick}>
+            <KebabDropdown
+              options={[
+                {
+                  label: deleting ? "삭제 중..." : "삭제",
+                  onClick: () => {
+                    if (!deleting) onDelete?.();
                   },
-                ]}
-              />
-            </div>
-          )}
-        </div>
-      )}
+                },
+              ]}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -46,16 +46,19 @@ export default function FolderModal({
 
   const { uploading, progress, upload, reset: resetUpload } = useImageUpload();
 
-  const detailInflight = new Map<number, Promise<ProjectDetail>>();
-  function fetchProjectDetailOnce(id: number) {
-    if (!detailInflight.has(id)) {
-      detailInflight.set(
+  const detailInflightRef = useRef<Map<number, Promise<ProjectDetail>>>(
+    new Map()
+  );
+  const fetchProjectDetailOnce = (id: number) => {
+    const m = detailInflightRef.current;
+    if (!m.has(id)) {
+      m.set(
         id,
-        getProjectDetail(id).finally(() => detailInflight.delete(id))
+        getProjectDetail(id).finally(() => m.delete(id))
       );
     }
-    return detailInflight.get(id)!;
-  }
+    return m.get(id)!;
+  };
 
   useEffect(() => {
     if (mode !== "edit" || !projectId) return;

--- a/src/components/Modal/FolderModal.tsx
+++ b/src/components/Modal/FolderModal.tsx
@@ -22,17 +22,6 @@ interface FolderModalProps {
   loading?: boolean;
 }
 
-const detailInflight = new Map<number, Promise<ProjectDetail>>();
-function fetchProjectDetailOnce(id: number) {
-  if (!detailInflight.has(id)) {
-    detailInflight.set(
-      id,
-      getProjectDetail(id).finally(() => detailInflight.delete(id))
-    );
-  }
-  return detailInflight.get(id)!;
-}
-
 export default function FolderModal({
   mode,
   projectId,
@@ -51,8 +40,22 @@ export default function FolderModal({
   const [name, setName] = useState(initialName);
   const [description, setDescription] = useState(initialDescription);
   const [syncing, setSyncing] = useState(false);
+  const [serverThumbUrl, setServerThumbUrl] = useState<string | null>(
+    initialThumbnail ?? null
+  );
 
   const { uploading, progress, upload, reset: resetUpload } = useImageUpload();
+
+  const detailInflight = new Map<number, Promise<ProjectDetail>>();
+  function fetchProjectDetailOnce(id: number) {
+    if (!detailInflight.has(id)) {
+      detailInflight.set(
+        id,
+        getProjectDetail(id).finally(() => detailInflight.delete(id))
+      );
+    }
+    return detailInflight.get(id)!;
+  }
 
   useEffect(() => {
     if (mode !== "edit" || !projectId) return;
@@ -70,6 +73,7 @@ export default function FolderModal({
         setName(detail.name ?? "");
         setDescription(detail.description ?? "");
         setThumbnailPreview(detail.thumbnailImageUrl ?? null);
+        setServerThumbUrl(detail.thumbnailImageUrl ?? null); // ★ 추가
         setSelectedFile(null);
         setRemoved(false);
         resetUpload();
@@ -103,6 +107,7 @@ export default function FolderModal({
     setSelectedFile(file);
     setThumbnailPreview(URL.createObjectURL(file));
     setRemoved(false);
+    // serverThumbUrl는 유지 (사용자가 새로 업로드하면 serverThumbUrl는 결국 사용되지 않음)
     resetUpload();
   };
 
@@ -119,6 +124,7 @@ export default function FolderModal({
     setThumbnailPreview(null);
     setSelectedFile(null);
     setRemoved(true);
+    setServerThumbUrl(null);
     resetUpload();
   };
 
@@ -133,18 +139,31 @@ export default function FolderModal({
       if (selectedFile) {
         uploadedUrl = await upload(selectedFile);
       }
+
       const payload: CreateProjectRequest = {
         name: name.trim(),
         description: description.trim(),
       };
+
       if (mode === "new") {
-        if (uploadedUrl && uploadedUrl.trim() !== "")
+        if (uploadedUrl && uploadedUrl.trim() !== "") {
           payload.thumbnailImageUrl = uploadedUrl.trim();
+        }
+        // new에서는 기존 서버 URL이란 개념이 없으므로 추가 X
       } else {
-        if (uploadedUrl && uploadedUrl.trim() !== "")
+        // edit 모드
+        if (uploadedUrl && uploadedUrl.trim() !== "") {
+          // 새 업로드가 있으면 그걸 전송
           payload.thumbnailImageUrl = uploadedUrl.trim();
-        else if (removed) payload.thumbnailImageUrl = "";
+        } else if (removed) {
+          // 삭제를 눌렀다면 빈 문자열 전송
+          payload.thumbnailImageUrl = "";
+        } else if (serverThumbUrl) {
+          // ★ 변경/삭제 없이 저장 → 기존 서버 썸네일을 재전송
+          payload.thumbnailImageUrl = serverThumbUrl;
+        }
       }
+
       onSubmit?.(payload);
     } catch (err) {
       console.error("이미지 업로드/전송 실패:", err);

--- a/src/components/MyPage/TroubleShootingList.tsx
+++ b/src/components/MyPage/TroubleShootingList.tsx
@@ -74,28 +74,19 @@ const TroubleShootingList = () => {
     if (isLoading) return null;
     if (sortedCards.length > 0) return null;
 
-    const sortLabel = sortBy === "latest" ? "최신순" : "중요도순";
-
     if (isMyPage) {
       if (selectedStatus === "inProgress")
         return "작성 중인 트러블슈팅이 없어요.";
       if (selectedStatus === "complete")
-        return `작성 완료된 트러블슈팅이 없어요. (${sortLabel})`;
+        return `작성 완료된 트러블슈팅이 없어요.`;
       if (selectedStatus === "created")
-        return `작성+요약 완료된 트러블슈팅이 없어요. (${sortLabel})`;
-      return `조건에 맞는 트러블슈팅이 없어요. (${sortLabel})`;
+        return `작성+요약 완료된 트러블슈팅이 없어요.`;
+      return `조건에 맞는 트러블슈팅이 없어요.`;
     } else {
       if (selectedTag) return `선택한 태그에 해당하는 트러블슈팅이 없어요.`;
-      return `아직 공개된 트러블슈팅이 없어요. (${sortLabel})`;
+      return `아직 공개된 트러블슈팅이 없어요.`;
     }
-  }, [
-    isLoading,
-    sortedCards.length,
-    isMyPage,
-    selectedStatus,
-    sortBy,
-    selectedTag,
-  ]);
+  }, [isLoading, sortedCards.length, isMyPage, selectedStatus, selectedTag]);
 
   const handleDeleted = async () => {
     try {

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -159,8 +159,7 @@ export default function ProjectFolderCard({
   );
 
   const ContainerClasses =
-    "flex flex-none p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card " +
-    "w-[300px] sm:w-[332px] md:w-[360px] lg:w-[384px]";
+    "flex w-full max-w-[384px] p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card overflow-hidden";
 
   return (
     <>

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -159,7 +159,7 @@ export default function ProjectFolderCard({
   );
 
   const ContainerClasses =
-    "flex w-full max-w-[384px] p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card overflow-hidden";
+    "flex w-full max-w-[384px] p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card";
 
   return (
     <>

--- a/src/components/Project/StatusFilterButton.tsx
+++ b/src/components/Project/StatusFilterButton.tsx
@@ -1,6 +1,6 @@
 interface StatusFilterButtonProps {
-  label: "작성 완료" | "요약 완료";
-  statusKey: "complete" | "created";
+  label: "작성 중" | "작성 완료" | "요약 완료";
+  statusKey: "inProgress" | "complete" | "created";
   isSelected: boolean;
   onClick: () => void;
 }
@@ -11,6 +11,13 @@ export default function StatusFilterButton({
   isSelected,
   onClick,
 }: StatusFilterButtonProps) {
+  const dotColorClass =
+    statusKey === "inProgress"
+      ? "bg-status-inProgress"
+      : statusKey === "complete"
+      ? "bg-status-complete"
+      : "bg-status-created";
+
   return (
     <button
       onClick={onClick}
@@ -20,11 +27,7 @@ export default function StatusFilterButton({
     >
       <div className="flex items-center gap-[6px] sm:gap-[8px]">
         <div
-          className={`w-[16px] h-[16px] sm:w-[18px] sm:h-[18px] rounded-full ${
-            statusKey === "complete"
-              ? "bg-status-complete"
-              : "bg-status-created"
-          }`}
+          className={`w-[16px] h-[16px] sm:w-[18px] sm:h-[18px] rounded-full ${dotColorClass}`}
         />
         <span className="text-body-20-regular">{label}</span>
       </div>

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -66,7 +66,6 @@ export interface EmailCheckResponse {
 
 export interface OauthRegisterRequest {
   userId: number;
-  kakaoNickname: string;
   nickname: string;
   field: string;
   bio: string;

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -13,17 +13,17 @@ import { useNavigate } from "react-router-dom";
 export default function CommunityPage() {
   const navigate = useNavigate();
 
-  const sortOptions = ["전체", "최신순", "추천순", "좋아요순"] as const;
+  const sortOptions = ["최신순", "좋아요순"] as const;
   type SortOption = (typeof sortOptions)[number];
 
-  const [selectedSort, setSelectedSort] = useState<SortOption>("전체");
+  const [selectedSort, setSelectedSort] = useState<SortOption>("최신순");
   const [selectedTab, setSelectedTab] = useState<"trouble" | "recent">(
     "trouble"
   );
 
   // UI 라벨 -> API sort 파라미터 매핑
   const sortBy: CommunitySort = useMemo(() => {
-    if (selectedSort === "최신순" || selectedSort === "전체") return "latest";
+    if (selectedSort === "최신순") return "latest";
     return "likes"; // "추천순" / "좋아요순" 모두 likes에 매핑
   }, [selectedSort]);
 

--- a/src/pages/Error/AuthGuardPage.tsx
+++ b/src/pages/Error/AuthGuardPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { PATH } from "@/constants/paths";
 import { useViewerId } from "@/store/auth";
@@ -34,6 +35,62 @@ export default function AuthGuardPage() {
     if (viewerId != null) nav(PATH.MYPAGE(String(viewerId)));
     else goLogin();
   };
+
+  // ---- NEW: 토큰 갱신 성공 감지 → 자동 복귀 ----
+  const bouncedRef = useRef(false);
+  const RECENT_MS = 10_000; // 최근 10초 이내 갱신 성공만 유효
+
+  const hasRecentRefreshOk = () => {
+    try {
+      const raw =
+        localStorage.getItem("auth:lastRefreshOkAt") ??
+        sessionStorage.getItem("auth:lastRefreshOkAt");
+      const ts = raw ? Number(raw) : NaN;
+      return Number.isFinite(ts) && Date.now() - ts < RECENT_MS;
+    } catch {
+      return false;
+    }
+  };
+
+  // 1) 마운트/상태 변경 시 즉시 판단
+  useEffect(() => {
+    if (bouncedRef.current) return;
+
+    const recent = hasRecentRefreshOk();
+
+    // 401: viewerId가 생기거나 최근 갱신 신호가 있으면 복귀
+    // 403: 최근 갱신 신호가 "있을 때만" 복귀 (권한 이슈 루프 방지)
+    const shouldBounce =
+      (status === 401 && (viewerId != null || recent)) ||
+      (status === 403 && recent);
+
+    if (shouldBounce) {
+      bouncedRef.current = true;
+      goBack();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewerId, status]);
+
+  // 2) 갱신이 "뒤늦게" 성공하는 경우를 위해 짧게 폴링
+  useEffect(() => {
+    if (bouncedRef.current) return;
+
+    let elapsed = 0;
+    const interval = window.setInterval(() => {
+      if (bouncedRef.current) return;
+      if (hasRecentRefreshOk()) {
+        bouncedRef.current = true;
+        goBack();
+      }
+      elapsed += 500;
+      if (elapsed >= RECENT_MS) {
+        window.clearInterval(interval);
+      }
+    }, 500);
+
+    return () => window.clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <section className="w-full flex items-center justify-center py-24 px-6">

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -33,6 +33,8 @@ import {
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
+import { isAxiosError } from "axios";
+import { startRefresh } from "@/api/axios";
 
 // ---------- 타입 ----------
 export type BlockData = {
@@ -97,7 +99,9 @@ export type SummaryStatus =
   | "PREPROCESSING"
   | "ANALYZING"
   | "POSTPROCESSING"
-  | "COMPLETED";
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED";
 
 export default function FreeFormWritePage() {
   // ------------ 기본 상태 ------------
@@ -412,16 +416,7 @@ export default function FreeFormWritePage() {
   // 상단 Save 버튼: 원본 저장 + 임시저장 보조
   const handleGlobalSave = async () => {
     if (!validateBasic()) return;
-    setBlocks((prev) => prev.map((b) => ({ ...b, isSaved: true })));
-    const quickMeta = resolveQuickMeta();
-    if (!quickMeta) {
-      setStatusMessage("프로젝트를 먼저 선택해주세요.");
-      setShowAlert(true);
-      setTimeout(() => setShowAlert(false), 1000);
-      return;
-    }
-    await saveOriginal(quickMeta);
-    await handleClickTempSave();
+    await handleClickTempSave(); // 내부에서 저장 후 토스트만 띄움
   };
 
   // End → 템플릿 선택 → 요약
@@ -438,28 +433,6 @@ export default function FreeFormWritePage() {
     setIsPostSaveModalOpen(true);
   };
 
-  // 임시저장용 메타값 자동 구성 (모달 없이)
-  const resolveQuickMeta = (): PostSavePayload | null => {
-    const pid =
-      previewMeta?.projectId ?? initialProjectId ?? projectList[0]?.id ?? null;
-
-    if (pid == null) return null; // 프로젝트 없으면 임시저장 불가
-
-    const pname =
-      previewMeta?.projectName ??
-      projectList.find((p) => p.id === pid)?.name ??
-      "";
-
-    return {
-      importance: previewMeta?.importance ?? 0,
-      thumbnail: previewMeta?.thumbnail ?? null,
-      description: previewMeta?.description ?? "",
-      visibility: previewMeta?.visibility ?? "public",
-      projectId: pid,
-      projectName: pname,
-    };
-  };
-
   // 저장 모달 → Next
   const handleNextInPostSaveModal = async (payload: PostSavePayload) => {
     setPreviewMeta(payload);
@@ -470,15 +443,22 @@ export default function FreeFormWritePage() {
       return;
     }
 
-    // SUMMARY 경로: 우선 원본을 COMPLETED 로 저장 → 템플릿 선택 열기
+    // SUMMARY 경로
     try {
-      const tags = await canonicalizeTags(selectedTags);
-      const form = buildForm("COMPLETED", payload, tags);
-      const id = await upsertPost(draftPostId, form);
-      setDraftPostId(id);
-      setCreatedPostId(id);
-
-      setIsTemplateSelectModalOpen(true);
+      if (isResume) {
+        // --- 수정 모드 ---
+        // 요약은 서버가 수정까지 처리하므로 여기선 수정 API 호출 안함
+        setCreatedPostId(resumePostId); // 이후 흐름에서 사용
+        setIsTemplateSelectModalOpen(true);
+      } else {
+        // --- 생성 모드(기존 동작) ---
+        const tags = await canonicalizeTags(selectedTags);
+        const form = buildForm("COMPLETED", payload, tags);
+        const id = await upsertPost(draftPostId, form); // create 또는 edit
+        setDraftPostId(id);
+        setCreatedPostId(id);
+        setIsTemplateSelectModalOpen(true);
+      }
     } catch (e) {
       console.error(e);
       setStatusMessage("문서 생성에 실패했어요. 잠시 후 다시 시도해주세요.");
@@ -548,9 +528,51 @@ export default function FreeFormWritePage() {
     let timer: number | null = null;
 
     const tick = async () => {
+      // 리프레시 진행 중이면 먼저 대기
+      const awaitRefreshIfAny = async () => {
+        const p = (window as any).__authRefreshPromise as Promise<
+          string | null
+        > | null;
+        if (p) {
+          try {
+            await p;
+          } catch {
+            /* ignore */
+          }
+        }
+      };
+
       try {
         const targetId = (createdPostId ?? resumePostId) as number;
-        const data: any = await getSummaryStatus(targetId, summaryTaskId);
+
+        await awaitRefreshIfAny();
+
+        const fetchOnce = () =>
+          getSummaryStatus(targetId, summaryTaskId, {
+            __skipGlobalAuthGuard: true, // 전역 가드 스킵(자체 처리)
+          });
+
+        let data: any;
+        try {
+          data = await fetchOnce();
+        } catch (e) {
+          // 401이면 리프레시 후 1회 재시도
+          if (isAxiosError(e) && e.response?.status === 401) {
+            const inflight = (window as any).__authRefreshPromise as Promise<
+              string | null
+            > | null;
+            const token = inflight ? await inflight : await startRefresh();
+            if (!token) throw e; // 실패 → 상위에서 처리(모달 닫기 등)
+
+            data = await getSummaryStatus(targetId, summaryTaskId, {
+              __skipGlobalAuthGuard: true,
+              headers: { Authorization: `Bearer ${token}` },
+            });
+          } else {
+            throw e;
+          }
+        }
+
         if (stopped) return;
 
         const p = Math.max(0, Math.min(100, data?.progress ?? 0));
@@ -570,7 +592,7 @@ export default function FreeFormWritePage() {
         if (data?.status === "COMPLETED" || p >= 100) {
           setSummaryProgress(100);
 
-          // 요약 성공 → postStatus = SUMMARIZED 로 반영
+          // 요약 성공 → postStatus = SUMMARIZED 반영 (기존 로직 유지)
           try {
             const targetIdNum = createdPostId ?? resumePostId!;
             await editPost(targetIdNum, { postStatus: "SUMMARIZED" } as any);
@@ -591,7 +613,7 @@ export default function FreeFormWritePage() {
           }
         }
       } catch (err) {
-        console.error(err);
+        console.error("poll tick error:", err);
       }
     };
 
@@ -782,6 +804,35 @@ export default function FreeFormWritePage() {
       input.addEventListener("change", onPick, { once: true });
       input.click();
     },
+  };
+
+  // (기존 함수들 아래에 추가)
+
+  const buildEditFormFromMeta = async (meta: PostSavePayload) => {
+    const tags = await canonicalizeTags(selectedTags);
+    // 이미 완료된 글이면 수정 후에도 COMPLETED 유지, 아니면 WRITING
+    const nextStatus: "WRITING" | "COMPLETED" = wasCompleted
+      ? "COMPLETED"
+      : "WRITING";
+    return buildForm(nextStatus, meta, tags);
+  };
+
+  // 템플릿 모달에서 '다음에/닫기' 등으로 요약을 시작하지 않을 때만 호출
+  const persistEditsIfEditMode = async () => {
+    if (!isResume || !resumePostId || !previewMeta) return;
+    try {
+      const form = await buildEditFormFromMeta(previewMeta);
+      await editPost(resumePostId, toEditPostRequest(form) as any);
+      setDraftPostId(resumePostId);
+      setCreatedPostId(resumePostId); // 이후 미리보기/네비에 활용
+      setShowSaveAlert(true);
+      setTimeout(() => setShowSaveAlert(false), 1000);
+    } catch (e) {
+      console.error("edit(save without summary) failed:", e);
+      setStatusMessage(
+        "수정 내용을 저장하지 못했어요. 잠시 후 다시 시도해주세요."
+      );
+    }
   };
 
   // ------------ UI ------------
@@ -979,8 +1030,14 @@ export default function FreeFormWritePage() {
             {isTemplateSelectModalOpen && (
               <TemplateSelectModal
                 onConfirm={(type, label) => handleConfirmTemplate(type, label)}
-                onClose={() => setIsTemplateSelectModalOpen(false)}
-                onLater={handleLater}
+                onClose={async () => {
+                  await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
+                  setIsTemplateSelectModalOpen(false);
+                }}
+                onLater={async () => {
+                  await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
+                  await handleLater();
+                }}
                 onPrev={() => {
                   setIsTemplateSelectModalOpen(false);
                   setIsPostSaveModalOpen(true);

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1031,12 +1031,22 @@ export default function FreeFormWritePage() {
               <TemplateSelectModal
                 onConfirm={(type, label) => handleConfirmTemplate(type, label)}
                 onClose={async () => {
-                  await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
-                  setIsTemplateSelectModalOpen(false);
+                  try {
+                    await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
+                  } catch (e) {
+                    console.error("Failed to persist edits on close:", e);
+                  } finally {
+                    setIsTemplateSelectModalOpen(false);
+                  }
                 }}
                 onLater={async () => {
-                  await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
-                  await handleLater();
+                  try {
+                    await persistEditsIfEditMode(); // 요약 안 함 → 수정 저장
+                    await handleLater();
+                  } catch (e) {
+                    console.error("Failed to persist edits or navigate:", e);
+                    setStatusMessage("저장 중 오류가 발생했습니다.");
+                  }
                 }}
                 onPrev={() => {
                   setIsTemplateSelectModalOpen(false);

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -961,21 +961,23 @@ export default function FreeFormWritePage() {
                 <MDEditor
                   className="mt-2"
                   value={block.content}
-                  onChange={(val) =>
-                    handleChangeBlock(block.id, "content", val || "")
+                  onChange={(val?: string) =>
+                    handleChangeBlock(block.id, "content", val ?? "")
                   }
                   preview="edit"
                   textareaProps={{
-                    onPaste: (e) => handlePasteImage(block.id, e),
-                    onDrop: (e) => handleDropImage(block.id, e),
-                    onDragOver: (e) => {
+                    onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) =>
+                      handlePasteImage(block.id, e),
+                    onDrop: (e: React.DragEvent<HTMLTextAreaElement>) =>
+                      handleDropImage(block.id, e),
+                    onDragOver: (e: React.DragEvent<HTMLTextAreaElement>) => {
                       if (e.dataTransfer?.types?.includes("Files")) {
                         e.preventDefault();
                         e.stopPropagation();
                       }
                     },
                   }}
-                  commandsFilter={(cmd) =>
+                  commandsFilter={(cmd: ICommand): ICommand =>
                     cmd.keyCommand === "image" ? imageUploadCmd : cmd
                   }
                 />

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -30,18 +30,6 @@ type ProjectPageResp = {
   size?: number;
 };
 
-const inflight = new Map<string, Promise<ProjectPageResp>>();
-
-function fetchPageOnce(page: number, size: number) {
-  const key = `${page}:${size}`;
-  if (!inflight.has(key)) {
-    const p = getProjectList(page, size).finally(() => inflight.delete(key));
-    inflight.set(key, p);
-  }
-
-  return inflight.get(key)!;
-}
-
 export default function HomePage() {
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -53,6 +41,18 @@ export default function HomePage() {
 
   const navigate = useNavigate();
   const viewerId = useViewerId();
+
+  const inflight = new Map<string, Promise<ProjectPageResp>>();
+
+  function fetchPageOnce(page: number, size: number) {
+    const key = `${page}:${size}`;
+    if (!inflight.has(key)) {
+      const p = getProjectList(page, size).finally(() => inflight.delete(key));
+      inflight.set(key, p);
+    }
+
+    return inflight.get(key)!;
+  }
 
   const goGuide = useCallback(
     (projectId?: number) => {
@@ -323,7 +323,8 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap gap-6">
+            {/* 유연한 컬럼: 화면에 맞춰 자동으로 1~N열, 각 셀 최소 320px */}
+            <div className="grid w-full gap-6 grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
               {projects.map((p) => (
                 <ProjectFolderCard
                   key={p.id}

--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -9,19 +9,11 @@ import { PATH } from "@/constants/paths";
 const SignPageOauth = () => {
   const navigate = useNavigate();
   const location = useLocation() as any;
-
-  // location.state에서 넘어온 값 (카카오 인증 직후)
   const stateUserId = location?.state?.userId as number | undefined;
-  const stateKakaoNickname = location?.state?.nickname as string | undefined;
+  const stateNickname = location?.state?.nickname as string | undefined;
 
-  // 카카오 원본 정보 (읽기 전용)
   const [userId, setUserId] = useState<number | null>(stateUserId ?? null);
-  const [kakaoNickname, setKakaoNickname] = useState<string>(
-    stateKakaoNickname ?? ""
-  );
-
-  // 사용자 입력용
-  const [nickname, setNickname] = useState<string>(""); // 서비스에서 사용할 닉네임
+  const [nickname, setNickname] = useState(stateNickname ?? "");
   const [field, setField] = useState("");
   const [bio, setBio] = useState("");
   const [githubad, setGithubad] = useState("");
@@ -34,25 +26,18 @@ const SignPageOauth = () => {
 
   // 새로고침 폴백
   useEffect(() => {
-    if (userId != null && kakaoNickname) return;
+    if (userId != null && nickname) return;
     try {
       const raw = sessionStorage.getItem("oauth_payload");
       if (raw) {
         const p = JSON.parse(raw) as { userId?: number; nickname?: string };
         if (p?.userId && !userId) setUserId(p.userId);
-        if (p?.nickname && !kakaoNickname) setKakaoNickname(p.nickname);
+        if (p?.nickname && !nickname) setNickname(p.nickname);
       }
     } catch (err) {
       console.debug("oauth_payload parse failed:", err);
     }
-  }, [userId, kakaoNickname]);
-
-  // UX: 사용자 입력 닉네임이 비어있다면, 카카오 닉네임을 기본값으로 채워줌
-  useEffect(() => {
-    if (!nickname && kakaoNickname) {
-      setNickname(kakaoNickname);
-    }
-  }, [kakaoNickname, nickname]);
+  }, [userId, nickname]);
 
   const validateForm = () => {
     let valid = true;
@@ -91,7 +76,6 @@ const SignPageOauth = () => {
     try {
       const payload: OauthRegisterRequest = {
         userId: userId!, // 카카오로 받은 ID
-        kakaoNickname: kakaoNickname.trim(),
         nickname: nickname.trim(),
         field: field.trim(),
         bio: bio.trim(),
@@ -138,48 +122,44 @@ const SignPageOauth = () => {
   };
 
   return (
-    <div className="flex w-screen h-screen overflow-hidden">
-      <img
-        src={onboarding_image}
-        className="w-[961.807px] h-full object-cover shrink-0"
-        alt="signup visual"
-      />
-      <div className="w-[960px] h-full px-[200px] py-[281px] flex flex-col justify-center items-center">
-        <div className="w-[560px] flex flex-col items-center gap-10">
-          <h2 className="text-black text-[48px] font-bold w-full font-pretendard">
+    <div className="min-h-screen flex flex-col md:flex-row">
+      {/* 좌측(또는 상단) 이미지 영역 */}
+      <div className="w-full md:w-1/2">
+        <img
+          src={onboarding_image}
+          alt="signup visual"
+          className="w-full h-40 xs:h-56 sm:h-72 md:h-screen object-cover"
+        />
+      </div>
+
+      {/* 우측(또는 하단) 폼 영역 */}
+      <div
+        className="
+          w-full md:w-1/2
+          flex items-center justify-center
+          px-5 sm:px-10 md:px-12 lg:px-16 xl:px-[200px]
+          py-8 sm:py-12 md:py-16 lg:py-24 xl:py-[281px]
+        "
+      >
+        <div className="w-full max-w-[560px] flex flex-col items-center gap-6 sm:gap-10">
+          <h2 className="w-full font-pretendard font-bold text-black text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-[48px]">
             회원가입
           </h2>
 
           <form
             onSubmit={handleSubmit}
-            className="flex flex-col items-start w-full"
+            className="flex flex-col items-start w-full gap-4"
           >
-            <div className="flex flex-col items-start w-full">
-              {/* 카카오 닉네임 */}
-              <Input
-                label="카카오 닉네임"
-                type="text"
-                value={kakaoNickname}
-                onChange={() => {}}
-                placeholder="카카오에서 전달된 닉네임"
-                error={""}
-                name="kakaoNickname"
-              />
-              <p className="text-xs text-gray-500 -mt-2 mb-3">
-                카카오에서 받은 닉네임이며, 계정 식별을 위해 그대로 저장됩니다.
-              </p>
-
-              {/* 서비스에서 사용할 닉네임 (사용자 입력) */}
+            <div className="flex flex-col items-start w-full gap-2 sm:gap-3">
               <Input
                 label="닉네임"
                 type="text"
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
-                placeholder="서비스에서 사용할 닉네임을 입력해주세요."
+                placeholder="닉네임을 입력해주세요."
                 error={nicknameError}
                 name="nickname"
               />
-
               <Input
                 label="분야"
                 type="text"
@@ -209,13 +189,13 @@ const SignPageOauth = () => {
               />
             </div>
 
-            <div className="flex flex-col items-start gap-4 w-full">
+            <div className="flex flex-col items-start gap-3 sm:gap-4 w-full">
               <button
                 type="submit"
-                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-60"
+                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center"
                 disabled={submitting}
               >
-                <span className="text-white text-[20px] font-semibold font-pretendard">
+                <span className="text-white text-lg sm:text-[20px] font-semibold font-pretendard">
                   {submitting ? "가입 처리 중..." : "회원가입"}
                 </span>
               </button>
@@ -223,7 +203,7 @@ const SignPageOauth = () => {
           </form>
 
           <p
-            className={`text-[13px] min-h-[25px] ${
+            className={`text-sm sm:text-[13px] min-h-[25px] ${
               formError ? "text-red-500" : "text-transparent"
             }`}
             aria-live="polite"
@@ -231,13 +211,15 @@ const SignPageOauth = () => {
             {formError || " "}
           </p>
 
-          <div className="flex flex-row items-end self-end gap-4">
-            <h2 className="text-[18px] text-gray-500 font-pretendard">
+          {/* 하단 링크: 모바일 정렬 보완 */}
+          <div className="flex flex-row items-end self-center md:self-end gap-3 sm:gap-4">
+            <h2 className="text-base sm:text-[18px] text-gray-500 font-pretendard">
               이미 계정이 있으신가요?
             </h2>
             <button
-              className="text-[18px] text-[#9737fd] underline font-pretendard"
+              className="text-base sm:text-[18px] text-[#9737fd] underline font-pretendard"
               onClick={() => navigate("/")}
+              type="button"
             >
               로그인
             </button>

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -157,6 +157,89 @@ export default function CombinedDetailPage() {
     return map[k] ?? 0;
   };
 
+  type DetailContentItem = {
+    id?: number;
+    subTitle?: string | null;
+    body?: string | null;
+    sequence?: number;
+  };
+
+  function buildFreeformPrefill(detail: any) {
+    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+      ? detail.contents
+      : [];
+
+    const blocks = contents
+      .slice()
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+      .map((c, i) => ({
+        id: c.id ?? i,
+        title: c.subTitle ?? "",
+        content: c.body ?? "",
+        isSaved: false,
+      }));
+
+    return {
+      editorType: "FREEFORM" as const,
+      title: detail?.title ?? "",
+      tags: detail?.postTags ?? [],
+      errorType: detail?.errorTag ?? null,
+      blocks,
+      savePrefill: {
+        importance: parseStar(detail?.starRating),
+        description: detail?.introduction ?? "",
+        visibility: detail?.isVisible ? "public" : "private",
+        projectId: detail?.projectId ?? null,
+        projectName: undefined,
+        thumbnail: detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null,
+      },
+      projectId: detail?.projectId ?? undefined,
+    };
+  }
+
+  function buildTemplatePrefill(detail: any) {
+    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+      ? detail.contents
+      : [];
+
+    const blocks = contents
+      .slice()
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+      .map((c, i) => ({
+        id: c.id ?? i,
+        content: c.body ?? "",
+        checklist: [],
+        checklistItems: [],
+        checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
+        question: c.subTitle ?? `질문 ${i + 1}`,
+        isSaved: false,
+      }));
+
+    return {
+      editorType: "TEMPLATE" as const,
+      title: detail?.title ?? "",
+      tags: detail?.postTags ?? [],
+      errorType: detail?.errorTag ?? null,
+      blocks,
+      savePrefill: {
+        importance: parseStar(detail?.starRating),
+        description: detail?.introduction ?? "",
+        visibility: detail?.isVisible ? "public" : "private",
+        projectId: detail?.projectId ?? null,
+        projectName: undefined,
+        thumbnail: detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null,
+      },
+      projectId: detail?.projectId ?? undefined,
+      // TempWritePage가 그대로 받아 쓰는 키
+      checklistError: Array.isArray(detail?.checklistError)
+        ? detail.checklistError
+        : [],
+      checklistReason: Array.isArray(detail?.checklistReason)
+        ? detail.checklistReason
+        : [],
+    };
+  }
+
   const SUMMARY_TYPE_LABELS: Record<string, string> = {
     RESUME: "자기소개서",
     INTERVIEW: "면접 대비",
@@ -401,19 +484,42 @@ export default function CombinedDetailPage() {
     }
   };
 
+  // 원본 수정(프리필) 네비게이션
+  const navigatingRef = useRef(false);
+
   const goEditOriginal = useCallback(async () => {
-    if (!postId) return;
+    if (navigatingRef.current) return;
+    navigatingRef.current = true;
+    setShowMenu(false);
+
     try {
-      const detail = await getPostDetail(Number(postId));
+      const pid = Number(postId);
+      if (!Number.isFinite(pid)) throw new Error("잘못된 포스트 ID");
+
+      const detail = await getPostDetail(pid);
       const tt = String((detail as any)?.templateType ?? "").toUpperCase();
       const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
+
+      const prefill = isFreeform
+        ? buildFreeformPrefill(detail)
+        : buildTemplatePrefill(detail);
+
       const editorPath = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
+
       navigate(editorPath, {
         replace: false,
-        state: { postId: Number(postId), mode: "edit" },
+        state: {
+          ...prefill,
+          postId: pid,
+          mode: "edit",
+          from: "combined-detail",
+        },
       });
-    } catch {
+    } catch (e) {
+      console.error(e);
       alert("수정 화면으로 이동할 수 없어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      navigatingRef.current = false;
     }
   }, [postId, navigate]);
 

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -19,7 +19,7 @@ import { useViewerId } from "@/store/auth";
 import { decideCombined } from "@/utils/combinedRoute";
 
 type VisibilityOption = "전체" | "공개" | "비공개";
-type StatusType = "complete" | "created";
+type StatusType = "inProgress" | "complete" | "created";
 type SortUI = "latest" | "important";
 
 export default function ProjectDetailPage() {
@@ -82,7 +82,8 @@ export default function ProjectDetailPage() {
   }, [projectId, isInvalid, hasProjectName]);
 
   const visibilityOptions: VisibilityOption[] = ["전체", "공개", "비공개"];
-  const [selectedStatus, setSelectedStatus] = useState<StatusType>("complete");
+  const [selectedStatus, setSelectedStatus] =
+    useState<StatusType>("inProgress");
   const [selectedSort, setSelectedSort] = useState<SortUI>("latest");
   const [selectedVisibility, setSelectedVisibility] =
     useState<VisibilityOption>("전체");
@@ -90,7 +91,11 @@ export default function ProjectDetailPage() {
     useState<ProjectTroubleSummaryType | null>(null);
 
   const toApiStatus = (s: StatusType) =>
-    s === "complete" ? "COMPLETED" : ("SUMMARIZED" as const);
+    s === "complete"
+      ? "COMPLETED"
+      : s === "created"
+      ? "SUMMARIZED"
+      : ("WRITING" as const);
   const toApiSort = (s: SortUI) =>
     s === "latest" ? "LATEST" : ("LIKES" as const);
   const toApiVisibility = (v: VisibilityOption) =>
@@ -174,6 +179,12 @@ export default function ProjectDetailPage() {
             {/* 상태 필터 */}
             <div className="flex items-center gap-3 sm:gap-6 self-stretch">
               <StatusFilterButton
+                label="작성 중"
+                statusKey="inProgress"
+                isSelected={selectedStatus === "inProgress"}
+                onClick={() => setSelectedStatus("inProgress")}
+              />
+              <StatusFilterButton
                 label="작성 완료"
                 statusKey="complete"
                 isSelected={selectedStatus === "complete"}
@@ -239,6 +250,21 @@ export default function ProjectDetailPage() {
                       const qs = new URLSearchParams({ from: "project" });
                       if (ownerId != null) qs.set("ownerId", String(ownerId));
 
+                      // '요약 완료'면 합본이 아니라 요약본 상세로 이동
+                      // - 현재 탭이 'created'이거나, 카드 자체 상태가 created인 경우
+                      // - summaryId 가 있을 때만 동작
+                      if (
+                        (selectedStatus === "created" ||
+                          card.status === "created") &&
+                        card.summaryId
+                      ) {
+                        navigate(PATH.POST_SUMMARY(card.summaryId), {
+                          state: { from: "project", ownerId },
+                        });
+                        return;
+                      }
+
+                      // 요약 완료가 아닌 경우에는 합본 분기/커뮤 상세/힌트 전달
                       const { goCombined, summaryId } = decideCombined(
                         card,
                         viewerId
@@ -247,11 +273,28 @@ export default function ProjectDetailPage() {
                         navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
                           state: { from: "project", ownerId },
                         });
-                      } else {
-                        navigate(
-                          `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`
-                        );
+                        return;
                       }
+
+                      // 홈 화면과 동일한 힌트 전달 (비공개/작성중 분기용)
+                      const statusFromList = card.status; // 'inProgress' | 'complete' | 'created'
+                      const isVisibleFromList = card.visibility === "public"; // boolean
+                      const summaryIdFromList = card.summaryId ?? undefined; // number | undefined
+                      const isMineFromList = card.isMine === true; // boolean
+
+                      navigate(
+                        `${PATH.COMMUNITY_POST(card.id)}?${qs.toString()}`,
+                        {
+                          state: {
+                            from: "project",
+                            ownerId,
+                            statusFromList,
+                            isVisibleFromList,
+                            summaryIdFromList,
+                            isMineFromList,
+                          },
+                        }
+                      );
                     }}
                   />
                 ))}

--- a/src/pages/TempWrite/PostLoadingModal.tsx
+++ b/src/pages/TempWrite/PostLoadingModal.tsx
@@ -11,7 +11,9 @@ export type SummaryStatus =
   | "PREPROCESSING"
   | "ANALYZING"
   | "POSTPROCESSING"
-  | "COMPLETED";
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED";
 
 const STATUS_UI: Record<
   SummaryStatus,
@@ -53,6 +55,18 @@ const STATUS_UI: Record<
     color: "#16A34A",
     trail: "#E8F5EE",
   },
+  FAILED: {
+    label: "요약에 실패했어요",
+    desc: "잠시 후 다시 시도하거나, 네트워크 상태를 확인해주세요.",
+    color: "#EF4444",
+    trail: "#FEE2E2",
+  },
+  CANCELLED: {
+    label: "요약을 취소했어요",
+    desc: "요약본 생성이 취소되었어요",
+    color: "#EF4444",
+    trail: "#FEE2E2",
+  },
 };
 
 export const statusToPercent = (s: SummaryStatus) =>
@@ -63,6 +77,8 @@ export const statusToPercent = (s: SummaryStatus) =>
     ANALYZING: 50,
     POSTPROCESSING: 80,
     COMPLETED: 100,
+    FAILED: 0,
+    CANCELLED: 0,
   }[s]);
 
 function fallbackByProgress(p: number) {
@@ -148,6 +164,26 @@ export default function PostLoadingModal({
               : ui.desc}
           </span>
         </div>
+
+        {/* 실패 시 경고 안내 */}
+        {status === "FAILED" && (
+          <div
+            role="alert"
+            className="w-full max-w-[460px] mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-left"
+          >
+            <p className="text-body-16-regular text-red-700">
+              {serverMessage?.trim() ||
+                "요약 생성에 실패했습니다. 잠시 후 다시 시도해 주세요."}
+            </p>
+            {/* 필요하면 재시도 버튼을 노출하세요.
+          <div className="mt-2">
+            <button onClick={onClose} className="px-3 py-1.5 rounded-md bg-red-600 text-white">
+              닫기
+            </button>
+          </div>
+          */}
+          </div>
+        )}
       </div>
     </BaseModal>
   );

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -264,7 +264,7 @@ export default function PostSaveModal({
 
           <div className="flex flex-col w-full lg:flex-1 xl:flex-[0.6] gap-4 md:gap-6">
             <span
-              className={`text-lg sm:text-xl font-semibold transition ${
+              className={`whitespace-nowrap text-lg sm:text-xl font-semibold transition ${
                 hasTriedSubmit && importance === 0
                   ? "text-purple-500"
                   : "text-black"

--- a/src/pages/TempWrite/PostSummaryDetail.tsx
+++ b/src/pages/TempWrite/PostSummaryDetail.tsx
@@ -10,6 +10,17 @@ type GuideContent = string | { type: "image"; src: string; alt?: string };
 
 const HEADER_OFFSET = 500;
 
+const inflightSummary = new Map<number, Promise<GetSummaryResponse>>();
+function fetchSummaryOnce(id: number) {
+  if (!inflightSummary.has(id)) {
+    inflightSummary.set(
+      id,
+      getPostSummary(id).finally(() => inflightSummary.delete(id))
+    );
+  }
+  return inflightSummary.get(id)!;
+}
+
 export default function PostSummaryDetail() {
   const { summaryId } = useParams<{ summaryId: string }>();
 
@@ -21,9 +32,13 @@ export default function PostSummaryDetail() {
     let cancelled = false;
     (async () => {
       try {
-        if (!summaryId) throw new Error("잘못된 요약 ID");
+        const id = Number(summaryId);
+        if (!id || Number.isNaN(id)) throw new Error("잘못된 요약 ID");
         setLoading(true);
-        const res = await getPostSummary(Number(summaryId));
+        setErr(null);
+
+        // 동일 ID에 대해 요청 1회로 합치기
+        const res = await fetchSummaryOnce(id);
         if (!cancelled) setData(res);
       } catch (e: any) {
         if (!cancelled) setErr(e?.message ?? "요약본을 불러오지 못했어요.");

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -32,10 +32,12 @@ import {
   type ICommand,
   type TextState,
 } from "@uiw/react-md-editor";
+import { isAxiosError } from "axios";
+import { startRefresh } from "@/api/axios";
 
 // ---- 숫자 인덱스 변환 유틸 ----
 const QI = { ERROR: 0, REASON: 1 } as const;
-const OFFSET: 0 | 1 = 0; // 서버가 1-based면 1로 변경
+const OFFSET = 1;
 
 const Q_ERROR = questionData[QI.ERROR]?.question;
 const Q_REASON = questionData[QI.REASON]?.question;
@@ -236,7 +238,9 @@ const TempWritePage = () => {
     | "PREPROCESSING"
     | "ANALYZING"
     | "POSTPROCESSING"
-    | "COMPLETED";
+    | "COMPLETED"
+    | "FAILED"
+    | "CANCELLED";
   const [summaryStatus, setSummaryStatus] = useState<SummaryStatus | null>(
     null
   );
@@ -358,6 +362,38 @@ const TempWritePage = () => {
     return out;
   };
 
+  // 현재 화면 상태 + PostSaveModal에서 받은 meta로 수정 페이로드 만들기
+  const buildEditFormFromMeta = async (meta: PostSavePayload) => {
+    const canonicalTags = await canonicalizeTags(selectedTags);
+    const { checklistError, checklistReason } =
+      encodeChecklistToNumbers(blocks);
+
+    return {
+      title,
+      introduction: meta.description ?? "",
+      postTags: canonicalTags,
+      isVisible: (meta.visibility ?? "public") === "public",
+      isSummaryCreated: false,
+      postStatus: "COMPLETED", // 저장(완료) 상태로 반영
+      starRating: Number(meta.importance ?? 0),
+      templateType: "GUIDELINE",
+      projectId: Number(meta.projectId),
+      thumbnailImageUrl: meta.thumbnail ?? undefined,
+      errorTag: selectedErrorType ?? "",
+      contents: toContentDtoList(blocks),
+      checklistError,
+      checklistReason,
+    };
+  };
+
+  // 수정 모드에서만 호출: 템플릿 선택 모달에서 요약을 시작하지 않는 경우에 저장
+  const persistEditsIfEditMode = async () => {
+    if (!isResume || !resumePostId || !previewMeta) return;
+    const form = await buildEditFormFromMeta(previewMeta);
+    await editPost(resumePostId, toEditPostRequest(form) as any);
+    setDraftPostId(resumePostId);
+  };
+
   // ---------- upsert ----------
   const upsertPost = async (maybeId: number | null, form: any) => {
     if (maybeId) {
@@ -411,31 +447,38 @@ const TempWritePage = () => {
     }
 
     try {
-      const canonicalTags = await canonicalizeTags(selectedTags);
-      const { checklistError, checklistReason } =
-        encodeChecklistToNumbers(blocks);
+      if (isResume) {
+        // --- 수정 모드 ---
+        // 여기서는 수정 API 호출하지 않음! (템플릿 모달에서 분기)
+        setIsTemplateSelectModalOpen(true);
+      } else {
+        // --- 생성 모드 (기존 동작 유지) ---
+        const canonicalTags = await canonicalizeTags(selectedTags);
+        const { checklistError, checklistReason } =
+          encodeChecklistToNumbers(blocks);
 
-      const form = {
-        title,
-        introduction: payload.description ?? "",
-        postTags: canonicalTags,
-        isVisible: (payload.visibility ?? "public") === "public",
-        isSummaryCreated: false,
-        postStatus: "COMPLETED",
-        starRating: Number(payload.importance ?? 0),
-        templateType: "GUIDELINE",
-        projectId: Number(payload.projectId),
-        thumbnailImageUrl: payload.thumbnail ?? undefined,
-        errorTag: selectedErrorType ?? "",
-        contents: toContentDtoList(blocks),
-        checklistError,
-        checklistReason,
-      };
+        const form = {
+          title,
+          introduction: payload.description ?? "",
+          postTags: canonicalTags,
+          isVisible: (payload.visibility ?? "public") === "public",
+          isSummaryCreated: false,
+          postStatus: "COMPLETED",
+          starRating: Number(payload.importance ?? 0),
+          templateType: "GUIDELINE",
+          projectId: Number(payload.projectId),
+          thumbnailImageUrl: payload.thumbnail ?? undefined,
+          errorTag: selectedErrorType ?? "",
+          contents: toContentDtoList(blocks),
+          checklistError,
+          checklistReason,
+        };
 
-      const id = await upsertPost(currentPostId, form);
-      setDraftPostId(id);
-      setCreatedPostId(id);
-      setIsTemplateSelectModalOpen(true);
+        const id = await upsertPost(currentPostId, form);
+        setDraftPostId(id);
+        setCreatedPostId(id);
+        setIsTemplateSelectModalOpen(true);
+      }
     } catch (e) {
       console.error(e);
       setStatusMessage("문서 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
@@ -509,9 +552,49 @@ const TempWritePage = () => {
     let timer: number | null = null;
 
     const tick = async () => {
+      const awaitRefreshIfAny = async () => {
+        const p = (window as any).__authRefreshPromise as Promise<
+          string | null
+        > | null;
+        if (p) {
+          try {
+            await p;
+          } catch {
+            /* ignore */
+          }
+        }
+      };
+
       try {
         const targetId = (createdPostId ?? resumePostId) as number;
-        const data: any = await getSummaryStatus(targetId, summaryTaskId);
+
+        await awaitRefreshIfAny();
+
+        const fetchOnce = () =>
+          getSummaryStatus(targetId, summaryTaskId, {
+            __skipGlobalAuthGuard: true,
+          });
+
+        let data: any;
+        try {
+          data = await fetchOnce();
+        } catch (e) {
+          if (isAxiosError(e) && e.response?.status === 401) {
+            const inflight = (window as any).__authRefreshPromise as Promise<
+              string | null
+            > | null;
+            const token = inflight ? await inflight : await startRefresh();
+            if (!token) throw e;
+
+            data = await getSummaryStatus(targetId, summaryTaskId, {
+              __skipGlobalAuthGuard: true,
+              headers: { Authorization: `Bearer ${token}` },
+            });
+          } else {
+            throw e;
+          }
+        }
+
         const p = Math.max(0, Math.min(100, data?.progress ?? 0));
         if (stopped) return;
 
@@ -543,7 +626,7 @@ const TempWritePage = () => {
           }
         }
       } catch (err) {
-        console.error(err);
+        console.error("poll tick error:", err);
       }
     };
 
@@ -982,9 +1065,15 @@ const TempWritePage = () => {
 
           {isTemplateSelectModalOpen && (
             <TemplateSelectModal
-              onConfirm={(type, label) => handleConfirmTemplate(type, label)}
-              onClose={() => setIsTemplateSelectModalOpen(false)}
-              onLater={handleLater}
+              onConfirm={(type, label) => handleConfirmTemplate(type, label)} // 요약 시작: 수정 API 호출 X
+              onClose={async () => {
+                await persistEditsIfEditMode(); // 요약 안 함 → 수정 반영
+                setIsTemplateSelectModalOpen(false);
+              }}
+              onLater={async () => {
+                await persistEditsIfEditMode(); // 요약 안 함 → 수정 반영
+                await handleLater();
+              }}
               onPrev={() => {
                 setIsTemplateSelectModalOpen(false);
                 setIsPostSaveModalOpen(true);

--- a/src/types/trouble.model.ts
+++ b/src/types/trouble.model.ts
@@ -30,7 +30,7 @@ export interface TroubleListItem {
 export type GetTroubleListResponse = PaginatedResponse<TroubleListItem>;
 
 // 프로젝트 전용 쿼리 타입
-export type ProjectTroubleStatus = "COMPLETED" | "SUMMARIZED";
+export type ProjectTroubleStatus = "WRITING" | "COMPLETED" | "SUMMARIZED";
 export type ProjectTroubleSort = "LATEST" | "IMPORTANT" | "LIKES";
 export type ProjectTroubleVisibility = "ALL" | "PUBLIC" | "PRIVATE";
 export type ProjectTroubleSummaryType =


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

### 수정한 에러 목록

- Save 모달창 중요도 텍스트
- 가이드템플릿 저장모달창 저장버튼 안눌림 -> 저장 버튼 클릭 시 요약 템플릿 선택 모달창으로 이동하지 않음
- 체크리스트 음수값 잘못 넘어감
- 임시저장 시 화면 나감
- 요약 -> 완성 페이지로 이동 버튼 안눌림
- 작성 중 트러블로그카드에 케밥 메뉴 추가
- 글 작성 후 원본 수정 클릭 시 트러블슈팅 작성 페이지 (제일 처음)으로 돌아감
이거 정확히는 커뮤니티 -> 내 게시글 -> 포스트 수정 시 정상동작, 홈 -> 내 게시글 -> 원본 수정 시 동작 X 입니다
- 요약 완료 글 수정 시 기존 글 내용이 로드되지 않음
- 카카오 로그인 시 회원가입 페이지에서 UI 깨짐 및 닉네임 수정 불가
- 검색 결과 없을 때 500 에러 화면에 보이면 안됨
- 폴더 수정하면 썸네일 삭제됨 
- 마이페이지에서 작성 완료 트러블슈팅 보려 할 때 ‘작성 완료된 트러블슈팅이 없어요. (최신순)’ 뜸
- 비공개글 작성 후 상세 조회 시 troubles/postid가 아닌 community/postid가 호출됨
- 중간에 save할 경우 임시저장 글 2개 생김
- 커뮤니티 추천순 빼기
- 프로젝트 상세 페이지에 작성 중 구분도 추가
- 프로젝트 상세 요약 완료 -> 요약본만 보여야 함 (상세 조회 시 합본 X)
- 마이페이지의 작성+요약완료 -> 합본
- Recents -> 합본
- 프로젝트 상세 페이지에서는 합본 버전별로 조회할 수 있어야 함
- 트러블슈팅 문서 수정 시에도 POST로 보내지는 문제
- 문서 수정 후 AI 요약본 생성 과정에서는 문서 수정 API를 호출할 필요 없음 (현재 문서 수정 -> 요약본 생성 시 PUT 호출)

## 📄 Description

- 프로젝트 상세 페이지에 작성 중 구분 추가의 경우 UI는 수정했고, 목록 받아오는 건 서버 수정 후 다시 연결해야 합니다.

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

### 아직 반영하지 못한 수정사항들

- 작성화면에서 md파일 브리뷰 선택 후 다시 입력 시 텍스트 편집 불가능
- 텍스트 복사 후 입력 커서가 잘못된 곳에 위치함 - 3번째줄부터 커서 위치가 잘못되어있음. 그냥 적을 때에도.
- 마크다운 텍스트 preview 제대로 표시 안됨

## 👀 References

로컬 깃 저장소가 망가져서 새로 클론하는 바람에 커밋들이 하나로 합쳐졌음...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증 갱신 교차 탭 신호 및 자동 복귀로 재로그인 중 끊김 감소
  - 요약 진행 상태에 실패/취소 상태 추가 및 오류 알림 표시
  - 프로젝트 상세에 “작성 중” 필터 추가(기본값), 상태 점색상 반영
  - 카드 헤더 메뉴 항상 노출
  - OAuth 가입 화면 전면 개편 및 카카오 닉네임 제거
  - 커뮤니티 정렬에서 “전체” 제거, 기본 “최신순”
  - 에디트 모드 편집 내용 자동 보존 및 에디터 진입 프리필
- 개선
  - 토큰 갱신 인지한 재시도/폴링 안정화, 302→로그인 리다이렉트 처리
  - 홈/요약 상세 데이터 중복 요청 방지
  - 프로젝트 폴더/홈 그리드 반응형 레이아웃 개선
  - 임시 저장 모달 라벨 줄바꿈 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->