### PR TITLE
FIX: 글 작성, 수정, 요약 관련 오류 수정

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -130,14 +130,54 @@ export const startRefresh = async (): Promise<string | null> => {
       __skipGlobalAuthGuard: true,
       __skipGlobal404: true,
     });
-    const newToken: string | undefined = r.data?.data?.accessToken;
+    // 다양한 응답 포맷을 지원
+    const pick = (d: any): string | null =>
+      d?.accessToken ??
+      d?.data?.accessToken ??
+      d?.content?.accessToken ??
+      d?.token ??
+      d?.data?.token ??
+      null;
+    const newToken = pick(r.data);
+
+    if (import.meta.env.DEV) {
+      // 민감정보 노출 방지(앞 8자만)
+      const mask = (t?: string | null) =>
+        t ? `${t.slice(0, 8)}…(${t.length})` : null;
+      console.groupCollapsed("[DEBUG] /auth/refresh response");
+      console.log("status:", r.status);
+      console.log("headers:", r.headers);
+      console.log("raw data:", r.data);
+      console.log("extracted accessToken:", mask(newToken));
+      console.groupEnd();
+    }
+
     if (!newToken) {
-      console.error("[Auth] Refresh response missing accessToken:", r.data);
+      console.error(
+        "[Auth] Refresh response missing accessToken (unrecognized shape).",
+        r.data
+      );
       return null;
     }
-    localStorage.setItem("accessToken", newToken);
 
