### PR TITLE
FIX: 트러블슈팅 알림 라우팅 수정 및 400 에러 대처

### DIFF
--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -46,6 +46,24 @@ function buildSSEHeaders(opts?: { token?: string; envType?: string }) {
   return headers;
 }
 
+function normalizeAlert(x: any): AlertServerItem | null {
+  if (!x) return null;
+  // 흔한 래퍼 형태 풀기
+  if (Array.isArray(x) && x.length) return normalizeAlert(x[0]);
+  if (x.data) return normalizeAlert(x.data);
+  if (x.alert) return normalizeAlert(x.alert);
+
+  // 다양한 키 대응
+  const title = x.title ?? x.alertTitle ?? x.notificationTitle ?? x.subject;
+  const message = x.message ?? x.alertMessage ?? x.body ?? x.content;
+  const targetUrl = x.targetUrl ?? x.link ?? x.url;
+
+  if (typeof title === "string" && typeof message === "string") {
+    return { title, message, targetUrl } as AlertServerItem;
+  }
+  return null;
+}
+
 // SSE 연결 (실시간 알림)
 export function connectAlertSSE(
   h: Handlers = {},
@@ -91,20 +109,17 @@ export function connectAlertSSE(
     },
 
     onmessage(ev) {
-      // 서버가 이벤트 이름을 준다면 'alert'만 처리
       if (ev.event && ev.event !== "alert") return;
-
       const d = ev.data;
-      // 서버/프록시 keepalive 주석 라인 무시
       if (typeof d === "string" && d.startsWith(":")) return;
       if (!d) return;
 
-      // 알림 payload만 파싱 시도
       try {
         const parsed = JSON.parse(d);
-        h.onMessage?.(parsed);
+        const item = normalizeAlert(parsed);
+        if (item) h.onMessage?.(item);
       } catch {
-        // 비-JSON은 무시 (예: "SSE 연결 성공")
+        // 비 JSON(환영 메시지 등)은 무시
       }
     },
 

--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -56,10 +56,15 @@ function normalizeAlert(x: any): AlertServerItem | null {
   // 다양한 키 대응
   const title = x.title ?? x.alertTitle ?? x.notificationTitle ?? x.subject;
   const message = x.message ?? x.alertMessage ?? x.body ?? x.content;
-  const targetUrl = x.targetUrl ?? x.link ?? x.url;
+  const rawUrl = x.targetUrl ?? x.link ?? x.url;
 
   if (typeof title === "string" && typeof message === "string") {
-    return { title, message, targetUrl } as AlertServerItem;
+    const alertId = typeof x.alertId === "number" ? x.alertId : Date.now(); // 임시 ID
+    const alertType = String(x.alertType ?? x.type ?? "UNKNOWN");
+    const isRead = Boolean(x.isRead ?? false);
+    const userId = typeof x.userId === "number" ? x.userId : 0;
+    const targetUrl = typeof rawUrl === "string" ? rawUrl : null;
+    return { alertId, title, message, alertType, isRead, targetUrl, userId };
   }
   return null;
 }

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -30,7 +30,7 @@ export default function NotificationModal() {
     if (item.type === "트러블슈팅") {
       if (viewerId != null) return PATH.MYPAGE(String(viewerId));
       // 로그인 정보가 없다면 적절한 폴백
-      return PATH.HOME; // 또는 PATH.LOGIN
+      return PATH.LOGIN;
     }
     // 2) 그 외엔 서버가 내려준 targetUrl을 내부 경로로만 허용
     return toInternalSpaPath(item.link);

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -4,6 +4,8 @@ import clsx from "clsx";
 import escapeIcon from "@/assets/icons/escape.svg";
 import useNotifications from "@/hooks/useNotifications";
 import { toInternalSpaPath } from "@/utils/url";
+import { useViewerId } from "@/store/auth";
+import { PATH } from "@/constants/paths";
 
 const tabs = ["전체", "트러블슈팅", "댓글", "좋아요"] as const;
 type TabType = (typeof tabs)[number];
@@ -19,6 +21,26 @@ export default function NotificationModal() {
   const [selectedTab, setSelectedTab] = useState<TabType>("전체");
   const { items, loading, error, removeOne } = useNotifications(selectedTab);
   const navigate = useNavigate();
+
+  const viewerId = useViewerId();
+
+  // 각 알림의 실제 이동 목적지 계산
+  const getDestination = (item: NotificationItem): string | null => {
+    // 1) 트러블슈팅 알림이면 무조건 내 마이페이지로
+    if (item.type === "트러블슈팅") {
+      if (viewerId != null) return PATH.MYPAGE(String(viewerId));
+      // 로그인 정보가 없다면 적절한 폴백
+      return PATH.HOME; // 또는 PATH.LOGIN
+    }
+    // 2) 그 외엔 서버가 내려준 targetUrl을 내부 경로로만 허용
+    return toInternalSpaPath(item.link);
+  };
+
+  const handleItemClick = (item: NotificationItem) => {
+    const dest = getDestination(item);
+    if (!dest) return;
+    navigate(dest);
+  };
 
   return (
     <div
@@ -65,33 +87,32 @@ export default function NotificationModal() {
           </div>
         ) : (
           <div className="flex flex-col gap-[24px]">
-            {items.map((item) => (
-              <div
-                key={item.id}
-                className="flex justify-between items-start group"
-              >
+            {items.map((item) => {
+              const clickable = !!getDestination(item); // 링크 유무/트러블슈팅 여부 포함
+              return (
                 <div
-                  onClick={() => {
-                    const internal = toInternalSpaPath(item.link);
-                    if (!internal) return;
-                    navigate(internal);
-                  }}
-                  className={clsx(
-                    "text-body-20-regular cursor-pointer transition-all",
-                    item.link &&
-                      "group-hover:text-primary group-hover:underline"
-                  )}
+                  key={item.id}
+                  className="flex justify-between items-start group"
                 >
-                  {item.text}
+                  <div
+                    onClick={() => clickable && handleItemClick(item)}
+                    className={clsx(
+                      "text-body-20-regular transition-all",
+                      clickable &&
+                        "cursor-pointer group-hover:text-primary group-hover:underline"
+                    )}
+                  >
+                    {item.text}
+                  </div>
+                  <img
+                    src={escapeIcon}
+                    alt="delete"
+                    className="w-[24px] h-[24px] cursor-pointer shrink-0"
+                    onClick={() => removeOne(item.id)}
+                  />
                 </div>
-                <img
-                  src={escapeIcon}
-                  alt="delete"
-                  className="w-[24px] h-[24px] cursor-pointer shrink-0"
-                  onClick={() => removeOne(item.id)}
-                />
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -69,7 +69,8 @@ export default function CommunityPostDetail() {
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
   const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  type LoadErr = { status?: number; message: string };
+  const [loadError, setLoadError] = useState<LoadErr | null>(null);
 
   // 좋아요/댓글 로컬 상태
   const [isLiked, setIsLiked] = useState(false);
@@ -100,6 +101,17 @@ export default function CommunityPostDetail() {
   const [asideOffset, setAsideOffset] = useState(0);
   // 섹션 refs는 HTMLDivElement로 구체화
   const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  // 서버 에러 응답 파싱
+  const parseApiError = (err: any): LoadErr => {
+    const status = err?.response?.status;
+    const message =
+      err?.response?.data?.error?.message ??
+      err?.response?.data?.message ??
+      err?.message ??
+      "요청 처리 중 오류가 발생했어요.";
+    return { status, message };
+  };
 
   useEffect(() => {
     const updateAsideOffset = () => {
@@ -405,7 +417,7 @@ export default function CommunityPostDetail() {
 
     const numId = Number(postId);
     if (!Number.isFinite(numId)) {
-      setLoadError("잘못된 포스트 ID");
+      setLoadError({ message: "잘못된 포스트 ID" });
       setLoading(false);
       return;
     }
@@ -576,11 +588,7 @@ export default function CommunityPostDetail() {
         }
       } catch (err: any) {
         if (!cancelled) {
-          setLoadError(
-            err?.response?.data?.message ??
-              err?.message ??
-              "포스트 불러오기 실패"
-          );
+          setLoadError(parseApiError(err));
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -946,14 +954,87 @@ export default function CommunityPostDetail() {
       </div>
     );
   }
-  if (loadError || !post) {
+
+  // CTA 핸들러들
+  const viewerIdForCta = detailCtx.viewerId;
+  const goBack = () => {
+    if (window.history.length > 1) navigate(-1);
+    else navigate(PATH.COMMUNITY, { replace: true });
+  };
+  const goCommunity = () => navigate(PATH.COMMUNITY, { replace: true });
+  const goHome = () => navigate(PATH.HOME, { replace: true });
+  const goLogin = () => {
+    const sp = new URLSearchParams();
+    sp.set("next", window.location.pathname + window.location.search);
+    navigate(`${PATH.ROOT}?${sp.toString()}`, { replace: true });
+  };
+  const goMyPage = () => {
+    if (viewerIdForCta != null) navigate(PATH.MYPAGE(String(viewerIdForCta)));
+    else goLogin();
+  };
+
+  const err = loadError;
+
+  // 1) 400 BAD_REQUEST이면 카드 UI
+  if (err && err.status === 400) {
+    return (
+      <section className="w-full flex items-center justify-center py-24 px-6">
+        <section className="w-full max-w-3xl rounded-2xl border border-gray-200 bg-white p-10 shadow-[0_2px_16px_rgba(0,0,0,0.06)]">
+          <div className="flex flex-col items-center text-center gap-6">
+            <div className="flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
+              <span className="text-4xl" aria-hidden>
+                ⚠️
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h1 className="text-head-32-semibold">요청을 처리할 수 없어요</h1>
+              <p className="text-body-16-regular text-gray-500">
+                {err.message}
+              </p>
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+              <button
+                onClick={goBack}
+                className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+              >
+                이전 페이지
+              </button>
+              <button
+                onClick={goCommunity}
+                className="px-4 h-11 rounded-lg bg-primary text-white hover:opacity-90 transition"
+              >
+                커뮤니티 홈
+              </button>
+              <button
+                onClick={goHome}
+                className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+              >
+                홈으로 가기
+              </button>
+              <button
+                onClick={goMyPage}
+                className="px-4 h-11 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition"
+              >
+                {viewerIdForCta != null ? "내 마이페이지" : "로그인하기"}
+              </button>
+            </div>
+          </div>
+        </section>
+      </section>
+    );
+  }
+
+  // 2) 그 외 에러/데이터 없음은 기존 단순 뷰 유지
+  if (!post || err) {
     return (
       <div className="w-full px-4 sm:px-6 md:px-8">
         <div className="mx-auto flex justify-center">
           <div
             className={`${CONTENT_WIDTH_CLASS} pt-24 sm:pt-[180px] text-red-600`}
           >
-            {loadError ?? "포스트를 찾을 수 없습니다."}
+            {err ? err.message : "포스트를 찾을 수 없습니다."}
           </div>
         </div>
       </div>

--- a/src/providers/AlertSSEProvider.tsx
+++ b/src/providers/AlertSSEProvider.tsx
@@ -1,9 +1,8 @@
 import { type PropsWithChildren, useEffect, useRef } from "react";
 import { connectAlertSSE } from "@/api/alert.api";
-import { useIsLoggedIn, useViewerId, useAuthStore } from "@/store/auth";
+import { useIsLoggedIn, useViewerId } from "@/store/auth";
 import { startRefresh } from "@/api/axios";
 import { useNotificationStore } from "@/store/notification";
-import type { AlertServerItem } from "@/types/alert.model";
 import { PATH } from "@/constants/paths";
 
 // 콜백 라우트 감지(풀 리다이렉트 방식: /auth/oauth-register 만 스킵)
@@ -17,14 +16,14 @@ async function tryRefreshOnce() {
 }
 
 // 타입 가드
-function isAlertPayload(x: any): x is AlertServerItem {
-  return x && typeof x === "object" && "title" in x && "message" in x;
-}
+// function isAlertPayload(x: any): x is AlertServerItem {
+//   return x && typeof x === "object" && "title" in x && "message" in x;
+// }
 
 export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const isLoggedIn = useIsLoggedIn();
   const viewerId = useViewerId();
-  const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
+  // const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
 
   const esCloseRef = useRef<null | (() => void)>(null);
   const connectedRef = useRef(false);
@@ -37,7 +36,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const retryMs = Number(import.meta.env.VITE_SSE_RETRY_MS ?? 3000);
 
   useEffect(() => {
-    if (!hydrated) return;
+    // if (!hydrated) return;
 
     // ✅ OAuth 콜백 라우트에서는 SSE/리프레시 전부 비활성화
     const pathname = window.location.pathname;
@@ -91,12 +90,18 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
 
       const close = connectAlertSSE(
         {
-          onOpen: () => console.log("[SSE] connected"),
+          onOpen: () => {
+            connectedRef.current = true;
+            console.log("[SSE] connected");
+          },
           onMessage: (payload) => {
-            if (!isAlertPayload(payload)) return;
+            // if (!isAlertPayload(payload)) return;
             useNotificationStore.getState().pushFromSSE(payload);
           },
-          onError: (e) => console.warn("[SSE] error", e),
+          onError: (e) => {
+            console.warn("[SSE] error", e);
+            connectedRef.current = false;
+          },
           onUnauthorized: async () => {
             // 콜백 라우트면 무시
             if (isAuthCallbackPath(window.location.pathname)) return;
@@ -119,7 +124,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
         close();
         connectedRef.current = false;
       };
-      connectedRef.current = true;
+      // connectedRef.current = true;
     };
 
     // StrictMode 중복 연결 방지: 0ms 지연으로 예약
@@ -152,7 +157,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       esCloseRef.current = null;
       connectedRef.current = false;
     };
-  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs]);
+  }, [isLoggedIn, viewerId, autoReconnect, retryMs]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ] 트러블슈팅 아이템 -> 마이페이지로 라우팅
- [ ] 400(삭제된 유저) 에러 -> 에러 페이지로

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 커뮤니티 글 상세: 400 전용 오류 화면 추가(맞춤 메시지 + 뒤로가기/커뮤니티 홈/홈/로그인·마이페이지 CTA).
  - 알림 모달: 항목별 목적지 계산 및 목적지 존재 시에만 클릭 가능하도록 개선(인터랙티브 스타일 적용).

- 버그 수정
  - 알림 수신 처리 개선: 다양한 서버 응답 형태를 유연하게 파싱해 알림 누락을 감소.
  - 오류 처리 일관화: API 오류를 표준화해 사용자 안내 메시지와 흐름 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->