### PR TITLE
FEAT: 온보딩 UI 수정 및 회원가입 관련

### DIFF
--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -1,6 +1,7 @@
 import { lazy } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { PATH } from "@/shared/config/paths";
+import TermsPublicPage from "@/pages/Login/TermsPublicPage";
 
 // 레이지 import (코드 스플리팅)
 const MainLayout = lazy(() => import("@/layouts/MainLayout"));
@@ -66,6 +67,7 @@ export const router = createBrowserRouter(
     { path: PATH.SIGNUP, element: <SignPageOne /> },
     { path: PATH.SIGNUP_DETAIL, element: <SignPageTwo /> },
     { path: PATH.TERMS, element: <TermsDetailPage /> },
+    { path: PATH.TERMS_FOOTER, element: <TermsPublicPage /> },
     { path: PATH.SIGNUP_OAUTH, element: <SignPageOauth /> },
 
     // 콜백 브릿지

--- a/src/pages/Login/Input.tsx
+++ b/src/pages/Login/Input.tsx
@@ -58,9 +58,7 @@ const Input: React.FC<InputProps> = ({
         role={showError ? "alert" : undefined}
         aria-hidden={!showError}
       >
-        <span className={`text-[13px] ${showError ? "text-red-500" : ""}`}>
-          {error || "placeholder"}
-        </span>
+        {showError && <span className="text-[13px] text-red-500">{error}</span>}
 
         {showError && errorActionLabel && onErrorActionClick && (
           <button

--- a/src/pages/Login/Input.tsx
+++ b/src/pages/Login/Input.tsx
@@ -9,6 +9,8 @@ interface InputProps {
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   name?: string;
+  errorActionLabel?: string;
+  onErrorActionClick?: () => void;
 }
 
 const Input: React.FC<InputProps> = ({
@@ -20,7 +22,11 @@ const Input: React.FC<InputProps> = ({
   onBlur,
   error,
   name,
+  errorActionLabel,
+  onErrorActionClick,
 }) => {
+  const showError = Boolean(error);
+
   return (
     <div className="flex flex-col items-start gap-2 w-full">
       <label className="text-black font-pretendard text-base sm:text-lg font-normal leading-normal">
@@ -39,17 +45,33 @@ const Input: React.FC<InputProps> = ({
         error ? "border-red-500 focus:ring-red-200" : "border-gray-300 bg-white"
       }`}
         aria-invalid={!!error}
+        aria-describedby={showError ? `${name ?? label}-error` : undefined}
       />
 
-      <p
-        className={`text-[13px] mt-1 min-h-[20px] transition-opacity duration-150
-      ${error ? "text-red-500 opacity-100" : "opacity-0"}`}
-        aria-live={error ? "polite" : undefined}
-        role={error ? "alert" : undefined}
-        aria-hidden={!error}
+      {/* 에러 메시지 + 우측 액션 버튼 영역 */}
+      <div
+        id={`${name ?? label}-error`}
+        className={`mt-1 min-h-[20px] w-full max-w-[560px] flex items-center transition-opacity duration-150 ${
+          showError ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        aria-live={showError ? "polite" : undefined}
+        role={showError ? "alert" : undefined}
+        aria-hidden={!showError}
       >
-        {error || "placeholder"}
-      </p>
+        <span className={`text-[13px] ${showError ? "text-red-500" : ""}`}>
+          {error || "placeholder"}
+        </span>
+
+        {showError && errorActionLabel && onErrorActionClick && (
+          <button
+            type="button"
+            onClick={onErrorActionClick}
+            className="pl-5 text-[13px] font-pretendard underline hover:opacity-80"
+          >
+            {errorActionLabel}
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/Login/SignPageOne.tsx
+++ b/src/pages/Login/SignPageOne.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import Input from "./Input";
 import onboarding_image from "../../assets/images/onboarding_image.png";
 import { postEmailCheck } from "@/api/auth.api";
 import { PATH } from "@/shared/config/paths";
+
+const EMAIL_DUP_MSG = "이미 가입된 이메일 입니다!";
 
 const SignPageOne = () => {
   const [email, setEmail] = useState("");
@@ -15,6 +17,18 @@ const SignPageOne = () => {
   const [formError, setFormError] = useState("");
   const [isFormValid, setIsFormValid] = useState(false);
   const navigate = useNavigate();
+
+  const AUTH_START_URL = useMemo(() => {
+    const base = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+    const callback = `${window.location.origin}${base}${PATH.OAUTH_REGISTER}`;
+    return `https://troublog.shop/oauth2/authorization/kakao?return_to=${encodeURIComponent(
+      callback
+    )}`;
+  }, []);
+
+  const handleKakaoLogin = () => {
+    window.location.href = AUTH_START_URL;
+  };
 
   useEffect(() => {
     const valid =
@@ -73,10 +87,10 @@ const SignPageOne = () => {
 
     try {
       await postEmailCheck(trimmedEmail);
-      setEmailError(""); // 서버에서 중복 아님 -> 에러 없음
+      setEmailError(""); // 중복 아님
     } catch (error: any) {
       if (error.response?.status === 409) {
-        setEmailError("이미 사용 중인 이메일입니다.");
+        setEmailError(EMAIL_DUP_MSG);
       } else {
         setEmailError("이메일 확인 중 오류가 발생했습니다.");
       }
@@ -116,6 +130,8 @@ const SignPageOne = () => {
     });
   };
 
+  const isEmailDuplicate = emailError === EMAIL_DUP_MSG;
+
   return (
     <div className="flex w-screen h-screen overflow-hidden">
       <img src={onboarding_image} className="w-1/2 h-full object-fill" />
@@ -138,6 +154,13 @@ const SignPageOne = () => {
                 onBlur={handleEmailBlur}
                 placeholder="이메일을 입력해주세요."
                 error={emailError}
+                // 409(중복)일 때만 우측에 텍스트 버튼 노출
+                errorActionLabel={
+                  isEmailDuplicate ? "카카오로 로그인하기" : undefined
+                }
+                onErrorActionClick={
+                  isEmailDuplicate ? handleKakaoLogin : undefined
+                }
               />
               <Input
                 label="비밀번호"

--- a/src/pages/Login/TermsPublicPage.tsx
+++ b/src/pages/Login/TermsPublicPage.tsx
@@ -1,0 +1,189 @@
+import HeaderLogoOnly from "@/layouts/Header/HeaderLogoOnly";
+import { useState } from "react";
+
+type Tab = "terms" | "privacy";
+
+export default function TermsPublicPage() {
+  const [tab, setTab] = useState<Tab>("terms");
+
+  return (
+    <div className="min-h-screen bg-white">
+      <HeaderLogoOnly />
+      {/* 상단 여백/헤더 자리 */}
+      <div className="h-12" />
+
+      <main className="mx-auto max-w-screen-xl px-4 sm:px-8">
+        {/* 탭 */}
+        <div className="flex items-center gap-3 sm:gap-4">
+          <button
+            onClick={() => setTab("terms")}
+            className={`px-5 sm:px-6 py-2.5 rounded-full text-sm sm:text-base transition
+              ${
+                tab === "terms"
+                  ? "bg-primary text-white"
+                  : "bg-subColor1 text-white"
+              }`}
+          >
+            이용약관
+          </button>
+          <button
+            onClick={() => setTab("privacy")}
+            className={`px-5 sm:px-6 py-2.5 rounded-full text-sm sm:text-base transition
+              ${
+                tab === "privacy"
+                  ? "bg-primary text-white"
+                  : "bg-subColor1 text-white"
+              }`}
+          >
+            개인정보 처리방침
+          </button>
+        </div>
+
+        {/* 카드 */}
+        <section className="mt-8 rounded-[20px] border border-black/5 bg-white shadow-[0_4px_24px_rgba(0,0,0,0.06)]">
+          <div className="p-5 sm:p-8">
+            {/* 스크롤 영역 */}
+            <div className="max-h-[65vh] overflow-auto pr-1 sm:pr-2 leading-relaxed text-[13px] sm:text-[15px] text-black/90">
+              {tab === "terms" ? <TermsBody /> : <PrivacyBody />}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* 하단 여백 */}
+      <div className="h-16" />
+    </div>
+  );
+}
+
+function TermsBody() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base sm:text-lg font-semibold">제1조 목적</h2>
+      <p>
+        본 약관은 TroubleLog(이하 “서비스”)가 제공하는 회원가입 및 서비스 이용과
+        관련하여, 서비스와 회원 간의 권리, 의무 및 책임사항을 규정함을 목적으로
+        합니다.
+      </p>
+
+      <h2 className="text-base sm:text-lg font-semibold">제2조 용어의 정의</h2>
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>회원: 서비스에 개인정보를 제공하여 회원가입을 완료한 자</li>
+        <li>닉네임: 회원 식별 및 서비스 이용을 위해 설정하는 이름</li>
+        <li>
+          선택 정보: 관심 분야, 한 줄 소개 등 본인 소개를 위해 입력하는 선택적
+          정보
+        </li>
+        <li>계정: 가입 및 서비스 이용을 위한 회원 식별 정보의 집합</li>
+        <li>이메일: 공지/알림 등 고지사항 전달을 위한 기본 수단</li>
+      </ol>
+
+      <h2 className="text-base sm:text-lg font-semibold">
+        제3조 약관의 효력 및 변경
+      </h2>
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>본 약관은 회원가입 시 동의 절차를 거쳐 효력이 발생합니다.</li>
+        <li>
+          회사는 합리적인 사유가 발생할 경우 약관을 변경할 수 있으며, 변경 시
+          공지합니다.
+        </li>
+      </ol>
+
+      <h2 className="text-base sm:text-lg font-semibold">
+        제4조 회원가입 및 계정 관리
+      </h2>
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>회원은 이메일과 비밀번호를 입력하여 가입할 수 있습니다.</li>
+        <li>
+          닉네임, 관심 분야, 한 줄 소개, 공개 여부 등은 선택 입력사항입니다.
+        </li>
+        <li>
+          회원은 본인 계정을 선량한 관리자의 주의로 관리해야 하며, 타인에게
+          양도·대여할 수 없습니다.
+        </li>
+      </ol>
+
+      <h2 className="text-base sm:text-lg font-semibold">제5조 서비스 제공</h2>
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>
+          회원은 트러블슈팅 지식 공유 및 문서화 기능을 이용할 수 있습니다.
+        </li>
+        <li>
+          운영상·기술적 사유로 서비스가 일시 중단될 수 있으며, 사전 고지를
+          원칙으로 합니다.
+        </li>
+      </ol>
+
+      <h2 className="text-base sm:text-lg font-semibold">제6조 회원의 의무</h2>
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>
+          회원은 허위 정보를 기재하거나 타인의 정보를 도용해서는 안 됩니다.
+        </li>
+        <li>
+          서비스 내에서 타인의 지적재산권, 명예 등을 침해해서는 안 됩니다.
+        </li>
+      </ol>
+
+      <h2 className="text-base sm:text-lg font-semibold">
+        제7조 서비스 이용 제한
+      </h2>
+      <p>
+        회원이 본 약관을 위반할 경우, 회사는 사전 통보 후 계정 이용을 제한하거나
+        삭제할 수 있습니다.
+      </p>
+
+      <h2 className="text-base sm:text-lg font-semibold">제8조 책임의 한계</h2>
+      <p>
+        서비스는 회원 간 발생하는 트러블슈팅 지식 공유 내용에 대해 보증하지
+        않습니다.
+      </p>
+
+      <h2 className="text-base sm:text-lg font-semibold">제9조 준거법</h2>
+      <p>본 약관은 대한민국 법률을 기준으로 해석합니다.</p>
+    </div>
+  );
+}
+
+function PrivacyBody() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base sm:text-lg font-semibold">
+        TroubleLog 개인정보처리방침
+      </h2>
+
+      <h3 className="text-sm sm:text-base font-semibold">
+        1. 수집하는 개인정보 항목
+      </h3>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>필수: 이메일, 비밀번호</li>
+        <li>선택: 닉네임, 관심 분야, 한 줄 소개, 깃허브 주소</li>
+      </ul>
+
+      <h3 className="text-sm sm:text-base font-semibold">
+        2. 수집 및 이용 목적
+      </h3>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>이메일 공지 및 공지사항 전달</li>
+        <li>비밀번호: 회원 로그인 및 보안</li>
+        <li>프로필/커뮤니티 기능 제공</li>
+      </ul>
+
+      <h3 className="text-sm sm:text-base font-semibold">3. 보관 및 파기</h3>
+      <p>
+        회원 탈퇴 시 즉시 모든 개인정보를 파기합니다. 다만, 관련 법령에 따라
+        보관 의무가 있는 경우 해당 기간 동안 보관합니다.
+      </p>
+
+      <h3 className="text-sm sm:text-base font-semibold">4. 제3자 제공</h3>
+      <p>원칙적으로 외부에 제공하지 않습니다.</p>
+
+      <h3 className="text-sm sm:text-base font-semibold">
+        5. 안전성 확보 조치
+      </h3>
+      <p>암호화 및 보안 기술을 적용하여 회원 정보를 보호합니다.</p>
+
+      <h3 className="text-sm sm:text-base font-semibold">6. 문의처</h3>
+      <p>개인정보 관련 문의: troublog.official@gmail.com</p>
+    </div>
+  );
+}

--- a/src/pages/Onboarding/IntroLandingPage.tsx
+++ b/src/pages/Onboarding/IntroLandingPage.tsx
@@ -86,7 +86,7 @@ export default function IntroLandingPage() {
           <div aria-hidden />
           <div className="relative mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-20 sm:py-24 lg:py-32">
             <div className="max-w-3xl mx-auto text-center">
-              <img src={logo} className="w-36 h-24 mx-auto pb-8" />
+              <img src={logo} alt="로고" className="w-36 h-24 mx-auto pb-8" />
               <p className="text-[#000] text-center text-6xl font-extrabold font-sans leading-[normal] whitespace-pre-line">
                 {`TrouBlog에 오신 걸
                 환영합니다!`}

--- a/src/pages/Onboarding/IntroLandingPage.tsx
+++ b/src/pages/Onboarding/IntroLandingPage.tsx
@@ -4,6 +4,7 @@ import { PATH } from "@/shared/config/paths";
 import HeaderLogoOnly from "@/layouts/Header/HeaderLogoOnly";
 import { FiChevronDown } from "react-icons/fi";
 
+import logo from "@/assets/icons/logo.svg";
 import HeroMock from "@/assets/images/intro/hero_mock.png";
 import GuideComposite from "@/assets/images/intro/guide_composite.png";
 
@@ -14,6 +15,7 @@ import SampleDocBlog from "@/assets/images/intro/sample_doc_blog.png";
 import SampleDocIssue from "@/assets/images/intro/sample_doc_issue.png";
 
 import LaptopSide from "@/assets/images/intro/laptop_side.png";
+import Footer from "@/layouts/Footer/Footer";
 
 type TabKey = "resume" | "interview" | "blog" | "issue";
 
@@ -81,18 +83,19 @@ export default function IntroLandingPage() {
           }}
         >
           {/* 대비를 위한 옅은 오버레이 */}
-          <div
-            className="absolute inset-0 bg-white/65 sm:bg-white/55"
-            aria-hidden
-          />
+          <div aria-hidden />
           <div className="relative mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-20 sm:py-24 lg:py-32">
             <div className="max-w-3xl mx-auto text-center">
-              <h1 className="text-head-48">TrouBlog에 오신 걸 환영합니다!</h1>
-              <p className="mt-5 text-body-20-regular text-gray-700 leading-relaxed sm:leading-8 whitespace-pre-line">
+              <img src={logo} className="w-36 h-24 mx-auto pb-8" />
+              <p className="text-[#000] text-center text-6xl font-extrabold font-sans leading-[normal] whitespace-pre-line">
+                {`TrouBlog에 오신 걸
+                환영합니다!`}
+              </p>
+              <p className="mt-5 text-var(--Gray4, #525252) text-center text-xl font-medium leading-[normal] whitespace-pre-line">
                 {`개발자의 문제 해결 기록이 성장으로 이어지는 곳
-버그, 이슈, 막막했던 순간들...
-그저 넘겼던 문제 해결 과정을 이제는 구조적으로 기록하고,
-이력서, 면접, 블로그, 이슈관리에 바로 활용할 수 있는 요약본까지 자동 생성해드립니다.`}
+                버그, 이슈, 막막했던 순간들...
+                그저 넘겼던 문제 해결 과정을 이제는 구조적으로 기록하고,
+                이력서, 면접, 블로그, 이슈관리에 바로 활용할 수 있는 요약본까지 자동 생성해드립니다.`}
               </p>
 
               {/* 스크롤 버튼 (아랫단으로만 이동) */}
@@ -119,36 +122,29 @@ export default function IntroLandingPage() {
         </section>
 
         {/* ================== 2) GUIDE ================== */}
-        <section
-          ref={nextSectionRef}
-          className="bg-gradient-to-b from-white via-[#F4ECFF] to-[#E6D4FF]"
-        >
-          <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-16 sm:py-20 lg:py-28 grid lg:grid-cols-2 gap-12 items-center">
+        <section ref={nextSectionRef}>
+          <div className="flex-row mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-20 sm:py-24 lg:py-32 justify-center items-center">
             <div className="order-2 lg:order-1">
+              <div className="order-1 lg:order-2 text-left space-y-5 sm:space-y-6 lg:pl-16 xl:pl-24">
+                <p className="pb-8 pr-20 text-center text-head-48">
+                  쉽고 명확하게 작성해 보세요!
+                </p>
+              </div>
+
               <img
                 src={GuideComposite}
                 alt="작성 가이드/체크리스트"
-                className="w-full h-auto rounded-2xl"
+                className="w-[55rem] mx-auto"
                 loading="lazy"
               />
-            </div>
-
-            <div className="order-1 lg:order-2 text-left space-y-5 sm:space-y-6 lg:pl-16 xl:pl-24">
-              <h2 className="text-head-32-bold text-primary whitespace-pre-line leading-relaxed sm:leading-9">{`쉽고 
-명확하게
-작성해 보세요!`}</h2>
-              <p className="text-body-20-regular text-gray-600 leading-relaxed sm:leading-8 whitespace-pre-line">
-                {`트러블로그가 트러블슈팅 해결을 위한
-가이드를 제공해드려요!`}
-              </p>
             </div>
           </div>
         </section>
 
         {/* ================== 3) FORMATS: 탭 버튼 + 매핑 샘플 ================== */}
         <section className="py-16 sm:py-20 lg:py-28">
-          <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8">
-            <h3 className="text-center text-head-32-bold">
+          <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 py-20 sm:py-24 lg:py-32">
+            <h3 className="text-center text-head-48">
               트러블로그를 통해 문제 해결 경험을 원하는 형식으로 정리해보세요!
             </h3>
 
@@ -161,65 +157,63 @@ export default function IntroLandingPage() {
                     key={key}
                     onClick={() => setActiveTab(key)}
                     className={[
-                      "px-4 sm:px-5 py-3 rounded-xl border transition",
+                      "justify-between w-60 h-28 pl-5 rounded-xl transition",
                       "text-left",
                       active
-                        ? "bg-primary text-white border-primary shadow-[0_8px_20px_rgba(155,93,224,0.20)]"
-                        : "bg-white text-gray-800 border-gray-200 hover:bg-gray-50",
+                        ? "bg-white border border-[#B8B8B8]"
+                        : "bg-[#EFEFEF]",
                     ].join(" ")}
                     aria-pressed={active}
                   >
-                    <div className="text-body-16-semibold">{title}</div>
-                    <div className={active ? "text-white/90" : "text-gray-500"}>
-                      {desc}
-                    </div>
+                    <div className="text-head-20-semibold pb-1">{title}</div>
+                    <div className="text-body-16-regular">{desc}</div>
                   </button>
                 );
               })}
             </div>
 
             {/* 샘플 문서 프리뷰 (탭에 따라 이미지 교체) */}
-            <div className="mt-10 sm:mt-14">
-              <div className="rounded-[20px] border border-gray-200 bg-white shadow-[0_10px_30px_rgba(0,0,0,0.08)] p-4 sm:p-6">
-                <img
-                  src={SAMPLE_BY_TAB[activeTab]}
-                  alt={`${TABS.find((t) => t.key === activeTab)?.title} 샘플`}
-                  className="w-full h-auto rounded-[14px]"
-                  loading="lazy"
-                />
-              </div>
+            <div className="mt-8 sm:mt-10">
+              <img
+                src={SAMPLE_BY_TAB[activeTab]}
+                alt={`${TABS.find((t) => t.key === activeTab)?.title} 샘플`}
+                className="w-[65rem] mx-auto"
+                loading="lazy"
+              />
             </div>
           </div>
         </section>
 
         {/* ================== 4) CTA ================== */}
         <section className="relative overflow-hidden py-20 sm:py-24 lg:py-28">
-          <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 grid lg:grid-cols-2 gap-10 items-center">
-            <div className="space-y-6 sm:space-y-7">
-              <h3 className="text-head-32-bold">지금 시작해보세요!</h3>
-              <p className="text-body-16-regular text-gray-600 whitespace-pre-line leading-relaxed sm:leading-7">
+          <div className="mx-auto max-w-screen-2xl px-6 sm:px-8 md:px-12 grid lg:grid-cols-2 items-center">
+            <div className="space-y-6 sm:space-y-7 pl-40">
+              <p className="text-[#000] text-left text-6xl font-extrabold font-sans leading-[normal]">
+                지금 시작해보세요!
+              </p>
+              <p className="mt-5 text-var(--Gray4, #525252) text-left text-xl font-medium leading-[normal] whitespace-pre-line">
                 {`버튼을 눌러 첫 기록을 남겨보세요.
-기록을 시작하면, 원하시는 형식으로 정리해드려요.`}
+                기록을 시작하면, 원하시는 형식으로 정리해드려요.`}
               </p>
               <button
                 onClick={() => nav(PATH.LOGIN)}
-                className="inline-flex h-12 items-center rounded-xl bg-primary px-6 text-white text-body-16-semibold hover:opacity-90 transition"
+                className="inline-flex h-12 items-center rounded-xl bg-primary px-6 text-white text-body-20-regular hover:opacity-90 transition"
               >
-                시작하기
+                트러블로그 작성하러 가기
               </button>
             </div>
 
-            <div className="w-full">
-              <img
-                src={LaptopSide}
-                alt="노트북 목업"
-                className="w-full h-auto"
-                loading="lazy"
-              />
-            </div>
+            <img
+              src={LaptopSide}
+              alt="노트북 목업"
+              className="w-30 h-auto pb-20"
+              loading="lazy"
+            />
           </div>
         </section>
       </main>
+
+      <Footer />
     </div>
   );
 }

--- a/src/shared/config/paths.ts
+++ b/src/shared/config/paths.ts
@@ -5,6 +5,7 @@ export const PATH = {
   SIGNUP: "/signup",
   SIGNUP_DETAIL: "/signup/detail",
   TERMS: "/signup/terms",
+  TERMS_FOOTER: "/terms",
   SIGNUP_OAUTH: "/signup/oauth",
   OAUTH_REGISTER: "/auth/oauth-register",
 

--- a/src/shared/ui/Modal/KakaoLinkConfirmModal.tsx
+++ b/src/shared/ui/Modal/KakaoLinkConfirmModal.tsx
@@ -1,0 +1,42 @@
+import kakaoLogoIcon from "@/assets/icons/kakaologo.svg";
+import BaseModal from "./BaseModal";
+
+type Props = {
+  open: boolean;
+  email?: string;
+  onClose: () => void;
+  onLink: () => void; // "카카오 연동하기"
+};
+
+export default function KakaoLinkConfirmModal({
+  open,
+  email = "user@example.com",
+  onClose,
+  onLink,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <BaseModal onClose={onClose} width="w-[min(526px)]" className="py-12 px-24">
+      <div className="w-full text-center space-y-4">
+        <h3 className="text-head-32-bold">이미 가입된 이메일입니다.</h3>
+
+        <p className="text-body-16-regular">
+          <span className="font-semibold">{email}</span> 이메일로 이미 계정이
+          존재합니다.
+          <br />
+          “기존 계정과 카카오 계정을 연결하시겠습니까?”
+        </p>
+
+        <button
+          type="button"
+          onClick={onLink}
+          className="mx-auto mt-4 flex w-44 h-12 py-4 items-center justify-center gap-[0.63rem] rounded-[999px] bg-[#FEE500] hover:brightness-95 active:scale-[0.99] transition"
+        >
+          <img src={kakaoLogoIcon} alt="kakao" className="w-5 h-5" />
+          <span className="text-head-20-semibold">카카오 연동하기</span>
+        </button>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/shared/ui/Modal/KakaoLinkDoneModal.tsx
+++ b/src/shared/ui/Modal/KakaoLinkDoneModal.tsx
@@ -1,0 +1,31 @@
+import BaseModal from "./BaseModal";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onGoLogin: () => void; // "로그인하기"
+};
+
+export default function KakaoLinkDoneModal({
+  open,
+  onClose,
+  onGoLogin,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <BaseModal onClose={onClose} width="w-[min(526px)]" className="py-12 px-24">
+      <div className="w-full text-center space-y-6">
+        <h3 className="text-head-32-bold">연동이 완료되었습니다.</h3>
+
+        <button
+          type="button"
+          onClick={onGoLogin}
+          className="mx-auto flex bg-primary text-white w-44 h-12 py-4 items-center justify-center rounded-[999px] hover:brightness-110 active:scale-[0.99] transition"
+        >
+          로그인하기
+        </button>
+      </div>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## ✅ What to do

- [x] 온보딩 UI 수정
- [x] 일반 회원가입 시 이메일 중복 -> 카카오로그인 버튼 띄우기
- [x] 카카오 로그인 시 이메일 중복 -> 통합 로그인 모달창 (모달창 UI만 따로 구현)
- [x] 푸터에 연결할 이용약관 페이지 UI 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카카오 소셜 로그인 흐름 추가
  * 약관·개인정보 전용 페이지 및 라우트 추가
  * 이메일 중복 시 카카오 연동 유도 및 연동 확인/완료 모달 추가

* **사용성 개선**
  * 입력 필드 오류 메시지에 액션 버튼 추가(오류 상황에서 대체 동작 제공)
  * 랜딩 페이지에 로고·푸터 추가 및 이미지 중심 레이아웃 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->