### PR TITLE
FIX: 에러 해결

### DIFF
--- a/src/entities/trouble/ui/TroubleShootingCard.tsx
+++ b/src/entities/trouble/ui/TroubleShootingCard.tsx
@@ -178,7 +178,7 @@ const TroubleShootingCard = ({
             <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
               <TagList tags={tags} variant="mypage" />
               <div className="flex items-center gap-3">
-                {!isSearchResult && importance !== undefined && (
+                {isMine && !isSearchResult && importance !== undefined && (
                   <div className="flex items-center gap-1">
                     <img
                       src={starIcon}

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -98,8 +98,7 @@ export default function ProjectDetailPage() {
       : s === "created"
       ? "SUMMARIZED"
       : ("WRITING" as const);
-  const toApiSort = (s: SortUI) =>
-    s === "latest" ? "LATEST" : ("LIKES" as const);
+  const toApiSort = (s: SortUI) => (s === "latest" ? "LATEST" : "IMPORTANT");
   const toApiVisibility = (v: VisibilityOption) =>
     v === "공개" ? "PUBLIC" : v === "비공개" ? "PRIVATE" : "ALL";
 


### PR DESCRIPTION
## ✅ What to do

- [x] 다른 사용자의 마이페이지에서는 중요도 표시 삭제
- [x] 프로젝트 폴더 내 중요도순 정렬 API url 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **중요도 배지 표시 범위 제한**: 사용자가 작성한 게시물에서만 중요도 배지가 표시됩니다. 이전에는 검색 결과가 아닌 모든 게시물에 표시되었습니다.
* **정렬 옵션 변경**: 최신순이 아닌 정렬 옵션 선택 시 '좋아요' 대신 '중요도' 기준으로 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->