### PR TITLE
fix: 미리보기 화면 다크모드 반영

### DIFF
--- a/src/entities/trouble/ui/PostGuideMd.tsx
+++ b/src/entities/trouble/ui/PostGuideMd.tsx
@@ -50,6 +50,7 @@ export default function PostGuideMd({
               <div key={i} className="w-full">
                 <MDEditor.Markdown
                   source={item}
+                  data-color-mode="light"
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw, rehypeSanitize]}
                 />

--- a/src/pages/MyPage/PostCombineMd.tsx
+++ b/src/pages/MyPage/PostCombineMd.tsx
@@ -30,6 +30,8 @@ export default function PostCombineMd({
               <MDEditor.Markdown
                 key={i}
                 source={item}
+                data-color-mode="light"
+                className="!bg-white !text-black wmde-markdown-light"
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeRaw, rehypeSanitize]}
               />

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -243,10 +243,10 @@ const EditorBlock = ({
           <div
             ref={editorWrapRef}
             className="w-full overflow-visible rounded-md border border-gray-200"
-            data-color-mode="light"
           >
             <MDEditor
               value={block.content}
+              data-color-mode="light"
               onChange={(val) => {
                 onChange(index, { content: val || "" });
                 requestAnimationFrame(autosize);
@@ -282,7 +282,11 @@ const EditorBlock = ({
           </div>
         ) : (
           <div className="w-full rounded-md border border-gray-200 p-3 min-h-[150px]">
-            <MDEditor.Markdown source={block.content || ""} />
+            <MDEditor.Markdown
+              source={block.content || ""}
+              data-color-mode="light"
+              className="!bg-white !text-black wmde-markdown-light"
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [ ]  한 일

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 마크다운 편집기에서 라이트 모드 스타일링을 개선하여 마크다운 콘텐츠의 텍스트 색상과 배경이 올바르게 표시되도록 수정했습니다.
  * 게시물 가이드, 결합 페이지 및 편집기에서 마크다운 렌더링 시 일관된 라이트 테마 스타일을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->