### PR TITLE
FIX: API 호출 관련 오류 수정 및 url 표시 개선

### DIFF
--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -83,7 +83,7 @@ export function connectAlertSSE(
   const ctrl = new AbortController();
   const headers = buildSSEHeaders({ token, envType });
 
-  fetchEventSource("/api/alert/connect", {
+  fetchEventSource(`${import.meta.env.VITE_API_BASE_URL}/alert/connect`, {
     method: "GET",
     headers,
     credentials: "include",

--- a/src/api/alert.api.ts
+++ b/src/api/alert.api.ts
@@ -83,7 +83,7 @@ export function connectAlertSSE(
   const ctrl = new AbortController();
   const headers = buildSSEHeaders({ token, envType });
 
-  fetchEventSource(`${import.meta.env.VITE_API_BASE_URL}/alert/connect`, {
+  fetchEventSource("/api/alert/connect", {
     method: "GET",
     headers,
     credentials: "include",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -251,7 +251,21 @@ const resId = api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // ✅ 401 → "무조건" 리프레시 먼저 시도, 성공 시 원요청 1회 재시도
+    // 토큰 전무 상태의 401은 refresh/가드 네비 금지 (그냥 실패로 반환)
+    const storedToken = localStorage.getItem("accessToken") || "";
+    const hasBearer = !!(cfg.headers && (cfg.headers as any).Authorization);
+
+    if (
+      status === 401 &&
+      !skipAuth &&
+      !isSSEAuth &&
+      !storedToken &&
+      !hasBearer
+    ) {
+      return Promise.reject(error);
+    }
+
+    // 401 → "무조건" 리프레시 먼저 시도, 성공 시 원요청 1회 재시도
     if (status === 401 && !skipAuth && !isSSEAuth) {
       let p = getRefreshPromise();
       if (!p) {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -18,6 +18,7 @@ declare module "axios" {
   export interface AxiosRequestConfig {
     __skipGlobal404?: boolean;
     __skipGlobalAuthGuard?: boolean;
+    __anonymous?: boolean;
     _retry?: boolean;
   }
 }
@@ -103,6 +104,18 @@ const reqId = api.interceptors.request.use((config) => {
   const reqOrigin = isAbsolute ? getOriginSafely(url) : API_ORIGIN;
   const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
   if (isExternalAbsolute) return config;
+
+  // 익명 요청이면 토큰/쿠키/EnvType만 최소화
+  if (config.__anonymous) {
+    // 토큰 금지
+    delete (config.headers as any).Authorization;
+    // 쿠키 금지 (CSRF 회피용)
+    config.withCredentials = false;
+    // EnvType 유지
+    if ((config.headers as any).EnvType == null)
+      (config.headers as any).EnvType = ENVTYPE;
+    return config;
+  }
 
   const token = localStorage.getItem("accessToken");
   if (token) (config.headers as any).Authorization = `Bearer ${token}`;
@@ -226,7 +239,8 @@ const resId = api.interceptors.response.use(
     }
 
     // 401/403 → 전역 가드 (특정 요청 스킵 가능)
-    const skipAuth = cfg.__skipGlobalAuthGuard === true;
+    const skipAuth =
+      cfg.__skipGlobalAuthGuard === true || cfg.__anonymous === true;
     const isSSEAuth = /\/alert|\/connect|\/events/i.test(String(reqUrl));
     const isRefreshCall = /\/auth\/refresh\b/.test(String(reqUrl));
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -100,12 +100,7 @@ const reqId = api.interceptors.request.use((config) => {
   const url = config.url ?? "";
   config.headers = config.headers ?? {};
 
-  const isAbsolute = isAbsoluteUrl(url);
-  const reqOrigin = isAbsolute ? getOriginSafely(url) : API_ORIGIN;
-  const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
-  if (isExternalAbsolute) return config;
-
-  // 익명 요청이면 토큰/쿠키/EnvType만 최소화
+  // 1) 익명 요청 우선 적용 (외부 URL 포함)
   if (config.__anonymous) {
     // 토큰 금지
     delete (config.headers as any).Authorization;
@@ -114,6 +109,16 @@ const reqId = api.interceptors.request.use((config) => {
     // EnvType 유지
     if ((config.headers as any).EnvType == null)
       (config.headers as any).EnvType = ENVTYPE;
+    return config;
+  }
+
+  // 2) 외부 절대 URL → 토큰/쿠키 금지
+  const isAbsolute = isAbsoluteUrl(url);
+  const reqOrigin = isAbsolute ? getOriginSafely(url) : API_ORIGIN;
+  const isExternalAbsolute = isAbsolute && reqOrigin !== API_ORIGIN;
+  if (isExternalAbsolute) {
+    delete (config.headers as any).Authorization;
+    config.withCredentials = false;
     return config;
   }
 

--- a/src/app/providers/sse.tsx
+++ b/src/app/providers/sse.tsx
@@ -1,6 +1,6 @@
 import { type PropsWithChildren, useEffect, useRef } from "react";
 import { connectAlertSSE } from "@/api/alert.api";
-import { useIsLoggedIn, useViewerId } from "@/store/auth";
+import { useAuthHydrated, useIsLoggedIn, useViewerId } from "@/store/auth";
 import { startRefresh } from "@/api/axios";
 import { useNotificationStore } from "@/store/notification";
 import { isAuthCallbackPath } from "@/shared/lib/auth-route";
@@ -18,6 +18,7 @@ async function tryRefreshOnce() {
 // }
 
 export default function AlertSSEProvider({ children }: PropsWithChildren) {
+  const hydrated = useAuthHydrated();
   const isLoggedIn = useIsLoggedIn();
   const viewerId = useViewerId();
   // const hydrated = (useAuthStore as any).persist?.hasHydrated?.() ?? true;
@@ -33,7 +34,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
   const retryMs = Number(import.meta.env.VITE_SSE_RETRY_MS ?? 3000);
 
   useEffect(() => {
-    // if (!hydrated) return;
+    if (!hydrated) return;
 
     // ✅ OAuth 콜백 라우트에서는 SSE/리프레시 전부 비활성화
     const pathname = window.location.pathname;
@@ -102,6 +103,10 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
           onUnauthorized: async () => {
             // 콜백 라우트면 무시
             if (isAuthCallbackPath(window.location.pathname)) return;
+
+            // 토큰이 없으면(로그인 전/로그아웃 상태) 리프레시 시도 자체를 하지 않음
+            if (!localStorage.getItem("accessToken")) return;
+
             if (refreshingRef.current) return;
             refreshingRef.current = true;
             const ok = await tryRefreshOnce();
@@ -154,7 +159,7 @@ export default function AlertSSEProvider({ children }: PropsWithChildren) {
       esCloseRef.current = null;
       connectedRef.current = false;
     };
-  }, [isLoggedIn, viewerId, autoReconnect, retryMs]);
+  }, [hydrated, isLoggedIn, viewerId, autoReconnect, retryMs]);
 
   return <>{children}</>;
 }

--- a/src/app/routes/ProtectedRoute/ProtectedRouter.tsx
+++ b/src/app/routes/ProtectedRoute/ProtectedRouter.tsx
@@ -1,4 +1,5 @@
 import { PATH } from "@/shared/config/paths";
+import { useAuthHydrated } from "@/store/auth";
 import type { ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 
@@ -10,6 +11,7 @@ interface ProtectedRouteProps {
 // const isDevBypass = true;
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const hydrated = useAuthHydrated();
   const isAuthenticated = !!localStorage.getItem("accessToken");
   const loc = useLocation();
 
@@ -18,8 +20,10 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   //   return <>{children}</>;
   // }
 
+  if (!hydrated) return null;
+
   if (!isAuthenticated) {
-    const next = encodeURIComponent(loc.pathname + loc.search);
+    const next = encodeURIComponent(`${loc.pathname}${loc.search}${loc.hash}`);
     return <Navigate to={`${PATH.ROOT}?next=${next}`} replace />;
   }
   return <>{children}</>;

--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -81,10 +81,10 @@ export const router = createBrowserRouter(
         // 검색
         { path: PATH.SEARCH, element: <SearchResultPage /> },
 
-        // 마이페이지
+        // 내 마이페이지: /user/mypage
         {
-          path: PATH.MYPAGE(":id"),
-          element: <MyPageLayout />,
+          path: PATH.MYPAGE_BASE,
+          element: <MyPageLayout />, // id 없음 → 내부에서 viewerId로 처리
           children: [
             { index: true, element: <TroubleShootingList /> },
             { path: "following", element: <MyFollowing /> },
@@ -93,17 +93,38 @@ export const router = createBrowserRouter(
             { path: "likes", element: <LikedPostsPage /> },
           ],
         },
+
+        // 타인 마이페이지: /user/mypage/:id
+        {
+          path: PATH.MYPAGE_ID(),
+          element: <MyPageLayout />, // id 존재
+          children: [
+            { index: true, element: <TroubleShootingList /> },
+            { path: "following", element: <MyFollowing /> },
+            { path: "follower", element: <MyFollowing /> },
+            { path: "statistics", element: <StatisticsPage /> },
+            { path: "likes", element: <LikedPostsPage /> },
+          ],
+        },
+
+        // 내 프로필 편집: /user/mypage/editprofile
+        { path: PATH.MYPAGE_EDIT_ME, element: <EditProfile /> },
+        // (옵션) 하위 호환 유지가 필요하면 아래도 유지
         { path: PATH.MYPAGE_EDIT(":id"), element: <EditProfile /> },
 
         // 프로젝트 상세
         { path: PATH.PROJECT_DETAIL(":id"), element: <ProjectDetailPage /> },
 
-        // 커뮤니티
+        // 커뮤니티: id/slug 둘 다 지원
         { path: PATH.COMMUNITY, element: <CommunityPage /> },
         {
-          path: PATH.COMMUNITY_POST(":postId"),
+          path: PATH.COMMUNITY_POST_ID(":postId"),
           element: <CommunityPostDetail />,
-        },
+        }, // 기존
+        {
+          path: PATH.COMMUNITY_POST_SLUG(":slug"),
+          element: <CommunityPostDetail />,
+        }, // 새 슬러그
       ],
     },
 

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -74,7 +74,11 @@ const Header = () => {
     const mypageMatch = path.match(/^\/user\/mypage\/([^/]+)/);
     const pageUserId = mypageMatch?.[1];
 
-    if (path.startsWith(PATH.MYPAGE(""))) {
+    if (path === PATH.MYPAGE_BASE) {
+      setPlaceholder(
+        "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
+      );
+    } else if (path.startsWith(PATH.MYPAGE_BASE + "/")) {
       if (pageUserId && myUserIdStr && pageUserId === myUserIdStr) {
         setPlaceholder(
           "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
@@ -131,7 +135,9 @@ const Header = () => {
       scope = "community";
       const mypageMatch = currentPath.match(/^\/user\/mypage\/([^/]+)/);
       pageUserId = mypageMatch?.[1] ?? "";
-      if (currentPath.startsWith(PATH.MYPAGE(""))) {
+      if (currentPath === PATH.MYPAGE_BASE) {
+        scope = "mypage";
+      } else if (currentPath.startsWith(PATH.MYPAGE_BASE + "/")) {
         scope = pageUserId === myUserIdStr ? "mypage" : "user";
       } else if (
         currentPath.startsWith(PATH.HOME) ||
@@ -223,7 +229,7 @@ const Header = () => {
                 <UserMenuDropdown
                   onClose={() => setIsUserDropdownOpen(false)}
                   onNavigateToMyPage={() => {
-                    if (myUserIdStr) navigate(PATH.MYPAGE(myUserIdStr));
+                    if (myUserIdStr) navigate(PATH.MYPAGE_BASE);
                     else navigate(PATH.ROOT);
                     setIsUserDropdownOpen(false);
                   }}

--- a/src/layouts/Header/HeaderWoSearch.tsx
+++ b/src/layouts/Header/HeaderWoSearch.tsx
@@ -91,7 +91,7 @@ const HeaderWoSearch = () => {
               <UserMenuDropdown
                 onClose={() => setIsUserDropdownOpen(false)}
                 onNavigateToMyPage={() => {
-                  if (myUserIdStr) navigate(PATH.MYPAGE(myUserIdStr));
+                  if (myUserIdStr) navigate(PATH.MYPAGE_BASE);
                   else navigate(PATH.ROOT);
                   setIsUserDropdownOpen(false);
                 }}

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -7,23 +7,26 @@ import { useViewerId } from "@/store/auth";
 import { PATH } from "@/shared/config/paths";
 
 const MyPageLayout = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id?: string }>();
   const location = useLocation();
   const navigate = useNavigate();
 
   const viewerId = useViewerId();
   const myUserIdStr = viewerId != null ? String(viewerId) : null;
 
-  const myUserId = typeof window !== "undefined" ? myUserIdStr : null;
-  const isMyPage = !!myUserId && id === myUserId;
+  // id가 없으면 '내 마이페이지'로 간주
+  const isMyPage = !id || (myUserIdStr != null && id === myUserIdStr);
 
   const [sortBy, setSortBy] = useState<"latest" | "important">("latest");
 
+  // 숫자 id 계산 (타인 페이지일 때만 의미 있음)
   const userIdNum = useMemo(() => {
+    if (!id) return NaN; // 내 페이지면 NaN
     const n = Number(id);
     return Number.isFinite(n) ? n : NaN;
   }, [id]);
 
+  // 태그 선택 시 URL 생성 로직: 내/타인 분기
   const selectedTag = useMemo(() => {
     const sp = new URLSearchParams(location.search);
     const t = sp.get("tag");
@@ -31,10 +34,8 @@ const MyPageLayout = () => {
   }, [location.search]);
 
   const handleSelectTag = (tag: string | null) => {
-    if (!id) return;
-    const url = tag
-      ? `${PATH.MYPAGE(id)}?tag=${encodeURIComponent(tag)}`
-      : PATH.MYPAGE(id);
+    const base = isMyPage ? PATH.MYPAGE_BASE : PATH.MYPAGE_ID(id!);
+    const url = tag ? `${base}?tag=${encodeURIComponent(tag)}` : base;
     navigate(url);
     window.scrollTo({ top: 0, behavior: "smooth" });
   };

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -20,6 +20,12 @@ export interface RegisterRequest {
   field: string;
   bio: string;
   githubUrl?: string;
+  termsAgreements: termsAgreements;
+}
+
+interface termsAgreements {
+  "1": boolean;
+  "2": boolean;
 }
 
 export interface RegisterResponse {

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -9,6 +9,7 @@ import type { CommunitySort } from "@/types/community.model";
 import { decideCombined } from "@/entities/trouble/lib/combinedRoute";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { makePostSlug } from "@/shared/lib/slug";
 
 export default function CommunityPage() {
   const navigate = useNavigate();
@@ -134,8 +135,10 @@ export default function CommunityPage() {
                     state: { from: "community", ownerId },
                   });
                 } else {
+                  // 제목 기반 슬러그 이동
+                  const slug = makePostSlug(card.title, id);
                   navigate(
-                    `${PATH.COMMUNITY_POST(String(id))}?${qs.toString()}`,
+                    `${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`,
                     {
                       state: { from: "community", ownerId },
                     }
@@ -144,7 +147,7 @@ export default function CommunityPage() {
               }}
               onAvatarClick={() => {
                 if (card.authorId != null)
-                  navigate(PATH.MYPAGE(String(card.authorId)));
+                  navigate(PATH.MYPAGE_ID(String(card.authorId)));
               }}
             />
           </div>

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -7,7 +7,7 @@ import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
 import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import { PATH } from "@/shared/config/paths";
 import useClickOutside from "@/hooks/useClickOutside";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import imageIcon from "@/assets/icons/image.svg";
 import starIcon from "@/assets/icons/star.svg";
@@ -33,6 +33,7 @@ import { useViewerId } from "@/store/auth";
 import { getPostDetail, hardDeletePost } from "@/api/post.api";
 import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
 import { postFollow, postUnfollow } from "@/api/user.api";
+import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 
 export interface CommunityPostDetailProps {
   errorType: string;
@@ -64,7 +65,7 @@ export default function CommunityPostDetail() {
   const CONTENT_WIDTH_CLASS =
     "w-full sm:w-[520px] md:w-[680px] lg:w-[820px] xl:w-[960px]";
 
-  const { postId } = useParams<{ postId: string }>();
+  const { postId, slug } = useParams<{ postId?: string; slug?: string }>();
   const navigate = useNavigate();
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
@@ -112,6 +113,13 @@ export default function CommunityPostDetail() {
       "요청 처리 중 오류가 발생했어요.";
     return { status, message };
   };
+
+  // 유효 ID 계산
+  const effectiveId = useMemo(() => {
+    if (postId && Number.isFinite(Number(postId))) return Number(postId);
+    if (slug) return extractIdFromSlug(slug);
+    return NaN;
+  }, [postId, slug]);
 
   useEffect(() => {
     const updateAsideOffset = () => {
@@ -415,22 +423,21 @@ export default function CommunityPostDetail() {
     setLoading(true);
     setLoadError(null);
 
-    const numId = Number(postId);
-    if (!Number.isFinite(numId)) {
+    if (!Number.isFinite(effectiveId)) {
       setLoadError({ message: "잘못된 포스트 ID" });
       setLoading(false);
       return;
     }
 
     const loadCommunity = async () => {
-      const communityData = await getCommunityPostDetail(numId);
+      const communityData = await getCommunityPostDetail(effectiveId);
       if (!communityData) throw new Error("빈 응답입니다.");
       const vm = toCommunityPostVM(communityData, detailCtx.viewerId);
       setPost(vm);
       setIsLiked(vm.isLiked);
       setLikeCounts(vm.likeCounts);
       setIsCommunitySource(true);
-      void loadComments(numId, 1, detailCtx.viewerId ?? null);
+      void loadComments(effectiveId, 1, detailCtx.viewerId ?? null);
     };
 
     const loadMineDraft = async (id: number) => {
@@ -512,13 +519,13 @@ export default function CommunityPostDetail() {
         // 1) 힌트가 있으면 즉시 분기 (중복 호출 차단)
         if (isMine && statusFromList === "inProgress") {
           // 작성 중 → 에디터(프리필 위해 1회 내 상세 호출)
-          await loadMineDraft(numId);
+          await loadMineDraft(effectiveId);
           return;
         }
 
         if (isMine && statusFromList === "created") {
           if (summaryIdFromList != null) {
-            navigate(PATH.COMBINED_DETAIL(numId, summaryIdFromList), {
+            navigate(PATH.COMBINED_DETAIL(effectiveId, summaryIdFromList), {
               replace: true,
               state: {
                 from: "community-detail",
@@ -529,7 +536,7 @@ export default function CommunityPostDetail() {
           }
           // 힌트에 summaryId가 없으면 한 번만 내 상세 조회로 보강
           try {
-            const myDetail = await getPostDetail(numId);
+            const myDetail = await getPostDetail(effectiveId);
             const sid =
               (typeof (myDetail as any)?.postSummaryId === "number" &&
                 (myDetail as any).postSummaryId) ||
@@ -537,7 +544,7 @@ export default function CommunityPostDetail() {
                 (myDetail as any).summaryId) ||
               null;
             if (sid != null) {
-              navigate(PATH.COMBINED_DETAIL(numId, sid), {
+              navigate(PATH.COMBINED_DETAIL(effectiveId, sid), {
                 replace: true,
                 state: {
                   from: "community-detail",
@@ -563,7 +570,7 @@ export default function CommunityPostDetail() {
             await loadCommunity();
           } else {
             // 비공개 완료 → 내 상세만
-            const myDetail = await getPostDetail(numId);
+            const myDetail = await getPostDetail(effectiveId);
             const vmMine = toPostDetailVM(myDetail as any, viewerId);
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
@@ -576,9 +583,9 @@ export default function CommunityPostDetail() {
         // 2) 힌트가 부족하면 기존 로직(내 상세로 판정 → 필요 시 커뮤) 실행
         if (isMine) {
           try {
-            const myDetail = await getPostDetail(numId);
+            const myDetail = await getPostDetail(effectiveId);
             const isDraft = (myDetail as any)?.completedAt == null;
-            if (isDraft) await loadMineDraft(numId);
+            if (isDraft) await loadMineDraft(effectiveId);
             else await loadCommunity();
           } catch {
             await loadCommunity();
@@ -599,7 +606,7 @@ export default function CommunityPostDetail() {
       cancelled = true;
     };
   }, [
-    postId,
+    effectiveId,
     detailCtx.viewerId,
     detailCtx.ownerId,
     detailCtx.statusFromList,
@@ -608,6 +615,17 @@ export default function CommunityPostDetail() {
     detailCtx.isMineFromList,
     navigate,
   ]);
+
+  useEffect(() => {
+    if (!post) return;
+    const canonical = PATH.COMMUNITY_POST_SLUG(
+      makePostSlug(post.title, postId ?? effectiveId)
+    );
+    // slug 경로가 아니면 슬러그로 교체
+    if (!slug || slug !== makePostSlug(post.title, effectiveId)) {
+      navigate(canonical, { replace: true });
+    }
+  }, [post, slug, effectiveId, navigate, postId]);
 
   const navigatingRef = useRef(false);
 
@@ -618,7 +636,7 @@ export default function CommunityPostDetail() {
     closeMenu();
 
     try {
-      const pid = Number(postId);
+      const pid = effectiveId;
       if (!Number.isFinite(pid)) return;
 
       const myDetail = await getPostDetail(pid);
@@ -653,7 +671,7 @@ export default function CommunityPostDetail() {
   // 작성자 프로필 클릭
   const handleProfileClick = () => {
     if (!post || post.authorId == null) return;
-    navigate(PATH.MYPAGE(String(post.authorId)));
+    navigate(PATH.MYPAGE_ID(String(post.authorId)));
   };
 
   // 좋아요 토글(커뮤니티 글에서만)
@@ -667,7 +685,7 @@ export default function CommunityPostDetail() {
     likeLockRef.current = true;
     setIsLiking(true);
 
-    const pid = Number(postId);
+    const pid = effectiveId;
     const wasLiked = isLiked;
     const prevCount = likeCounts;
 
@@ -708,7 +726,7 @@ export default function CommunityPostDetail() {
   // 댓글 1페이지를 강제 새로고침(작성/삭제 직후 사용)
   const reloadCommentsFirstPage = useCallback(async () => {
     if (!postId) return;
-    await loadComments(Number(postId), 1, detailCtx.viewerId ?? null);
+    await loadComments(effectiveId, 1, detailCtx.viewerId ?? null);
   }, [postId, detailCtx.viewerId]);
 
   // 댓글 제출(커뮤니티 글에서만)
@@ -727,7 +745,7 @@ export default function CommunityPostDetail() {
     setCommentInput("");
 
     try {
-      const created = await createCommunityComment(Number(postId), {
+      const created = await createCommunityComment(effectiveId, {
         contents,
       });
       const mapped = toPostComment(created, detailCtx.viewerId, {
@@ -763,7 +781,7 @@ export default function CommunityPostDetail() {
 
     try {
       const created = await replyCommunityComment(
-        Number(postId),
+        effectiveId,
         Number(parentId),
         { contents }
       );
@@ -788,7 +806,7 @@ export default function CommunityPostDetail() {
   // 댓글 내용 수정
   const handleEdit = async (id: string, newContent: string) => {
     if (!postId || !isCommunitySource) return;
-    const pid = Number(postId);
+    const pid = effectiveId;
     const cid = Number(id);
     try {
       const updated = await updateCommunityComment({
@@ -835,7 +853,7 @@ export default function CommunityPostDetail() {
 
     try {
       setDeleting(true);
-      await hardDeletePost(Number(postId));
+      await hardDeletePost(effectiveId);
       alert("문서가 영구 삭제되었습니다.");
 
       if (detailCtx.from === "community") {
@@ -969,7 +987,7 @@ export default function CommunityPostDetail() {
     navigate(`${PATH.ROOT}?${sp.toString()}`, { replace: true });
   };
   const goMyPage = () => {
-    if (viewerIdForCta != null) navigate(PATH.MYPAGE(String(viewerIdForCta)));
+    if (viewerIdForCta != null) navigate(PATH.MYPAGE_BASE);
     else goLogin();
   };
 
@@ -1101,7 +1119,9 @@ export default function CommunityPostDetail() {
               <div className="flex w-full flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
                 <div
                   className="flex items-center gap-[14px] sm:gap-[20px] cursor-pointer"
-                  onClick={() => navigate(PATH.MYPAGE(String(post.authorId)))}
+                  onClick={() =>
+                    navigate(PATH.MYPAGE_ID(String(post.authorId)))
+                  }
                 >
                   <img
                     src={post.authorProfile || imageIcon}
@@ -1309,7 +1329,7 @@ export default function CommunityPostDetail() {
                     disabled={cLoading}
                     onClick={() =>
                       loadComments(
-                        Number(postId),
+                        effectiveId,
                         cPage,
                         detailCtx.viewerId ?? null
                       )

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -618,9 +618,10 @@ export default function CommunityPostDetail() {
 
   useEffect(() => {
     if (!post) return;
-    const canonical = PATH.COMMUNITY_POST_SLUG(
-      makePostSlug(post.title, postId ?? effectiveId)
-    );
+    const canonical =
+      PATH.COMMUNITY_POST_SLUG(
+        makePostSlug(post.title, postId ?? effectiveId)
+      ) + window.location.search;
     // slug 경로가 아니면 슬러그로 교체
     if (!slug || slug !== makePostSlug(post.title, effectiveId)) {
       navigate(canonical, { replace: true });

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -132,7 +132,7 @@ const EditProfile = () => {
     }
     try {
       await patchProfile(profile);
-      navigate(PATH.MYPAGE(id!));
+      navigate(PATH.MYPAGE_BASE);
     } catch (error) {
       console.error("프로필 수정 실패:", error);
     }

--- a/src/pages/Error/AuthGuardPage.tsx
+++ b/src/pages/Error/AuthGuardPage.tsx
@@ -32,7 +32,7 @@ export default function AuthGuardPage() {
   };
 
   const goMyPage = () => {
-    if (viewerId != null) nav(PATH.MYPAGE(String(viewerId)));
+    if (viewerId != null) nav(PATH.MYPAGE_BASE);
     else goLogin();
   };
 

--- a/src/pages/Error/NotFoundPage.tsx
+++ b/src/pages/Error/NotFoundPage.tsx
@@ -19,7 +19,7 @@ export default function NotFoundPage() {
 
   const goMyPage = () => {
     if (viewerId != null) {
-      navigate(PATH.MYPAGE(String(viewerId)));
+      navigate(PATH.MYPAGE_BASE);
     } else {
       navigate(PATH.ROOT);
     }

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from "react-router-dom";
 import plusIcon from "@/assets/icons/plus.svg";
 import { useAuthHydrated, useIsLoggedIn, useViewerId } from "@/store/auth";
 import { decideCombined } from "@/entities/trouble/lib/combinedRoute";
+import { makePostSlug } from "@/shared/lib/slug";
 
 const PAGE_SIZE = 10;
 
@@ -398,7 +399,8 @@ export default function HomePage() {
                     compact
                     onDeleted={handleRecentDeleted}
                     onClick={() => {
-                      const ownerId = viewerId; // 내 글 목록이라면 viewerId로 충분
+                      const ownerId = card.authorId ?? undefined;
+
                       const qs = new URLSearchParams({ from: "home" });
                       if (ownerId != null) qs.set("ownerId", String(ownerId));
 
@@ -420,26 +422,24 @@ export default function HomePage() {
                         return;
                       }
 
-                      // CPD가 분기 판단에 쓸 힌트를 state로 전달
+                      // 제목 기반 슬러그 경로로 이동
+                      const slug = makePostSlug(card.title, card.id);
                       navigate(
-                        `${PATH.COMMUNITY_POST(
-                          String(card.id)
-                        )}?${qs.toString()}`,
+                        `${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`,
                         {
                           state: {
                             from: "home",
                             ownerId,
-                            statusFromList, // 작성 상태
-                            isVisibleFromList, // 공개/비공개 (boolean)
-                            summaryIdFromList, // 요약 id(있을 수도)
-                            isMineFromList, // 내 글 여부 힌트
+                            statusFromList,
+                            isVisibleFromList,
+                            summaryIdFromList,
+                            isMineFromList,
                           },
                         }
                       );
                     }}
                     onAvatarClick={() => {
-                      if (viewerId != null)
-                        navigate(PATH.MYPAGE(String(viewerId)));
+                      if (viewerId != null) navigate(PATH.MYPAGE_BASE);
                       else navigate(PATH.LOGIN);
                     }}
                   />

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -15,7 +15,7 @@ import useTroubleCards from "@/features/mypage/useTroubleCards";
 import { PATH } from "@/shared/config/paths";
 import { useNavigate } from "react-router-dom";
 import plusIcon from "@/assets/icons/plus.svg";
-import { useViewerId } from "@/store/auth";
+import { useAuthHydrated, useIsLoggedIn, useViewerId } from "@/store/auth";
 import { decideCombined } from "@/entities/trouble/lib/combinedRoute";
 
 const PAGE_SIZE = 10;
@@ -31,6 +31,8 @@ type ProjectPageResp = {
 };
 
 export default function HomePage() {
+  const hydrated = useAuthHydrated();
+  const isLoggedIn = useIsLoggedIn();
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -104,7 +106,12 @@ export default function HomePage() {
     reload: recentsReload,
   } = useTroubleCards(
     { type: "all" },
-    { infinite: true, pageSize: 10, sortBy: "latest" }
+    {
+      infinite: true,
+      pageSize: 10,
+      sortBy: "latest",
+      enabled: hydrated && isLoggedIn,
+    }
   );
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -112,6 +119,7 @@ export default function HomePage() {
 
   const loadPage = useCallback(
     async (nextPage: number, { append = true, useOnce = true } = {}) => {
+      if (!hydrated || !isLoggedIn) return; // 안전망
       if (isLoadingRef.current) return;
       if (!hasNextRef.current && nextPage !== 1) return;
 
@@ -148,15 +156,17 @@ export default function HomePage() {
         setIsLoading(false);
       }
     },
-    []
+    [hydrated, isLoggedIn]
   );
 
   useEffect(() => {
+    if (!hydrated || !isLoggedIn) return;
     loadPage(1, { append: false, useOnce: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [hydrated, isLoggedIn]);
 
   useEffect(() => {
+    if (!hydrated || !isLoggedIn) return;
     if (!sentinelRef.current) return;
     const el = sentinelRef.current;
 
@@ -167,6 +177,7 @@ export default function HomePage() {
         if (fetchingRef.current) return;
         if (!hasNextRef.current) return;
         if (isLoadingRef.current) return;
+        if (!hydrated || !isLoggedIn) return;
 
         fetchingRef.current = true;
         void loadPage(pageRef.current + 1, {
@@ -186,7 +197,7 @@ export default function HomePage() {
     io.observe(el);
     return () => io.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [hydrated, isLoggedIn]);
 
   const handleCreateProject = async (data: CreateProjectRequest) => {
     try {

--- a/src/pages/Login/SignPageTwo.tsx
+++ b/src/pages/Login/SignPageTwo.tsx
@@ -63,6 +63,11 @@ const SignPageTwo = () => {
         field,
         bio,
         githubUrl: githubad || undefined,
+        // 임시
+        termsAgreements: {
+          "1": true,
+          "2": true,
+        },
       };
 
       await postRegister(payload);

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -692,7 +692,14 @@ export default function CombinedDetailPage() {
               <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center self-stretch gap-4">
                 <div
                   className="flex items-center gap-4 sm:gap-[28px] cursor-pointer"
-                  onClick={() => authorId && navigate(PATH.MYPAGE_BASE)}
+                  onClick={() => {
+                    if (!authorId) return;
+                    if (viewerId != null && authorId === viewerId) {
+                      navigate(PATH.MYPAGE_BASE);
+                    } else {
+                      navigate(PATH.MYPAGE_ID(String(authorId)));
+                    }
+                  }}
                 >
                   <img
                     src={authorProfile || imageIcon}

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -692,9 +692,7 @@ export default function CombinedDetailPage() {
               <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center self-stretch gap-4">
                 <div
                   className="flex items-center gap-4 sm:gap-[28px] cursor-pointer"
-                  onClick={() =>
-                    authorId && navigate(PATH.MYPAGE(String(authorId)))
-                  }
+                  onClick={() => authorId && navigate(PATH.MYPAGE_BASE)}
                 >
                   <img
                     src={authorProfile || imageIcon}

--- a/src/pages/TempWrite/PreviewPage.tsx
+++ b/src/pages/TempWrite/PreviewPage.tsx
@@ -221,7 +221,7 @@ export default function PreviewPage() {
     setComments((prev) => [c, ...prev]);
     setCommentInput("");
   };
-  const handleProfileClick = () => navigate(PATH.MYPAGE?.("1") ?? "/");
+  const handleProfileClick = () => navigate(PATH.MYPAGE_BASE ?? "/");
 
   // 로딩/에러/빈데이터 처리
   if (loading) {

--- a/src/shared/config/paths.ts
+++ b/src/shared/config/paths.ts
@@ -11,13 +11,18 @@ export const PATH = {
   HOME: "/user/home",
   SEARCH: "/user/search",
 
-  // 동적 세그먼트는 콜백 형태로만 제공(한 곳에서 관리)
-  MYPAGE: (id = ":id") => `/user/mypage/${id}`,
-  MYPAGE_EDIT: (id = ":id") => `/user/mypage/${id}/editprofile`,
+  // 마이페이지: 내 페이지(무 id) / 타인 페이지(id 포함) 분리
+  MYPAGE_BASE: "/user/mypage", // 내 마이페이지
+  MYPAGE_ID: (id = ":id") => `/user/mypage/${id}`, // 타인 마이페이지
+  MYPAGE_EDIT_ME: "/user/mypage/editprofile", // 내 프로필 편집
+  MYPAGE_EDIT: (id = ":id") => `/user/mypage/${id}/editprofile`, // (옵션) 타인 경로 유지 필요시
+
+  // 프로젝트/커뮤니티
   PROJECT_DETAIL: (id = ":id") => `/user/project/${id}`,
 
   COMMUNITY: "/user/community",
-  COMMUNITY_POST: (postId = ":postId") => `/user/community/${postId}`,
+  COMMUNITY_POST_ID: (postId = ":postId") => `/user/community/${postId}`, // 하위 호환
+  COMMUNITY_POST_SLUG: (slug = ":slug") => `/user/community/p/${slug}`, // 새 슬러그 경로
 
   TEMP_WRITING: "/tempwriting",
   FREEFORM_WRITING: "/freeformwriting",

--- a/src/shared/lib/slug.ts
+++ b/src/shared/lib/slug.ts
@@ -1,0 +1,19 @@
+export const slugify = (s: string) =>
+  s
+    .normalize("NFC") // 유니코드 정규화
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-") // 공백 → 하이픈
+    // 영문/숫자/밑줄/하이픈/한글만 유지
+    .replace(/[^-\w\uAC00-\uD7A3]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, ""); // 앞뒤 하이픈 제거
+
+export const makePostSlug = (title: string, id: string | number) =>
+  `${slugify(title)}-${id}`;
+
+export const extractIdFromSlug = (slug: string) => {
+  const tail = slug.split("-").pop();
+  const n = Number(tail);
+  return Number.isFinite(n) ? n : NaN;
+};

--- a/src/shared/ui/Modal/NotificationModal.tsx
+++ b/src/shared/ui/Modal/NotificationModal.tsx
@@ -28,7 +28,7 @@ export default function NotificationModal() {
   const getDestination = (item: NotificationItem): string | null => {
     // 1) 트러블슈팅 알림이면 무조건 내 마이페이지로
     if (item.type === "트러블슈팅") {
-      if (viewerId != null) return PATH.MYPAGE(String(viewerId));
+      if (viewerId != null) return PATH.MYPAGE_BASE;
       // 로그인 정보가 없다면 적절한 폴백
       return PATH.LOGIN;
     }

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -29,6 +29,15 @@ export const useAuthStore = create<AuthState>()(
       onRehydrateStorage: () => (state) => {
         // rehydrate가 끝남을 표시
         state?.setHydrated(true);
+
+        // 토큰이 없으면 반쪽 로그인 제거: user 비우기
+        try {
+          const hasToken = !!localStorage.getItem("accessToken");
+          if (!hasToken) state?.clearUser();
+        } catch {
+          // 스토리지 접근 실패 시에도 user 비우기(보수적)
+          state?.clearUser();
+        }
       },
     }
   )

--- a/src/widgets/mypage/MyPageSidebar.tsx
+++ b/src/widgets/mypage/MyPageSidebar.tsx
@@ -11,6 +11,7 @@ import circleBIcon from "@/assets/icons/circle_b.svg";
 import { getUserInfo, postFollow, postUnfollow } from "@/api/user.api";
 import type { UserInfoData } from "@/models/user.model";
 import githubIcon from "@/assets/icons/githubIcon.svg";
+import { useViewerId } from "@/store/auth";
 
 const SUBPATH = {
   FOLLOWING: "following",
@@ -52,6 +53,8 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { id } = useParams<{ id: string }>();
+  const viewerId = useViewerId();
+
   const {
     selectedStatus,
     setSelectedStatus,
@@ -64,14 +67,20 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   const [userInfo, setUserInfo] = useState<DisplayUser | null>(null);
   const [followLoading, setFollowLoading] = useState(false);
 
-  const basePath = PATH.MYPAGE(id!);
+  // 내/타인에 따라 베이스 경로를 정확히 설정
+  const basePath = props.isMyPage
+    ? PATH.MYPAGE_BASE
+    : PATH.MYPAGE_ID(id ?? ":id");
+
   const isOnMainPage = location.pathname === basePath;
 
   const refetch = useCallback(async () => {
     try {
-      if (!id) return;
-      // 내 페이지든 남의 페이지든 동일 API 사용
-      const data: UserInfoData = await getUserInfo(Number(id));
+      // 내 페이지면 viewerId, 타인이면 URL의 id 사용
+      const rawId = props.isMyPage ? viewerId ?? NaN : id ? Number(id) : NaN;
+      if (!Number.isFinite(rawId)) return; // 로그인/하이드레이션 전이라면 잠시 대기
+
+      const data: UserInfoData = await getUserInfo(Number(rawId));
       setUserInfo({
         userId: data.userId,
         nickname: data.nickname,
@@ -86,7 +95,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
     } catch (error) {
       console.error("사용자 정보 불러오기 실패:", error);
     }
-  }, [id, props.isMyPage, setViewedUser]);
+  }, [id, viewerId, props.isMyPage, setViewedUser]);
 
   useEffect(() => {
     refetch();
@@ -95,7 +104,7 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
   useEffect(() => () => resetViewedUser(), [resetViewedUser]);
 
   useEffect(() => {
-    const onMain = location.pathname === PATH.MYPAGE(id!);
+    const onMain = location.pathname === PATH.MYPAGE_BASE;
     if (!onMain) {
       resetSelectedStatus();
       resetSelectedTag();
@@ -252,13 +261,13 @@ const MyPageSideBar = (props: MyPageSideBarProps) => {
               <FollowButton
                 label="팔로잉"
                 colorClass="bg-subColor1"
-                onClick={() => handleUnfollow(Number(id))}
+                onClick={() => id && handleUnfollow(Number(id))}
               />
             ) : (
               <FollowButton
                 label="팔로우"
                 colorClass="bg-primary"
-                onClick={() => handleFollow(Number(id))}
+                onClick={() => id && handleFollow(Number(id))}
               />
             )}
           </div>

--- a/src/widgets/mypage/TroubleShootingList.tsx
+++ b/src/widgets/mypage/TroubleShootingList.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useOutletContext } from "react-router-dom";
 import { PATH } from "@/shared/config/paths";
 import { useViewerId } from "@/store/auth";
 import { decideCombined } from "@/entities/trouble/lib/combinedRoute";
+import { makePostSlug } from "@/shared/lib/slug";
 
 interface OutletContextType {
   isMyPage: boolean;
@@ -137,8 +138,13 @@ const TroubleShootingList = () => {
                   card,
                   viewerId
                 );
-                const ownerIdForState =
-                  isMyPage && viewerId != null ? Number(viewerId) : undefined;
+                const ownerIdForState = isMyPage
+                  ? viewerId != null
+                    ? Number(viewerId)
+                    : undefined
+                  : card.authorId != null
+                  ? Number(card.authorId)
+                  : undefined;
 
                 if (goCombined && summaryId != null) {
                   navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
@@ -157,19 +163,19 @@ const TroubleShootingList = () => {
                 if (ownerIdForState != null)
                   qs.set("ownerId", String(ownerIdForState));
 
-                navigate(
-                  `${PATH.COMMUNITY_POST(String(card.id))}?${qs.toString()}`,
-                  {
-                    state: {
-                      from: "mypage",
-                      ownerId: ownerIdForState,
-                      statusFromList,
-                      isVisibleFromList,
-                      summaryIdFromList,
-                      isMineFromList,
-                    },
-                  }
-                );
+                // 슬러그 생성
+                const slug = makePostSlug(vm.title, card.id);
+
+                navigate(`${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`, {
+                  state: {
+                    from: "mypage",
+                    ownerId: ownerIdForState,
+                    statusFromList,
+                    isVisibleFromList,
+                    summaryIdFromList,
+                    isMineFromList,
+                  },
+                });
               }}
             />
           );


### PR DESCRIPTION
## ✅ What to do

- [x] 닉네임 중복 체크 오류 수정
- [x] 회원가입 시 약관 동의 필드 임의 추가 (임시)
- [x] 로그인 전에 API 호출하는 문제 해결
- [x] 표시되는 url(path) 사용성 개선

## 📄 Description

- 닉네임 중복 체크 API 호출 시 발생하는 unauthorized 오류 해결
- 회원가입 API 호출 시 약관 동의 여부 필드 임의 추가
  - 추후에 약관 동의 UI 및 로직 삽입 후 수정할 예정
- 최초로 앱 진입했을 때 온보딩 페이지에서 '시작하기' 버튼 클릭 시 한 번 튕기는 문제 해결
  - 로그인 전에 API 호출하는 문제 해결
- path 수정
  - 본인의 마이페이지인 경우 뒤에 id 제거
  - 포스트의 경우 path에 포스트 이름 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 커뮤니티 포스트에 슬러그 기반 URL 추가로 직관적 링크 제공
  * 내 프로필(기본 경로)과 타인 프로필(아이디 경로) 분리 및 관련 라우팅/네비게이션 정비
  * 회원가입 요청에 약관 동의(termsAgreements) 필드 추가

* **버그 수정**
  * 인증 하이드레이션(복원) 상태를 반영해 불필요한 리프레시/요청을 방지
  * 익명 요청 처리 추가: 인증 헤더/쿠키 비활성화 및 전역 인증 가드 건너뛰기
* **안정성**
  * 하이드레이션 후 토큰 부재 시 사용자 상태 정리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->