-    setRecentRefreshOk(); // NEW: 갱신 성공 신호
+    // 저장 전 기존 값과 비교 로그(DEV)
+    if (import.meta.env.DEV) {
+      const before = localStorage.getItem("accessToken");
+      console.debug(
+        "[DEBUG] localStorage.accessToken (before):",
+        before ? `${before.slice(0, 8)}…(${before.length})` : null
+      );
+    }
+    localStorage.setItem("accessToken", newToken);
+    if (import.meta.env.DEV) {
+      const after = localStorage.getItem("accessToken");
+      console.debug(
+        "[DEBUG] localStorage.accessToken (after):",
+        after ? `${after.slice(0, 8)}…(${after.length})` : null
+      );
+    }
+
+    setRecentRefreshOk(); // 갱신 성공 신호
     return newToken;
   } catch {
     return null;
@@ -323,4 +363,18 @@ if (import.meta.env.DEV) {
   (window as any).__api = api;
   (window as any).__apiBase = API_BASE_URL;
   (window as any).__apiOrigin = API_ORIGIN;
+  (window as any).__forceRefresh = async () => {
+    console.groupCollapsed("[DEBUG] __forceRefresh()");
+    const t = await startRefresh();
+    console.log(
+      "startRefresh() returned:",
+      t ? `${t.slice(0, 8)}…(${t.length})` : t
+    );
+    console.log(
+      "localStorage.accessToken now:",
+      localStorage.getItem("accessToken")
+    );
+    console.groupEnd();
+    return t;
+  };
 }

--- a/src/api/post.api.ts
+++ b/src/api/post.api.ts
@@ -50,7 +50,7 @@ export const createPost = (body: CreatePostRequest) =>
 export const editPost = (postId: number, body: EditPostRequest) =>
   getAPIResponseData<EditPostResponse>({
     url: `/troubles/${postId}`,
-    method: "PUT",
+    method: "PATCH",
     data: body,
   });
 

--- a/src/components/Card/CardTitleSection.tsx
+++ b/src/components/Card/CardTitleSection.tsx
@@ -15,7 +15,7 @@ export default function CardTitleSection({
   visibility,
   createdAt,
   isMine,
-  status,
+  // status,
   summaryType,
 }: CardTitleSectionProps) {
   return (
@@ -29,7 +29,7 @@ export default function CardTitleSection({
 
         {/* 바로 옆(작은 여백) */}
         {isMine &&
-          (status === "created" && summaryType ? (
+          (summaryType ? (
             <span className="ml-1 sm:ml-2 text-body-16-regular text-gray3 shrink-0">
               {summaryType}
             </span>

--- a/src/components/MyPage/FollowingBtn.tsx
+++ b/src/components/MyPage/FollowingBtn.tsx
@@ -19,40 +19,40 @@ const FollowingBtn = ({
   onFollowClick,
 }: FollowingProps) => {
   const nav = useNavigate();
+  const goProfile = () => nav(`/user/mypage/${userId}`);
+
   return (
-    <div className="flex justify-between w-[948px] items-center self-stretch py-[25px] border-b border-gray1">
-      <div
-        className="flex items-center gap-3"
-        onClick={() => nav(`/user/mypage/${userId}`)}
+    <div className="flex justify-between items-center self-stretch w-full py-4 sm:py-6 border-b border-gray1">
+      {/* 왼쪽: 프로필(클릭 시 이동) */}
+      <button
+        type="button"
+        onClick={goProfile}
+        className="flex items-center gap-3 sm:gap-4 min-w-0 focus:outline-none"
       >
         <img
           src={profileUrl || userIcon}
           alt="user"
-          className="w-[52px] h-[52px]"
+          className="w-10 h-10 sm:w-12 sm:h-12 md:w-[52px] md:h-[52px] rounded-full object-cover"
         />
-
-        <div className="flex w-[143px] flex-col items-start gap-0.5">
-          <p className="font-sans text-2xl font-bold leading-normal">
+        <div className="flex flex-col items-start gap-0.5 min-w-0">
+          <p className="font-sans font-bold leading-normal text-xl sm:text-2xl truncate max-w-[44vw] sm:max-w-[360px]">
             {nickname}
           </p>
-          <p className="text-body-16-regular">{email}</p>
+          <p className="text-body-14-regular sm:text-body-16-regular text-gray-600 truncate max-w-[44vw] sm:max-w-[360px]">
+            {email}
+          </p>
         </div>
-      </div>
-      {isFollowed ? (
-        <button
-          onClick={onFollowClick}
-          className="flex w-[68px] h-10 px-[13px] py-2.5 justify-center items-center rounded-[10px] bg-subColor1 text-white"
-        >
-          팔로잉
-        </button>
-      ) : (
-        <button
-          onClick={onFollowClick}
-          className="flex w-[68px] h-10 px-[13px] py-2.5 justify-center items-center rounded-[10px] bg-primary text-white"
-        >
-          팔로우
-        </button>
-      )}
+      </button>
+
+      {/* 오른쪽: 팔로우 버튼 */}
+      <button
+        onClick={onFollowClick}
+        className={`h-9 sm:h-10 px-3 sm:px-4 rounded-[10px] text-white text-sm sm:text-base ${
+          isFollowed ? "bg-subColor1" : "bg-primary"
+        }`}
+      >
+        {isFollowed ? "팔로잉" : "팔로우"}
+      </button>
     </div>
   );
 };

--- a/src/components/MyPage/MyFollowing.tsx
+++ b/src/components/MyPage/MyFollowing.tsx
@@ -7,46 +7,50 @@ import {
   postFollow,
   postUnfollow,
 } from "@/api/user.api";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
 const MyFollowing = () => {
   const [followList, setFollowList] = useState<FollowingData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
   const { id } = useParams();
   const userId = Number(id);
+  const { pathname } = useLocation();
 
   useEffect(() => {
-    const path = location.pathname.split("/").pop();
+    const path = pathname.split("/").pop();
 
     const fetchData = async () => {
       try {
-        let data: FollowingData[] = [];
+        setLoading(true);
+        setErr(null);
 
-        if (path === "following") {
-          data = await getFollowings(userId);
-        } else if (path === "follower") {
-          data = await getFollowers(userId);
-        }
+        let data: FollowingData[] = [];
+        if (path === "following") data = await getFollowings(userId);
+        else if (path === "follower") data = await getFollowers(userId);
 
         setFollowList(data);
       } catch (e) {
         console.error("목록 가져오기 실패", e);
+        setErr("목록을 불러오지 못했어요.");
+      } finally {
+        setLoading(false);
       }
     };
 
-    fetchData();
-  }, [userId, location.pathname]);
+    if (Number.isFinite(userId)) {
+      fetchData();
+    }
+  }, [userId, pathname]);
 
   const handleFollowClick = async (id: number) => {
     try {
       const target = followList.find((user) => user.userId === id);
-
       if (!target) return;
 
-      if (target.isFollowed) {
-        await postUnfollow(id);
-      } else {
-        await postFollow(id);
-      }
+      if (target.isFollowed) await postUnfollow(id);
+      else await postFollow(id);
 
       setFollowList((prev) =>
         prev.map((user) =>
@@ -58,19 +62,53 @@ const MyFollowing = () => {
     }
   };
 
+  const pathTail = pathname.split("/").pop();
+  const emptyMessage =
+    pathTail === "following"
+      ? "아직 팔로잉한 사용자가 없어요."
+      : "아직 팔로워가 없어요.";
+
+  const showEmpty = !loading && !err && followList.length === 0;
+
   return (
-    <div className="flex flex-col gap-4 w-[948px]">
-      {followList.map((user) => (
-        <FollowingBtn
-          key={user.userId}
-          userId={user.userId}
-          nickname={user.nickname}
-          email={user.email}
-          isFollowed={user.isFollowed}
-          profileUrl={user.profileUrl}
-          onFollowClick={() => handleFollowClick(user.userId)}
-        />
-      ))}
+    <div className="w-full max-w-[948px] mx-auto px-4 sm:px-0 flex flex-col gap-4 sm:gap-6">
+      {/* 에러 메시지 */}
+      {err && (
+        <div className="text-red-600 text-body-14-regular sm:text-body-16-regular">
+          {err}
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {showEmpty && (
+        <div className="w-full flex h-[120px] sm:h-[132px] justify-center items-center rounded-[8px] bg-white">
+          <span className="text-body-16-regular sm:text-body-20-regular">
+            {emptyMessage}
+          </span>
+        </div>
+      )}
+
+      {/* 리스트 */}
+      {!showEmpty &&
+        followList.map((user) => (
+          <FollowingBtn
+            key={user.userId}
+            userId={user.userId}
+            nickname={user.nickname}
+            email={user.email}
+            isFollowed={user.isFollowed}
+            profileUrl={user.profileUrl}
+            onFollowClick={() => handleFollowClick(user.userId)}
+          />
+        ))}
+
+      {/* 로딩 스켈레톤 */}
+      {loading && (
+        <>
+          <div className="w-full h-[64px] sm:h-[84px] bg-gray-100 rounded-[8px]" />
+          <div className="w-full h-[64px] sm:h-[84px] bg-gray-100 rounded-[8px]" />
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/MyPage/MyPageSidebar.tsx
+++ b/src/components/MyPage/MyPageSidebar.tsx
@@ -180,7 +180,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   };
 
   return (
-    <div className="flex w-full md:w-[296px] flex-col items-start gap-8 sm:gap-12 xl:gap-[140px] md:sticky md:top-24">
+    <div className="flex w-full md:w-[296px] flex-col items-start gap-8 sm:gap-12 xl:gap-[140px] md:sticky md:top-24 mb-12 sm:mb-16 lg:mb-24">
       {/* 상단 프로필 영역 */}
       <div className="flex flex-col items-center gap-3 self-stretch">
         <img

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -159,8 +159,7 @@ export default function ProjectFolderCard({
   );
 
   const ContainerClasses =
-    "flex flex-none p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card " +
-    "w-[300px] sm:w-[332px] md:w-[360px] lg:w-[384px]";
+    "flex flex-none p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card w-[300px] sm:w-[332px] md:w-[360px] lg:w-[384px]";
 
   return (
     <>

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -116,7 +116,7 @@ export default function ProjectFolderCard({
 
       {/* 텍스트 영역: 고정 폭 제거 + 줄바꿈/잘림 안전 */}
       <div className="flex-1 min-w-0 flex flex-col items-start gap-3 sm:gap-[18px]">
-        <div className="flex flex-col items-start gap-1 self-stretch min-w-0">
+        <div className="flex flex-col items-start gap-1 self-stretch min-w-0 ">
           <span className="text-head-20-semibold block truncate" title={name}>
             {name}
           </span>

--- a/src/components/Project/ProjectFolderCard.tsx
+++ b/src/components/Project/ProjectFolderCard.tsx
@@ -159,7 +159,8 @@ export default function ProjectFolderCard({
   );
 
   const ContainerClasses =
-    "flex w-full max-w-[384px] p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card";
+    "flex flex-none p-[16px] flex-col items-start gap-[10px] rounded-[8px] bg-white shadow-card " +
+    "w-[300px] sm:w-[332px] md:w-[360px] lg:w-[384px]";
 
   return (
     <>

--- a/src/mappers/troubleCard.mapper.ts
+++ b/src/mappers/troubleCard.mapper.ts
@@ -10,8 +10,46 @@ import {
 
 export type TroublogCardVM = TroublogCardProps & { createdAtIso: string };
 
+type AnySummary = {
+  summaryId?: number;
+  summaryType?: string; // "RESUME" | "INTERVIEW" | "BLOG" | "ISSUE_MANAGEMENT"
+  summaryCreatedAt?: string;
+};
+
+function pickDisplaySummaryType(t: TroubleListItem): string | undefined {
+  // 루트에 값이 오면 그걸 우선 사용
+  if (t.summaryType) return t.summaryType as string;
+
+  const list: AnySummary[] = Array.isArray(t.summaries)
+    ? (t.summaries as AnySummary[])
+    : [];
+  if (list.length === 0) return undefined;
+
+  // postSummaryId 우선
+  let chosen: AnySummary | undefined =
+    t.postSummaryId != null
+      ? list.find((s) => s.summaryId === t.postSummaryId)
+      : undefined;
+
+  // 없으면 최신 summaryCreatedAt
+  if (!chosen) {
+    chosen = [...list].sort(
+      (a, b) =>
+        new Date(b.summaryCreatedAt ?? 0).getTime() -
+        new Date(a.summaryCreatedAt ?? 0).getTime()
+    )[0];
+  }
+
+  return chosen?.summaryType;
+}
+
 export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
   const iso = t.date ?? "";
+
+  // summaries에서 대표 요약 enum을 뽑아 라벨 매핑
+  const enumType = pickDisplaySummaryType(t);
+  const label = enumType ? mapSummaryType(enumType) : undefined;
+
   return {
     id: t.id,
     isMine: true, // 서버에 소유자 정보가 오면 교체
@@ -23,7 +61,7 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     createdAtIso: iso,
     tags: Array.isArray(t.techs) ? t.techs : [],
     importance: t.starRating ?? 0,
-    summaryType: mapSummaryType(t.summaryType),
+    summaryType: label,
     imageUrl: t.imageUrl ?? "",
     likeCount: t.likeCount ?? undefined,
     commentCount: t.commentCount ?? undefined,

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -66,6 +66,7 @@ export interface EmailCheckResponse {
 
 export interface OauthRegisterRequest {
   userId: number;
+  kakaoNickname: string;
   nickname: string;
   field: string;
   bio: string;

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -279,7 +279,7 @@ export default function FreeFormWritePage() {
     title,
     introduction: meta?.description ?? "",
     postTags,
-    isVisible: (meta?.visibility ?? "public") === "public",
+    isVisible: (meta?.visibility ?? "private") === "public",
     isSummaryCreated: false,
     postStatus,
     starRating: Number(meta?.importance ?? 0),
@@ -345,7 +345,7 @@ export default function FreeFormWritePage() {
       const meta: PostSavePayload = {
         importance: previewMeta?.importance ?? 0,
         description: previewMeta?.description ?? "",
-        visibility: previewMeta?.visibility ?? "public",
+        visibility: previewMeta?.visibility ?? "private",
         projectId: Number(projectId),
         projectName:
           projectNameById(selectedProjectIdPage) ||
@@ -1012,7 +1012,8 @@ export default function FreeFormWritePage() {
                 }
                 initialVisibility={
                   previewMeta?.visibility ??
-                  location.state?.savePrefill?.visibility
+                  location.state?.savePrefill?.visibility ??
+                  "private"
                 }
                 initialProjectId={
                   selectedProjectIdPage ??

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -208,6 +208,22 @@ export default function FreeFormWritePage() {
   const closingRef = useRef(false);
   const titleInputRef = useRef<HTMLInputElement | null>(null);
 
+  // 썸네일 상태
+  const [currentThumbnail, setCurrentThumbnail] = useState<string | null>(null);
+
+  // 수정 모드 초기 진입 시 상세 조회에서 가져오기
+  useEffect(() => {
+    (async () => {
+      if (!isResume || !resumePostId) return;
+      try {
+        const d: any = await getPostDetail(resumePostId);
+        setCurrentThumbnail(d?.thumbnailImageUrl ?? null);
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, [isResume, resumePostId]);
+
   // 프리필 + 포커스
   useEffect(() => {
     if (location.state?.editorType === "FREEFORM") {
@@ -1024,6 +1040,7 @@ export default function FreeFormWritePage() {
                 }
                 initialThumbnail={
                   previewMeta?.thumbnail ??
+                  currentThumbnail ??
                   location.state?.savePrefill?.thumbnail ??
                   null
                 }

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -14,7 +14,7 @@ import PostSaveModal, {
 import PostLoadingModal from "@/pages/TempWrite/PostLoadingModal";
 import TemplateSelectModal from "@/pages/TempWrite/TemplateSelectModal";
 import PostSuccessModal from "@/pages/TempWrite/PostSuccessModal";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { PATH } from "@/constants/paths";
 import { useProjectList } from "@/hooks/useProjectList";
 import type { PostContentDto, SummaryTypeParam } from "@/models/post.model";
@@ -107,8 +107,14 @@ export default function FreeFormWritePage() {
   // ------------ 기본 상태 ------------
   const navigate = useNavigate();
   const location = useLocation() as { state?: IncomingFreeformState };
+  const params = useParams<{ id?: string; postId?: string }>();
+  const paramPostId = useMemo(() => {
+    const raw = params?.id ?? params?.postId;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }, [params]);
 
-  const [wasCompleted, setWasCompleted] = useState(false);
+  // const [wasCompleted, setWasCompleted] = useState(false);
   const [title, setTitle] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedErrorType, setSelectedErrorType] = useState<string | null>(
@@ -117,6 +123,8 @@ export default function FreeFormWritePage() {
   const [blocks, setBlocks] = useState<BlockData[]>([
     { id: Date.now(), title: "", content: "", isSaved: false },
   ]);
+
+  const [createdPostId, setCreatedPostId] = useState<number | null>(null);
 
   // 프로젝트 목록
   const { data: projectList = [], loading: projectsLoading } = useProjectList();
@@ -150,9 +158,9 @@ export default function FreeFormWritePage() {
 
   // 이어쓰기(수정) 여부 + 대상 포스트
   const resumePostId = useMemo(() => {
-    const pid = location.state?.postId;
+    const pid = location.state?.postId ?? paramPostId;
     return typeof pid === "number" && Number.isFinite(pid) ? pid : null;
-  }, [location.state]);
+  }, [location.state, paramPostId]);
   const isResume = resumePostId != null;
 
   // 초안 ID (새로 작성 시 create 결과, 이어쓰기 시 기존 id)
@@ -161,19 +169,25 @@ export default function FreeFormWritePage() {
     if (resumePostId) setDraftPostId(resumePostId);
   }, [resumePostId]);
 
-  // 최초 1회 완료 여부 (completedAt 존재)
-  useEffect(() => {
-    (async () => {
-      if (!isResume || !resumePostId) return;
-      try {
-        const detail: any = await getPostDetail(resumePostId);
-        const completedAt = detail?.completedAt ?? null;
-        setWasCompleted(Boolean(completedAt));
-      } catch {
-        // ignore
-      }
-    })();
-  }, [isResume, resumePostId]);
+  // 모든 저장/요약 경로에서 이 ID만 사용
+  const currentPostId = useMemo(
+    () => createdPostId ?? draftPostId ?? resumePostId ?? paramPostId ?? null,
+    [createdPostId, draftPostId, resumePostId, paramPostId]
+  );
+
+  // // 최초 1회 완료 여부 (completedAt 존재)
+  // useEffect(() => {
+  //   (async () => {
+  //     if (!isResume || !resumePostId) return;
+  //     try {
+  //       const detail: any = await getPostDetail(resumePostId);
+  //       const completedAt = detail?.completedAt ?? null;
+  //       setWasCompleted(Boolean(completedAt));
+  //     } catch {
+  //       // ignore
+  //     }
+  //   })();
+  // }, [isResume, resumePostId]);
 
   // ------------ 모달/알림 ------------
   const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
@@ -190,7 +204,6 @@ export default function FreeFormWritePage() {
 
   // ------------ 요약/상태 ------------
   const [previewMeta, setPreviewMeta] = useState<PostSavePayload | null>(null);
-  const [createdPostId, setCreatedPostId] = useState<number | null>(null);
   const [summaryTaskId, setSummaryTaskId] = useState<string | null>(null);
   const [summaryProgress, setSummaryProgress] = useState(0);
   const [summaryStatus, setSummaryStatus] = useState<SummaryStatus | null>(
@@ -210,16 +223,44 @@ export default function FreeFormWritePage() {
 
   // 썸네일 상태
   const [currentThumbnail, setCurrentThumbnail] = useState<string | null>(null);
+  const [initialPostStatus, setInitialPostStatus] = useState<
+    "WRITING" | "COMPLETED" | "SUMMARIZED" | null
+  >(null);
+  const wasEverCompleted = useMemo(
+    () =>
+      initialPostStatus === "COMPLETED" || initialPostStatus === "SUMMARIZED",
+    [initialPostStatus]
+  );
+  const [detailPrefill, setDetailPrefill] = useState<PostSavePayload | null>(
+    null
+  );
 
   // 수정 모드 초기 진입 시 상세 조회에서 가져오기
+  const [detailLoaded, setDetailLoaded] = useState(!isResume);
   useEffect(() => {
     (async () => {
       if (!isResume || !resumePostId) return;
       try {
         const d: any = await getPostDetail(resumePostId);
         setCurrentThumbnail(d?.thumbnailImageUrl ?? null);
+        const s = (d?.postStatus ?? d?.status) as
+          | "WRITING"
+          | "COMPLETED"
+          | "SUMMARIZED"
+          | undefined;
+        setInitialPostStatus(s ?? null);
+        setDetailPrefill({
+          importance: Number(d?.starRating ?? 0),
+          description: String(d?.introduction ?? ""),
+          visibility: d?.isVisible ? "public" : "private",
+          projectId: Number.isFinite(d?.projectId) ? Number(d.projectId) : null,
+          projectName: "", // 필요시 후속 조회로 채워도 무방
+          thumbnail: d?.thumbnailImageUrl ?? null,
+        });
       } catch {
         /* ignore */
+      } finally {
+        setDetailLoaded(true);
       }
     })();
   }, [isResume, resumePostId]);
@@ -324,11 +365,21 @@ export default function FreeFormWritePage() {
   };
 
   // ------------ upsert 유틸 ------------
-  const upsertPost = async (maybeId: number | null, form: PostForm) => {
-    if (maybeId) {
-      await editPost(maybeId, toEditPostRequest(form) as any);
-      return maybeId;
+  const upsertPost = async (
+    maybeId: number | null,
+    form: PostForm,
+    opts?: { forceEdit?: boolean }
+  ) => {
+    // 수정 모드에선 어떤 경우에도 생성 금지
+    const resolvedId = opts?.forceEdit
+      ? resumePostId ?? paramPostId ?? maybeId
+      : maybeId;
+
+    if (resolvedId) {
+      await editPost(resolvedId, toEditPostRequest(form) as any);
+      return resolvedId;
     }
+
     const created: any = await createPost(toCreatePostRequest(form) as any);
     const newId = Number(
       created?.id ?? created?.data?.id ?? created?.content?.id
@@ -340,6 +391,12 @@ export default function FreeFormWritePage() {
   // ------------ 임시 저장 (WRITING) ------------
   const handleClickTempSave = async (): Promise<boolean> => {
     if (isSaving) return false;
+    if (isResume && !detailLoaded) {
+      setStatusMessage(
+        "문서 정보를 불러오는 중이에요. 잠시 후 다시 시도해주세요."
+      );
+      return false;
+    }
     setIsSaving(true);
     try {
       if (!validateBasic()) return false;
@@ -347,6 +404,7 @@ export default function FreeFormWritePage() {
       const projectId =
         selectedProjectIdPage ??
         previewMeta?.projectId ??
+        detailPrefill?.projectId ??
         location.state?.savePrefill?.projectId ??
         initialProjectId ??
         null;
@@ -359,20 +417,27 @@ export default function FreeFormWritePage() {
 
       const canonicalTags = await canonicalizeTags(selectedTags);
       const meta: PostSavePayload = {
-        importance: previewMeta?.importance ?? 0,
-        description: previewMeta?.description ?? "",
-        visibility: previewMeta?.visibility ?? "private",
+        importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
+        description:
+          previewMeta?.description ?? detailPrefill?.description ?? "",
+        visibility:
+          previewMeta?.visibility ?? detailPrefill?.visibility ?? "private",
         projectId: Number(projectId),
         projectName:
           projectNameById(selectedProjectIdPage) ||
           previewMeta?.projectName ||
+          detailPrefill?.projectName ||
           location.state?.savePrefill?.projectName ||
           projectNameById(initialProjectId),
-        thumbnail: previewMeta?.thumbnail ?? null,
+        thumbnail: previewMeta?.thumbnail ?? detailPrefill?.thumbnail ?? null,
       };
 
-      const form = buildForm("WRITING", meta, canonicalTags);
-      const id = await upsertPost(draftPostId, form);
+      const form = buildForm(
+        wasEverCompleted ? initialPostStatus ?? "COMPLETED" : "WRITING",
+        meta,
+        canonicalTags
+      );
+      const id = await upsertPost(currentPostId, form, { forceEdit: isResume });
 
       setDraftPostId(id);
       setCreatedPostId(id);
@@ -393,14 +458,13 @@ export default function FreeFormWritePage() {
   // ------------ 최종 저장 (원본 COMPLETED 저장) ------------
   const saveOriginal = async (meta: PostSavePayload) => {
     const tags = await canonicalizeTags(selectedTags);
-    // 이미 완료된 포스트라면 수정 시에도 COMPLETED 유지
-    const nextStatus: "WRITING" | "COMPLETED" = wasCompleted
-      ? "COMPLETED"
-      : "WRITING";
+    // 최종 저장은 COMPLETED 고정(단, 기존이 SUMMARIZED면 유지)
+    const nextStatus: "COMPLETED" | "SUMMARIZED" =
+      initialPostStatus === "SUMMARIZED" ? "SUMMARIZED" : "COMPLETED";
     const form = buildForm(nextStatus, meta, tags);
 
     try {
-      const id = await upsertPost(draftPostId, form);
+      const id = await upsertPost(currentPostId, form, { forceEdit: isResume });
       setDraftPostId(id);
       setCreatedPostId(id);
 
@@ -437,6 +501,13 @@ export default function FreeFormWritePage() {
 
   // End → 템플릿 선택 → 요약
   const handleEnd = () => {
+    if (isResume && !detailLoaded) {
+      setStatusMessage(
+        "문서 정보를 불러오는 중이에요. 잠시 후 다시 시도해주세요."
+      );
+      return false;
+    }
+
     if (!validateBasic()) return;
     for (const block of blocks) {
       if (!(block.title ?? "").trim()) {
@@ -451,6 +522,12 @@ export default function FreeFormWritePage() {
 
   // 저장 모달 → Next
   const handleNextInPostSaveModal = async (payload: PostSavePayload) => {
+    if (isResume && !detailLoaded) {
+      setStatusMessage(
+        "문서 정보를 불러오는 중이에요. 잠시 후 다시 시도해주세요."
+      );
+      return false;
+    }
     setPreviewMeta(payload);
     setIsPostSaveModalOpen(false);
 
@@ -470,7 +547,9 @@ export default function FreeFormWritePage() {
         // --- 생성 모드(기존 동작) ---
         const tags = await canonicalizeTags(selectedTags);
         const form = buildForm("COMPLETED", payload, tags);
-        const id = await upsertPost(draftPostId, form); // create 또는 edit
+        const id = await upsertPost(currentPostId, form, {
+          forceEdit: isResume,
+        }); // create 또는 edit
         setDraftPostId(id);
         setCreatedPostId(id);
         setIsTemplateSelectModalOpen(true);
@@ -508,6 +587,40 @@ export default function FreeFormWritePage() {
       const postId = createdPostId ?? resumePostId;
       if (!postId) throw new Error("Post가 아직 생성되지 않았어요.");
 
+      // 1) 요약 시작 전, 최신 내용으로 반드시 수정 API 호출
+      const effectiveMeta: PostSavePayload = {
+        importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
+        description:
+          previewMeta?.description ?? detailPrefill?.description ?? "",
+        visibility:
+          previewMeta?.visibility ?? detailPrefill?.visibility ?? "private",
+        projectId:
+          previewMeta?.projectId ??
+          detailPrefill?.projectId ??
+          selectedProjectIdPage ??
+          initialProjectId ??
+          null,
+        projectName:
+          previewMeta?.projectName ||
+          detailPrefill?.projectName ||
+          projectNameById(selectedProjectIdPage) ||
+          projectNameById(initialProjectId),
+        thumbnail:
+          previewMeta?.thumbnail ??
+          detailPrefill?.thumbnail ??
+          currentThumbnail ??
+          null,
+      };
+      if (!effectiveMeta.projectId) {
+        throw new Error("프로젝트를 선택해주세요.");
+      }
+
+      const editForm = await buildEditFormFromMeta(effectiveMeta, {
+        mode: "summary",
+      });
+      await editPost(postId, toEditPostRequest(editForm) as any);
+
+      // 2) 수정 성공 후에만 요약 로딩 UI 오픈 및 요약 시작
       setIsTemplateSelectModalOpen(false);
       setIsLoadingModalOpen(true);
       setSummaryProgress(0);
@@ -816,12 +929,20 @@ export default function FreeFormWritePage() {
 
   // (기존 함수들 아래에 추가)
 
-  const buildEditFormFromMeta = async (meta: PostSavePayload) => {
+  const buildEditFormFromMeta = async (
+    meta: PostSavePayload,
+    opts?: { mode?: "temp" | "final" | "summary" } // temp: 임시 저장, final: 최종 저장, summary: 요약 시작 직전 저장
+  ) => {
     const tags = await canonicalizeTags(selectedTags);
-    // 이미 완료된 글이면 수정 후에도 COMPLETED 유지, 아니면 WRITING
-    const nextStatus: "WRITING" | "COMPLETED" = wasCompleted
-      ? "COMPLETED"
-      : "WRITING";
+    const mode = opts?.mode ?? "temp";
+    const nextStatus: "WRITING" | "COMPLETED" | "SUMMARIZED" = (() => {
+      // 최종 저장이거나 요약 시작 직전에는 COMPLETED로 고정(단, 기존이 SUMMARIZED면 유지)
+      if (mode === "final" || mode === "summary") {
+        return initialPostStatus === "SUMMARIZED" ? "SUMMARIZED" : "COMPLETED";
+      }
+      // 임시 저장은 기존 정책 유지
+      return wasEverCompleted ? initialPostStatus ?? "COMPLETED" : "WRITING";
+    })();
     return buildForm(nextStatus, meta, tags);
   };
 
@@ -829,7 +950,7 @@ export default function FreeFormWritePage() {
   const persistEditsIfEditMode = async () => {
     if (!isResume || !resumePostId || !previewMeta) return;
     try {
-      const form = await buildEditFormFromMeta(previewMeta);
+      const form = await buildEditFormFromMeta(previewMeta, { mode: "final" });
       await editPost(resumePostId, toEditPostRequest(form) as any);
       setDraftPostId(resumePostId);
       setCreatedPostId(resumePostId); // 이후 미리보기/네비에 활용
@@ -934,7 +1055,7 @@ export default function FreeFormWritePage() {
                         }
                         await handleGlobalSave();
                       }}
-                      disabled={isSaving}
+                      disabled={isSaving || (isResume && !detailLoaded)}
                       className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100 disabled:opacity-50 w-full sm:w-auto"
                     >
                       Save
@@ -942,6 +1063,7 @@ export default function FreeFormWritePage() {
 
                     <button
                       onClick={handleEnd}
+                      disabled={isResume && !detailLoaded}
                       className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600 w-full sm:w-auto"
                     >
                       End
@@ -1012,26 +1134,31 @@ export default function FreeFormWritePage() {
                 selectedErrorType={selectedErrorType}
                 initialImportance={
                   previewMeta?.importance ??
+                  detailPrefill?.importance ??
                   location.state?.savePrefill?.importance
                 }
                 initialDescription={
                   previewMeta?.description ??
+                  detailPrefill?.description ??
                   location.state?.savePrefill?.description
                 }
                 initialVisibility={
                   previewMeta?.visibility ??
+                  detailPrefill?.visibility ??
                   location.state?.savePrefill?.visibility ??
                   "private"
                 }
                 initialProjectId={
                   selectedProjectIdPage ??
                   previewMeta?.projectId ??
+                  detailPrefill?.projectId ??
                   location.state?.savePrefill?.projectId ??
                   initialProjectId ??
                   null
                 }
                 initialThumbnail={
                   previewMeta?.thumbnail ??
+                  detailPrefill?.thumbnail ??
                   currentThumbnail ??
                   location.state?.savePrefill?.thumbnail ??
                   null

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -608,14 +608,6 @@ export default function FreeFormWritePage() {
         if (data?.status === "COMPLETED" || p >= 100) {
           setSummaryProgress(100);
 
-          // 요약 성공 → postStatus = SUMMARIZED 반영 (기존 로직 유지)
-          try {
-            const targetIdNum = createdPostId ?? resumePostId!;
-            await editPost(targetIdNum, { postStatus: "SUMMARIZED" } as any);
-          } catch (e) {
-            console.error("포스트 SUMMARIZED 반영 실패(FreeForm):", e);
-          }
-
           if (typeof data?.postSummaryId === "number") {
             setCompletedSummaryId(data.postSummaryId);
             setIsLoadingModalOpen(false);
@@ -1089,6 +1081,7 @@ export default function FreeFormWritePage() {
               <PostSuccessModal
                 onClose={() => setIsSuccessModalOpen(false)}
                 summaryId={completedSummaryId}
+                postId={createdPostId ?? resumePostId ?? undefined}
               />
             )}
           </div>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -323,8 +323,7 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            {/* 유연한 컬럼: 화면에 맞춰 자동으로 1~N열, 각 셀 최소 320px */}
-            <div className="grid w-full gap-6 grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
+            <div className="flex flex-wrap gap-6">
               {projects.map((p) => (
                 <ProjectFolderCard
                   key={p.id}

--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -9,11 +9,19 @@ import { PATH } from "@/constants/paths";
 const SignPageOauth = () => {
   const navigate = useNavigate();
   const location = useLocation() as any;
-  const stateUserId = location?.state?.userId as number | undefined;
-  const stateNickname = location?.state?.nickname as string | undefined;
 
+  // location.state에서 넘어온 값 (카카오 인증 직후)
+  const stateUserId = location?.state?.userId as number | undefined;
+  const stateKakaoNickname = location?.state?.nickname as string | undefined;
+
+  // 카카오 원본 정보 (읽기 전용)
   const [userId, setUserId] = useState<number | null>(stateUserId ?? null);
-  const [nickname, setNickname] = useState(stateNickname ?? "");
+  const [kakaoNickname, setKakaoNickname] = useState<string>(
+    stateKakaoNickname ?? ""
+  );
+
+  // 사용자 입력용
+  const [nickname, setNickname] = useState<string>(""); // 서비스에서 사용할 닉네임
   const [field, setField] = useState("");
   const [bio, setBio] = useState("");
   const [githubad, setGithubad] = useState("");
@@ -26,18 +34,25 @@ const SignPageOauth = () => {
 
   // 새로고침 폴백
   useEffect(() => {
-    if (userId != null && nickname) return;
+    if (userId != null && kakaoNickname) return;
     try {
       const raw = sessionStorage.getItem("oauth_payload");
       if (raw) {
         const p = JSON.parse(raw) as { userId?: number; nickname?: string };
         if (p?.userId && !userId) setUserId(p.userId);
-        if (p?.nickname && !nickname) setNickname(p.nickname);
+        if (p?.nickname && !kakaoNickname) setKakaoNickname(p.nickname);
       }
     } catch (err) {
       console.debug("oauth_payload parse failed:", err);
     }
-  }, [userId, nickname]);
+  }, [userId, kakaoNickname]);
+
+  // UX: 사용자 입력 닉네임이 비어있다면, 카카오 닉네임을 기본값으로 채워줌
+  useEffect(() => {
+    if (!nickname && kakaoNickname) {
+      setNickname(kakaoNickname);
+    }
+  }, [kakaoNickname, nickname]);
 
   const validateForm = () => {
     let valid = true;
@@ -76,6 +91,7 @@ const SignPageOauth = () => {
     try {
       const payload: OauthRegisterRequest = {
         userId: userId!, // 카카오로 받은 ID
+        kakaoNickname: kakaoNickname.trim(),
         nickname: nickname.trim(),
         field: field.trim(),
         bio: bio.trim(),
@@ -122,44 +138,48 @@ const SignPageOauth = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col md:flex-row">
-      {/* 좌측(또는 상단) 이미지 영역 */}
-      <div className="w-full md:w-1/2">
-        <img
-          src={onboarding_image}
-          alt="signup visual"
-          className="w-full h-40 xs:h-56 sm:h-72 md:h-screen object-cover"
-        />
-      </div>
-
-      {/* 우측(또는 하단) 폼 영역 */}
-      <div
-        className="
-          w-full md:w-1/2
-          flex items-center justify-center
-          px-5 sm:px-10 md:px-12 lg:px-16 xl:px-[200px]
-          py-8 sm:py-12 md:py-16 lg:py-24 xl:py-[281px]
-        "
-      >
-        <div className="w-full max-w-[560px] flex flex-col items-center gap-6 sm:gap-10">
-          <h2 className="w-full font-pretendard font-bold text-black text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-[48px]">
+    <div className="flex w-screen h-screen overflow-hidden">
+      <img
+        src={onboarding_image}
+        className="w-[961.807px] h-full object-cover shrink-0"
+        alt="signup visual"
+      />
+      <div className="w-[960px] h-full px-[200px] py-[281px] flex flex-col justify-center items-center">
+        <div className="w-[560px] flex flex-col items-center gap-10">
+          <h2 className="text-black text-[48px] font-bold w-full font-pretendard">
             회원가입
           </h2>
 
           <form
             onSubmit={handleSubmit}
-            className="flex flex-col items-start w-full gap-4"
+            className="flex flex-col items-start w-full"
           >
-            <div className="flex flex-col items-start w-full gap-2 sm:gap-3">
+            <div className="flex flex-col items-start w-full">
+              {/* 카카오 닉네임 */}
+              <Input
+                label="카카오 닉네임"
+                type="text"
+                value={kakaoNickname}
+                onChange={() => {}}
+                placeholder="카카오에서 전달된 닉네임"
+                error={""}
+                name="kakaoNickname"
+              />
+              <p className="text-xs text-gray-500 -mt-2 mb-3">
+                카카오에서 받은 닉네임이며, 계정 식별을 위해 그대로 저장됩니다.
+              </p>
+
+              {/* 서비스에서 사용할 닉네임 (사용자 입력) */}
               <Input
                 label="닉네임"
                 type="text"
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
-                placeholder="닉네임을 입력해주세요."
+                placeholder="서비스에서 사용할 닉네임을 입력해주세요."
                 error={nicknameError}
                 name="nickname"
               />
+
               <Input
                 label="분야"
                 type="text"
@@ -189,13 +209,13 @@ const SignPageOauth = () => {
               />
             </div>
 
-            <div className="flex flex-col items-start gap-3 sm:gap-4 w-full">
+            <div className="flex flex-col items-start gap-4 w-full">
               <button
                 type="submit"
-                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center"
+                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-60"
                 disabled={submitting}
               >
-                <span className="text-white text-lg sm:text-[20px] font-semibold font-pretendard">
+                <span className="text-white text-[20px] font-semibold font-pretendard">
                   {submitting ? "가입 처리 중..." : "회원가입"}
                 </span>
               </button>
@@ -203,7 +223,7 @@ const SignPageOauth = () => {
           </form>
 
           <p
-            className={`text-sm sm:text-[13px] min-h-[25px] ${
+            className={`text-[13px] min-h-[25px] ${
               formError ? "text-red-500" : "text-transparent"
             }`}
             aria-live="polite"
@@ -211,15 +231,13 @@ const SignPageOauth = () => {
             {formError || " "}
           </p>
 
-          {/* 하단 링크: 모바일 정렬 보완 */}
-          <div className="flex flex-row items-end self-center md:self-end gap-3 sm:gap-4">
-            <h2 className="text-base sm:text-[18px] text-gray-500 font-pretendard">
+          <div className="flex flex-row items-end self-end gap-4">
+            <h2 className="text-[18px] text-gray-500 font-pretendard">
               이미 계정이 있으신가요?
             </h2>
             <button
-              className="text-base sm:text-[18px] text-[#9737fd] underline font-pretendard"
+              className="text-[18px] text-[#9737fd] underline font-pretendard"
               onClick={() => navigate("/")}
-              type="button"
             >
               로그인
             </button>

--- a/src/pages/Login/SignPageOne.tsx
+++ b/src/pages/Login/SignPageOne.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Input from "./Input";
 import onboarding_image from "../../assets/images/onboarding_image.png";
 import { postEmailCheck } from "@/api/auth.api";
+import { PATH } from "@/constants/paths";
 
 const SignPageOne = () => {
   const [email, setEmail] = useState("");
@@ -181,7 +182,7 @@ const SignPageOne = () => {
             </h2>
             <button
               className="text-[18px] text-[#9737fd] underline font-pretendard"
-              onClick={() => navigate("/")}
+              onClick={() => navigate(PATH.LOGIN)}
             >
               로그인
             </button>

--- a/src/pages/Login/SignPageTwo.tsx
+++ b/src/pages/Login/SignPageTwo.tsx
@@ -159,7 +159,7 @@ const SignPageTwo = () => {
             </h2>
             <button
               className="text-sm sm:text-base md:text-lg text-[#9737fd] underline font-pretendard"
-              onClick={() => navigate("/")}
+              onClick={() => navigate(PATH.LOGIN)}
             >
               로그인
             </button>

--- a/src/pages/MyPage/LikedPostsPage.tsx
+++ b/src/pages/MyPage/LikedPostsPage.tsx
@@ -16,6 +16,8 @@ const LikedPostsPage = () => {
     navigate(PATH.COMMUNITY_POST(postId));
   };
 
+  const showEmpty = !loading && !error && items.length === 0;
+
   return (
     <div className="w-full max-w-[948px] mx-auto px-4 sm:px-0 flex flex-col gap-6 sm:gap-10 pb-16 sm:pb-[78px]">
       {/* 에러/로딩 */}
@@ -26,14 +28,25 @@ const LikedPostsPage = () => {
       )}
 
       <div className="flex flex-col items-start self-stretch">
-        {items.map((card) => (
-          <TroubleShootingCard
-            key={card.id}
-            {...card}
-            onDeleted={handleDeleted}
-            onClick={handleCardClick}
-          />
-        ))}
+        {/* 빈 상태 */}
+        {showEmpty && (
+          <div className="w-full flex h-[132px] justify-center items-center rounded-[8px]">
+            <span className="text-body-20-regular">
+              아직 좋아요한 포스트가 없어요.
+            </span>
+          </div>
+        )}
+
+        {/* 리스트 */}
+        {!showEmpty &&
+          items.map((card) => (
+            <TroubleShootingCard
+              key={card.id}
+              {...card}
+              onDeleted={handleDeleted}
+              onClick={handleCardClick}
+            />
+          ))}
 
         {/* 로딩 스켈레톤 */}
         {loading && (
@@ -44,7 +57,9 @@ const LikedPostsPage = () => {
         )}
 
         {/* 무한 스크롤 센티널 */}
-        {hasNext && <div ref={sentinelRef} style={{ height: 1 }} />}
+        {!showEmpty && hasNext && !loading && (
+          <div ref={sentinelRef} style={{ height: 1 }} />
+        )}
       </div>
     </div>
   );

--- a/src/pages/Onboarding/IntroLandingPage.tsx
+++ b/src/pages/Onboarding/IntroLandingPage.tsx
@@ -37,7 +37,7 @@ export default function IntroLandingPage() {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-  // ✅ 선택된 카드(i)를 뷰포트 "가운데"로 정확히 스크롤 (패딩/갭/뷰폭 무관)
+  // 선택된 카드(i)를 뷰포트 "가운데"로 정확히 스크롤 (패딩/갭/뷰폭 무관)
   const centerActive = useCallback((i: number) => {
     const vp = viewportRef.current;
     const el = itemRefs.current[i];
@@ -120,7 +120,6 @@ export default function IntroLandingPage() {
           </div>
         </section>
 
-        {/* ⬇︎ 여기부터 전체를 감싸는 그라데이션 */}
         <div className="bg-gradient-to-b from-white via-[#F4ECFF] to-[#E6D4FF]">
           {/* 작성 가이드 섹션 */}
           <section className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-16 sm:py-20 lg:py-28 grid lg:grid-cols-2 gap-12 items-center">
@@ -140,7 +139,7 @@ export default function IntroLandingPage() {
               />
             </div>
 
-            <div className="order-1 lg:order-2 text-left space-y-5 sm:space-y-6">
+            <div className="order-1 lg:order-2 text-left space-y-5 sm:space-y-6 lg:pl-16 xl:pl-24 2xl:pl-32">
               <h2 className="text-head-32-bold text-primary whitespace-pre-line leading-relaxed sm:leading-9">
                 {`쉽고 
 명확하게

--- a/src/pages/TempWrite/PostSaveModal.tsx
+++ b/src/pages/TempWrite/PostSaveModal.tsx
@@ -101,7 +101,7 @@ export default function PostSaveModal({
   }, [initialProjectId, defaultProjectId]);
 
   useEffect(() => {
-    if (initialThumbnail !== undefined) setThumbnail(initialThumbnail);
+    setThumbnail(initialThumbnail ?? null);
   }, [initialThumbnail]);
 
   useEffect(() => {

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -270,6 +270,18 @@ const TempWritePage = () => {
 
   // 썸네일 상태
   const [currentThumbnail, setCurrentThumbnail] = useState<string | null>(null);
+  // 최초 작성 상태
+  const [initialPostStatus, setInitialPostStatus] = useState<
+    "WRITING" | "COMPLETED" | "SUMMARIZED" | null
+  >(null);
+  const wasEverCompleted = useMemo(
+    () =>
+      initialPostStatus === "COMPLETED" || initialPostStatus === "SUMMARIZED",
+    [initialPostStatus]
+  );
+  const [detailPrefill, setDetailPrefill] = useState<PostSavePayload | null>(
+    null
+  );
 
   // 수정 모드 초기 진입 시 상세 조회에서 가져오기
   useEffect(() => {
@@ -278,6 +290,22 @@ const TempWritePage = () => {
       try {
         const d: any = await getPostDetail(resumePostId);
         setCurrentThumbnail(d?.thumbnailImageUrl ?? null);
+        // 서버 필드명 상이할 수 있어 둘 다 고려
+        const s = (d?.postStatus ?? d?.status) as
+          | "WRITING"
+          | "COMPLETED"
+          | "SUMMARIZED"
+          | undefined;
+        setInitialPostStatus(s ?? null);
+        // ← 기존 introduction / starRating / visibility / projectId 등을 프리필에 저장
+        setDetailPrefill({
+          importance: Number(d?.starRating ?? 0),
+          description: String(d?.introduction ?? ""),
+          visibility: d?.isVisible ? "public" : "private",
+          projectId: Number.isFinite(d?.projectId) ? Number(d.projectId) : null,
+          projectName: "", // 필요시 후속 조회로 채워도 무방
+          thumbnail: d?.thumbnailImageUrl ?? null,
+        });
       } catch {
         /* ignore */
       }
@@ -380,10 +408,23 @@ const TempWritePage = () => {
   };
 
   // 현재 화면 상태 + PostSaveModal에서 받은 meta로 수정 페이로드 만들기
-  const buildEditFormFromMeta = async (meta: PostSavePayload) => {
+  const buildEditFormFromMeta = async (
+    meta: PostSavePayload,
+    opts?: { mode?: "temp" | "final" | "summary" } // temp: 임시저장, final: 최종저장(요약 안함), summary: 요약 직전 최종저장
+  ) => {
+    const mode = opts?.mode ?? "temp";
     const canonicalTags = await canonicalizeTags(selectedTags);
     const { checklistError, checklistReason } =
       encodeChecklistToNumbers(blocks);
+    const nextStatus: "WRITING" | "COMPLETED" | "SUMMARIZED" = (() => {
+      // 최종 저장(요약 유무와 무관)에서는 COMPLETED로 고정,
+      // 다만 기존이 SUMMARIZED면 그대로 유지
+      if (mode === "final" || mode === "summary") {
+        return initialPostStatus === "SUMMARIZED" ? "SUMMARIZED" : "COMPLETED";
+      }
+      // 임시 저장은 기존 정책 유지: 과거에 완료 이력 있으면 그대로 유지, 아니면 WRITING
+      return wasEverCompleted ? initialPostStatus ?? "COMPLETED" : "WRITING";
+    })();
 
     return {
       title,
@@ -391,7 +432,7 @@ const TempWritePage = () => {
       postTags: canonicalTags,
       isVisible: (meta.visibility ?? "private") === "public",
       isSummaryCreated: false,
-      postStatus: "COMPLETED", // 저장(완료) 상태로 반영
+      postStatus: nextStatus, // 저장(완료) 상태로 반영
       starRating: Number(meta.importance ?? 0),
       templateType: "GUIDELINE",
       projectId: Number(meta.projectId),
@@ -406,7 +447,7 @@ const TempWritePage = () => {
   // 수정 모드에서만 호출: 템플릿 선택 모달에서 요약을 시작하지 않는 경우에 저장
   const persistEditsIfEditMode = async () => {
     if (!isResume || !resumePostId || !previewMeta) return;
-    const form = await buildEditFormFromMeta(previewMeta);
+    const form = await buildEditFormFromMeta(previewMeta, { mode: "final" });
     await editPost(resumePostId, toEditPostRequest(form) as any);
     setDraftPostId(resumePostId);
   };
@@ -527,9 +568,39 @@ const TempWritePage = () => {
     if (isStartingSummary) return;
     setIsStartingSummary(true);
     try {
-      if (!createdPostId && !resumePostId)
-        throw new Error("Post가 아직 생성되지 않았어요.");
+      const postId = createdPostId ?? resumePostId;
+      if (!postId) throw new Error("Post가 아직 생성되지 않았어요.");
 
+      // 1) 요약 시작 전, 항상 최신 내용으로 수정 API 호출
+      const effectiveMeta: PostSavePayload = {
+        importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
+        description:
+          previewMeta?.description ?? detailPrefill?.description ?? "",
+        visibility:
+          previewMeta?.visibility ?? detailPrefill?.visibility ?? "private",
+        projectId:
+          previewMeta?.projectId ??
+          detailPrefill?.projectId ??
+          selectedProjectIdPage ??
+          initialProjectId ??
+          null,
+        projectName:
+          previewMeta?.projectName ||
+          detailPrefill?.projectName ||
+          projectNameById(selectedProjectIdPage) ||
+          projectNameById(initialProjectId),
+        thumbnail: previewMeta?.thumbnail ?? detailPrefill?.thumbnail ?? null,
+      };
+      if (!effectiveMeta.projectId) {
+        throw new Error("프로젝트를 선택해주세요.");
+      }
+
+      const editForm = await buildEditFormFromMeta(effectiveMeta, {
+        mode: "summary",
+      });
+      await editPost(postId, toEditPostRequest(editForm) as any);
+
+      // 2) 수정 성공 후에만 요약 로딩 UI 오픈 및 요약 시작
       setIsTemplateSelectModalOpen(false);
       setIsLoadingModalOpen(true);
       setSummaryProgress(0);
@@ -537,10 +608,7 @@ const TempWritePage = () => {
       setStatusMessage("");
       setTemplateLabel(label);
 
-      const taskId = await startSummaryCompat(
-        createdPostId ?? (resumePostId as number),
-        type
-      );
+      const taskId = await startSummaryCompat(postId, type);
       setSummaryTaskId(taskId);
     } catch (e) {
       console.error(e);
@@ -731,20 +799,25 @@ const TempWritePage = () => {
         encodeChecklistToNumbers(blocks);
 
       const meta: PostSavePayload = {
-        importance: previewMeta?.importance ?? 0,
-        description: previewMeta?.description ?? "",
-        visibility: previewMeta?.visibility ?? "private",
+        importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
+        description:
+          previewMeta?.description ?? detailPrefill?.description ?? "",
+        visibility:
+          previewMeta?.visibility ?? detailPrefill?.visibility ?? "private",
         projectId:
           selectedProjectIdPage ??
+          previewMeta?.projectId ??
+          detailPrefill?.projectId ??
           location.state?.savePrefill?.projectId ??
           initialProjectId ??
           null,
         projectName:
           projectNameById(selectedProjectIdPage) ||
           previewMeta?.projectName ||
+          detailPrefill?.projectName ||
           location.state?.savePrefill?.projectName ||
           projectNameById(initialProjectId),
-        thumbnail: previewMeta?.thumbnail ?? null,
+        thumbnail: previewMeta?.thumbnail ?? detailPrefill?.thumbnail ?? null,
       };
 
       if (!meta.projectId) {
@@ -759,7 +832,9 @@ const TempWritePage = () => {
         postTags: canonicalTags,
         isVisible: (meta.visibility ?? "private") === "public",
         isSummaryCreated: false,
-        postStatus: "WRITING",
+        postStatus: wasEverCompleted
+          ? initialPostStatus ?? "COMPLETED"
+          : "WRITING",
         starRating: Number(meta.importance ?? 0),
         templateType: "GUIDELINE",
         projectId: Number(meta.projectId),
@@ -1055,26 +1130,31 @@ const TempWritePage = () => {
               selectedErrorType={selectedErrorType}
               initialImportance={
                 previewMeta?.importance ??
+                detailPrefill?.importance ??
                 location.state?.savePrefill?.importance
               }
               initialDescription={
                 previewMeta?.description ??
+                detailPrefill?.description ??
                 location.state?.savePrefill?.description
               }
               initialVisibility={
                 previewMeta?.visibility ??
+                detailPrefill?.visibility ??
                 location.state?.savePrefill?.visibility ??
                 "private"
               }
               initialProjectId={
                 selectedProjectIdPage ??
                 previewMeta?.projectId ??
+                detailPrefill?.projectId ??
                 location.state?.savePrefill?.projectId ??
                 initialProjectId ??
                 null
               }
               initialThumbnail={
                 previewMeta?.thumbnail ??
+                detailPrefill?.thumbnail ??
                 currentThumbnail ??
                 location.state?.savePrefill?.thumbnail ??
                 null

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -24,6 +24,7 @@ import {
   cancelSummary,
   editPost,
   getTagsByKeyword,
+  getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
 import {
@@ -266,6 +267,22 @@ const TempWritePage = () => {
     () => draftPostId ?? resumePostId ?? null,
     [draftPostId, resumePostId]
   );
+
+  // 썸네일 상태
+  const [currentThumbnail, setCurrentThumbnail] = useState<string | null>(null);
+
+  // 수정 모드 초기 진입 시 상세 조회에서 가져오기
+  useEffect(() => {
+    (async () => {
+      if (!isResume || !resumePostId) return;
+      try {
+        const d: any = await getPostDetail(resumePostId);
+        setCurrentThumbnail(d?.thumbnailImageUrl ?? null);
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, [isResume, resumePostId]);
 
   // ---------- 프리필 ----------
   useEffect(() => {
@@ -1058,6 +1075,7 @@ const TempWritePage = () => {
               }
               initialThumbnail={
                 previewMeta?.thumbnail ??
+                currentThumbnail ??
                 location.state?.savePrefill?.thumbnail ??
                 null
               }

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -372,7 +372,7 @@ const TempWritePage = () => {
       title,
       introduction: meta.description ?? "",
       postTags: canonicalTags,
-      isVisible: (meta.visibility ?? "public") === "public",
+      isVisible: (meta.visibility ?? "private") === "public",
       isSummaryCreated: false,
       postStatus: "COMPLETED", // 저장(완료) 상태로 반영
       starRating: Number(meta.importance ?? 0),
@@ -461,7 +461,7 @@ const TempWritePage = () => {
           title,
           introduction: payload.description ?? "",
           postTags: canonicalTags,
-          isVisible: (payload.visibility ?? "public") === "public",
+          isVisible: (payload.visibility ?? "private") === "public",
           isSummaryCreated: false,
           postStatus: "COMPLETED",
           starRating: Number(payload.importance ?? 0),
@@ -716,7 +716,7 @@ const TempWritePage = () => {
       const meta: PostSavePayload = {
         importance: previewMeta?.importance ?? 0,
         description: previewMeta?.description ?? "",
-        visibility: previewMeta?.visibility ?? "public",
+        visibility: previewMeta?.visibility ?? "private",
         projectId:
           selectedProjectIdPage ??
           location.state?.savePrefill?.projectId ??
@@ -740,7 +740,7 @@ const TempWritePage = () => {
         title,
         introduction: meta.description ?? "",
         postTags: canonicalTags,
-        isVisible: (meta.visibility ?? "public") === "public",
+        isVisible: (meta.visibility ?? "private") === "public",
         isSummaryCreated: false,
         postStatus: "WRITING",
         starRating: Number(meta.importance ?? 0),
@@ -1046,7 +1046,8 @@ const TempWritePage = () => {
               }
               initialVisibility={
                 previewMeta?.visibility ??
-                location.state?.savePrefill?.visibility
+                location.state?.savePrefill?.visibility ??
+                "private"
               }
               initialProjectId={
                 selectedProjectIdPage ??


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

### 수정한 에러 목록
- 온보딩 화면 두번째 섹션 UI 텍스트 오른쪽으로
- 회원가입 화면에서 이미 계정이 있으신가요? -> 랜딩 페이지로 이동
- 카카오 회원가입 페이지 화면 깨짐 (텍스트가 좌측 이미지보다 아래)
- 카카오닉네임 받는 부분 없음
- MyPageSidebar에 기본적으로 아래 여백 주기
- 좋아요한 포스트 없을 경우 텍스트
- 팔로잉/팔로워 없을 경우 텍스트
-  임시저장 -> 기본값 공개글로 설정되어 있음
- 글 저장 모달창에서 기존 썸네일 있을 시 띄워주고 서버에도 함께 보내기 
- 가이드 템플릿 한 번 요약 완료 -> 원본 수정 -> 요약 미생성 시 요약 완료 게시글에 뜨지 않음
- 가이드 템플릿 글 비공개로 저장 안됨 (수정 시에?) -> 요약 생성 안하면 비공개로 저장되는데 요약 생성 시 공개로 저장됨
- 자유템플릿 요약 후 완성본 조회 오류 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 닉네임 입력/표시가 추가된 소셜 회원가입 지원.
  - 글쓰기(자유/임시) 재개 시 게시글 상세 자동 불러오기 및 필드 사전 채움.

- 개선
  - 팔로잉/팔로워에 로딩·에러·빈 상태 처리 추가.
  - 좋아요한 포스트 빈 상태 표시 추가.
  - 카드 타이틀의 요약 표시 조건 단순화로 노출 일관성 향상.
  - 게시글 수정 시 단계별 저장/완료 흐름 정교화.

- UI/UX
  - 마이페이지 팔로잉 아이템: 아바타/텍스트 전체 클릭으로 프로필 이동, 버튼 레이블/스타일 개선.
  - 프로젝트 폴더 카드 및 홈 섹션 레이아웃/반응형 폭 조정.
  - 사이드바 여백과 온보딩 가이드 패딩 개선.
  - OAuth 가입 화면 레이아웃 개편 및 읽기 전용 카카오 닉네임 필드 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->