### PR TITLE
feat: 카카오 통합 계정 연동 화면 구현

### DIFF
--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -16,6 +16,7 @@ const IntroLandingPage = lazy(
 const LoginPage = lazy(() => import("@/pages/Login/LoginPage"));
 const SignPageOne = lazy(() => import("@/pages/Login/SignPageOne"));
 const SignPageTwo = lazy(() => import("@/pages/Login/SignPageTwo"));
+const CombineSignPage = lazy(() => import("@/pages/Login/CombineSignPage"));
 
 const TermsDetailPage = lazy(() => import("@/pages/Login/TermsDetailPage"));
 const SignPageOauth = lazy(() => import("@/pages/Login/SignPageOauth"));
@@ -69,6 +70,7 @@ export const router = createBrowserRouter(
     { path: PATH.TERMS, element: <TermsDetailPage /> },
     { path: PATH.TERMS_FOOTER, element: <TermsPublicPage /> },
     { path: PATH.SIGNUP_OAUTH, element: <SignPageOauth /> },
+    { path: PATH.COMBINE_SIGNUP, element: <CombineSignPage /> },
 
     // 콜백 브릿지
     { path: PATH.OAUTH_REGISTER, element: <OAuthPopupKakao /> },

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1085,35 +1085,67 @@ export default function FreeFormWritePage() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="제목을 입력하세요."
-                className="text-2xl sm:text-3xl md:text-4xl font-bold text-black outline-none w-full leading-tight"
+                className="text-3xl sm:text-4xl md:text-5xl font-bold text-black outline-none w-full leading-tight"
               />
               <div className="flex w-full max-w-[1200px] justify-between gap-3 flex-wrap">
-                <div className="flex gap-3 items-center flex-wrap w-full lg:w-auto">
-                  {/* 프로젝트 선택 */}
-                  <DropDownButton
-                    options={projectNames}
-                    placeholder={
-                      projectsLoading
-                        ? "프로젝트 불러오는 중..."
-                        : projectNameById(selectedProjectIdPage) ||
-                          "프로젝트를 선택하세요"
-                    }
-                    width="w-full sm:w-[160px] lg:w-[200px]"
-                    onSelect={(name) =>
-                      setSelectedProjectIdPage(nameToId.get(name) ?? null)
-                    }
-                  />
+                <div className="flex flex-col gap-4 w-full">
+                  <div className="flex items-end justify-between">
+                    <div className="flex gap-3 items-center flex-wrap w-full lg:w-auto">
+                      {/* 프로젝트 선택 */}
+                      <DropDownButton
+                        options={projectNames}
+                        placeholder={
+                          projectsLoading
+                            ? "프로젝트 불러오는 중..."
+                            : projectNameById(selectedProjectIdPage) ||
+                              "프로젝트를 선택하세요"
+                        }
+                        width="w-full sm:w-[200px] lg:w-[220px]"
+                        onSelect={(name) =>
+                          setSelectedProjectIdPage(nameToId.get(name) ?? null)
+                        }
+                      />
 
-                  {/* 에러 종류 */}
-                  <DropDownButton
-                    options={errorOptions}
-                    placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
-                    width="w-full sm:w-[200px] lg:w-[240px]"
-                    onSelect={(selectedError) =>
-                      setSelectedErrorType(selectedError)
-                    }
-                  />
+                      {/* 에러 종류 */}
+                      <DropDownButton
+                        options={errorOptions}
+                        placeholder={
+                          selectedErrorType ?? "에러 종류를 선택하세요"
+                        }
+                        width="w-full sm:w-[200px] lg:w-[240px]"
+                        onSelect={(selectedError) =>
+                          setSelectedErrorType(selectedError)
+                        }
+                      />
+                    </div>
 
+                    <div className="flex gap-2 w-full lg:w-auto">
+                      <div className="flex flex-col sm:flex-row gap-2 w-full lg:w-auto">
+                        <button
+                          onClick={async () => {
+                            if (!canSave) {
+                              setShowAlert(true);
+                              setTimeout(() => setShowAlert(false), 1000);
+                              return;
+                            }
+                            await handleGlobalSave();
+                          }}
+                          disabled={isSaving || (isResume && !detailLoaded)}
+                          className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100 disabled:opacity-50 w-full sm:w-auto"
+                        >
+                          Save
+                        </button>
+
+                        <button
+                          onClick={handleEnd}
+                          disabled={isResume && !detailLoaded}
+                          className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600 w-full sm:w-auto"
+                        >
+                          End
+                        </button>
+                      </div>
+                    </div>
+                  </div>
                   {/* 태그 */}
                   <div className="w-full sm:w-auto min-w-[200px]">
                     <CategoryTag
@@ -1122,40 +1154,13 @@ export default function FreeFormWritePage() {
                     />
                   </div>
                 </div>
-
-                <div className="flex gap-2 w-full lg:w-auto">
-                  <div className="flex flex-col sm:flex-row gap-2 w-full lg:w-auto">
-                    <button
-                      onClick={async () => {
-                        if (!canSave) {
-                          setShowAlert(true);
-                          setTimeout(() => setShowAlert(false), 1000);
-                          return;
-                        }
-                        await handleGlobalSave();
-                      }}
-                      disabled={isSaving || (isResume && !detailLoaded)}
-                      className="px-4 py-2 border border-gray-200 rounded-xl text-sm text-purple-500 hover:bg-gray-100 disabled:opacity-50 w-full sm:w-auto"
-                    >
-                      Save
-                    </button>
-
-                    <button
-                      onClick={handleEnd}
-                      disabled={isResume && !detailLoaded}
-                      className="px-4 py-2 bg-purple-500 text-white rounded-xl text-sm hover:bg-purple-600 w-full sm:w-auto"
-                    >
-                      End
-                    </button>
-                  </div>
-                </div>
               </div>
             </div>
 
             {/* 블록 리스트 */}
             {blocks.map((block) => (
               <div key={block.id} className="w-full">
-                <div className="w-full flex items-end h-[60px] mb-2">
+                <div className="w-full flex items-end h-[50px] mb-2">
                   <input
                     type="text"
                     value={block.title}

--- a/src/pages/Login/CombineSignPage.tsx
+++ b/src/pages/Login/CombineSignPage.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import Input from "./Input";
+import onboarding_image from "../../assets/images/onboarding_image.png";
+import { postEmailCheck } from "@/api/auth.api";
+
+const CombineSignPage = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [emailError, setEmailError] = useState<{
+    message: string;
+    action?: string;
+  } | null>(null);
+
+  const [passwordError, setPasswordError] = useState("");
+  const [formError, setFormError] = useState("");
+  const [isFormValid, setIsFormValid] = useState(false);
+  const navigate = useNavigate();
+
+  //   const AUTH_START_URL = useMemo(() => {
+  //     const base = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+  //     const callback = `${window.location.origin}${base}${PATH.OAUTH_REGISTER}`;
+  //     return `https://troublog.shop/oauth2/authorization/kakao?return_to=${encodeURIComponent(
+  //       callback
+  //     )}`;
+  //   }, []);
+
+  // 폼 전체 유효성 체크
+  useEffect(() => {
+    setIsFormValid(email.trim() !== "" && password.trim() !== "");
+  }, [email, password]);
+
+  const validateForm = () => {
+    let valid = true;
+
+    setEmailError(null);
+    setPasswordError("");
+    setFormError("");
+
+    if (!email) {
+      setEmailError({ message: "이메일을 입력해주세요." });
+      valid = false;
+    }
+
+    if (!password) {
+      setPasswordError("비밀번호를 입력해주세요.");
+      valid = false;
+    }
+
+    return valid;
+  };
+
+  // 이메일 확인: 연동 조건 (DB에 존재해야 OK)
+  const handleEmailBlur = async () => {
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail) {
+      setEmailError({ message: "이메일을 입력해주세요." });
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(trimmedEmail)) {
+      setEmailError({ message: "유효한 이메일 형식을 입력해주세요." });
+      return;
+    }
+
+    setEmailError(null);
+
+    try {
+      // 200이면 가입된 이메일이 아님 → 연동 불가
+      await postEmailCheck(trimmedEmail);
+
+      setEmailError({
+        message: "가입된 이메일이 아닙니다. 기존 계정으로 먼저 가입해주세요.",
+      });
+    } catch (error: any) {
+      if (error.response?.status === 409) {
+        // 이메일이 이미 존재 → 연동 가능
+        setEmailError(null);
+      } else {
+        setEmailError({
+          message: "이메일 확인 중 오류가 발생했습니다.",
+        });
+      }
+    }
+  };
+
+  const handlePasswordBlur = () => {
+    setPasswordError(password.trim() ? "" : "비밀번호를 입력해주세요.");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    navigate("/signup/detail", {
+      state: { email, password },
+    });
+  };
+
+  return (
+    <div className="flex w-screen h-screen overflow-hidden">
+      <img src={onboarding_image} className="w-1/2 h-full object-fill" />
+
+      <div className="w-full lg:w-1/2 h-full scale-[0.8] px-6 sm:px-16 lg:px-[200px] py-12 sm:py-24 lg:py-[281px] flex flex-col justify-center items-center">
+        <div className="w-full max-w-[560px] flex flex-col items-center gap-10">
+          <h2 className="text-black text-3xl sm:text-4xl lg:text-[36px] font-bold w-full font-pretendard">
+            카카오 통합회원 연동
+          </h2>
+
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col items-start gap-4 w-full"
+          >
+            <div className="flex flex-col items-start w-full">
+              <Input
+                label="이메일"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onBlur={handleEmailBlur}
+                placeholder="이메일을 입력해주세요."
+                error={emailError?.message}
+              />
+
+              <Input
+                label="비밀번호"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onBlur={handlePasswordBlur}
+                placeholder="비밀번호를 입력해주세요."
+                error={passwordError}
+              />
+            </div>
+
+            {formError && (
+              <p className="text-red-500 text-[16px] mt-1">{formError}</p>
+            )}
+
+            <div className="flex flex-col items-start gap-4 w-full">
+              <button
+                type="submit"
+                disabled={!isFormValid || !!emailError}
+                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-50"
+              >
+                <span className="text-white text-[20px] font-semibold font-pretendard">
+                  완료
+                </span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CombineSignPage;

--- a/src/pages/Login/SignPageOne.tsx
+++ b/src/pages/Login/SignPageOne.tsx
@@ -6,12 +6,18 @@ import { postEmailCheck } from "@/api/auth.api";
 import { PATH } from "@/shared/config/paths";
 
 const EMAIL_DUP_MSG = "이미 가입된 이메일 입니다!";
+const KAKAO_COMBINE_LINK = "카카오로 로그인하기";
 
 const SignPageOne = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordcf, setPasswordcf] = useState("");
-  const [emailError, setEmailError] = useState("");
+
+  const [emailError, setEmailError] = useState<{
+    message: string;
+    action?: string;
+  } | null>(null);
+
   const [passwordError, setPasswordError] = useState("");
   const [passwordcfError, setPasswordcfError] = useState("");
   const [formError, setFormError] = useState("");
@@ -30,24 +36,28 @@ const SignPageOne = () => {
     window.location.href = AUTH_START_URL;
   };
 
+  // 폼 전체 유효성 체크
   useEffect(() => {
     const valid =
       email.trim() !== "" &&
       password.trim() !== "" &&
       passwordcf.trim() !== "" &&
       password === passwordcf;
+
     setIsFormValid(valid);
   }, [email, password, passwordcf]);
 
+  // 폼 제출 유효성
   const validateForm = () => {
     let valid = true;
-    setEmailError("");
+
+    setEmailError(null);
     setPasswordError("");
     setPasswordcfError("");
     setFormError("");
 
     if (!email) {
-      setEmailError("이메일을 입력해주세요.");
+      setEmailError({ message: "이메일을 입력해주세요." });
       valid = false;
     }
     if (!password) {
@@ -66,33 +76,36 @@ const SignPageOne = () => {
     return valid;
   };
 
+  // 이메일 중복 + 형식 체크
   const handleEmailBlur = async () => {
     const trimmedEmail = email.trim();
 
-    // 1) 빈 이메일
     if (!trimmedEmail) {
-      setEmailError("이메일을 입력해주세요.");
+      setEmailError({ message: "이메일을 입력해주세요." });
       return;
     }
 
-    // 2) 이메일 형식 유효성
+    // 이메일 형식 검사
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(trimmedEmail)) {
-      setEmailError("유효한 이메일 형식을 입력해주세요.");
+      setEmailError({ message: "유효한 이메일 형식을 입력해주세요." });
       return;
     }
 
-    // 형식이 맞으면 에러 초기화
-    setEmailError("");
+    // 문제 없으면 일단 초기화
+    setEmailError(null);
 
     try {
       await postEmailCheck(trimmedEmail);
-      setEmailError(""); // 중복 아님
+      setEmailError(null); // 중복 아님
     } catch (error: any) {
       if (error.response?.status === 409) {
-        setEmailError(EMAIL_DUP_MSG);
+        setEmailError({
+          message: EMAIL_DUP_MSG,
+          action: KAKAO_COMBINE_LINK, // 우측 버튼 label
+        });
       } else {
-        setEmailError("이메일 확인 중 오류가 발생했습니다.");
+        setEmailError({ message: "이메일 확인 중 오류가 발생했습니다." });
       }
     }
   };
@@ -122,19 +135,19 @@ const SignPageOne = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!validateForm()) return;
+
     navigate("/signup/detail", {
-      state: {
-        email,
-        password,
-      },
+      state: { email, password },
     });
   };
 
-  const isEmailDuplicate = emailError === EMAIL_DUP_MSG;
+  // 중복 이메일 여부 판별 (message 기반)
+  const isEmailDuplicate = emailError?.message === EMAIL_DUP_MSG;
 
   return (
     <div className="flex w-screen h-screen overflow-hidden">
       <img src={onboarding_image} className="w-1/2 h-full object-fill" />
+
       <div className="w-full lg:w-1/2 h-full scale-[0.8] px-6 sm:px-16 lg:px-[200px] py-12 sm:py-24 lg:py-[281px] flex flex-col justify-center items-center">
         <div className="w-full max-w-[560px] flex flex-col items-center gap-10">
           <h2 className="text-black text-3xl sm:text-4xl lg:text-[36px] font-bold w-full font-pretendard">
@@ -153,15 +166,15 @@ const SignPageOne = () => {
                 onChange={(e) => setEmail(e.target.value)}
                 onBlur={handleEmailBlur}
                 placeholder="이메일을 입력해주세요."
-                error={emailError}
-                // 409(중복)일 때만 우측에 텍스트 버튼 노출
+                error={emailError?.message} // 문자열만 전달
                 errorActionLabel={
-                  isEmailDuplicate ? "카카오로 로그인하기" : undefined
+                  isEmailDuplicate ? KAKAO_COMBINE_LINK : undefined
                 }
                 onErrorActionClick={
                   isEmailDuplicate ? handleKakaoLogin : undefined
                 }
               />
+
               <Input
                 label="비밀번호"
                 type="password"
@@ -171,6 +184,7 @@ const SignPageOne = () => {
                 placeholder="비밀번호를 입력해주세요."
                 error={passwordError}
               />
+
               <Input
                 label="비밀번호 확인"
                 type="password"

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1057,40 +1057,40 @@ const TempWritePage = () => {
               placeholder="제목을 입력하세요."
               className="w-[1100px] md:w-[870px] text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-black outline-none leading-tight placeholder:text-neutral-400"
             />
+            <div className="flex flex-col gap-4">
+              <div className="flex gap-5 items-center flex-wrap w-full lg:w-auto ">
+                <DropDownButton
+                  options={projectNames}
+                  placeholder={
+                    projectsLoading
+                      ? "프로젝트 불러오는 중..."
+                      : projectNameById(selectedProjectIdPage) ||
+                        "프로젝트를 선택하세요"
+                  }
+                  width="w-full sm:w-[200px] md:w-[220px]"
+                  onSelect={(name: string) =>
+                    setSelectedProjectIdPage(nameToId.get(name) ?? null)
+                  }
+                />
 
-            <div className="flex gap-5 items-center flex-wrap w-full lg:w-auto ">
-              <DropDownButton
-                options={projectNames}
-                placeholder={
-                  projectsLoading
-                    ? "프로젝트 불러오는 중..."
-                    : projectNameById(selectedProjectIdPage) ||
-                      "프로젝트를 선택하세요"
-                }
-                width="w-full sm:w-[160px] lg:w-[200px]"
-                onSelect={(name: string) =>
-                  setSelectedProjectIdPage(nameToId.get(name) ?? null)
-                }
-              />
-
-              <DropDownButton
-                options={[
-                  "Build/Compile Error",
-                  "Runtime Error",
-                  "Dependency/Version Error",
-                  "Network/API Error",
-                  "Authentication/Authorization Error",
-                  "Database Error",
-                  "UI/Rendering Error",
-                  "Configuration Error",
-                  "Timeout/Error Handling",
-                  "Third-Party Library Error",
-                ]}
-                placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
-                width="w-full sm:w-[200px] lg:w-[240px]"
-                onSelect={(v: string) => setSelectedErrorType(v)}
-              />
-
+                <DropDownButton
+                  options={[
+                    "Build/Compile Error",
+                    "Runtime Error",
+                    "Dependency/Version Error",
+                    "Network/API Error",
+                    "Authentication/Authorization Error",
+                    "Database Error",
+                    "UI/Rendering Error",
+                    "Configuration Error",
+                    "Timeout/Error Handling",
+                    "Third-Party Library Error",
+                  ]}
+                  placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
+                  width="w-full sm:w-[200px] lg:w-[240px]"
+                  onSelect={(v: string) => setSelectedErrorType(v)}
+                />
+              </div>
               <div className="w-full sm:w-auto min-w-[200px]">
                 <CategoryTag value={selectedTags} onChange={setSelectedTags} />
               </div>

--- a/src/shared/config/paths.ts
+++ b/src/shared/config/paths.ts
@@ -8,6 +8,7 @@ export const PATH = {
   TERMS_FOOTER: "/terms",
   SIGNUP_OAUTH: "/signup/oauth",
   OAUTH_REGISTER: "/auth/oauth-register",
+  COMBINE_SIGNUP: "/signup/combine",
 
   USER: "/user",
   HOME: "/user/home",


### PR DESCRIPTION
## ✅ What to do

- [x] 회원가입 창에서 이미 가입된 회원일 경우 카카오 로그인으로 유도
- [x] 카카오 일반 계정 통합하는 화면 구현
- [x] 작성화면 태그 overflow 개선

## 📄 Description

**CombineSignPage.tsx**
- 일반 회원가입으로 가입한 사용자가 카카오로 간편 로그인을 하고자할때 이어지는 화면입니다.
- 카카오 자체 로그인시에 가입된 사용자라고 확인이 될경우 위 페이지로 다이렉팅됩니다

**회원가입창에서 중복 이메일시 카카오로 로그인 버튼**

- 일반 회원가입창에서 이메일 중복일 경우 카카오로 로그인하기라는 버튼이 활성화 된다고 피그마에 나와있는데 ... 중복된 이메일이라고해서 카카오 가입자인건지 일반 가입자이건지 모르기에 중복 이메일일 경우 무조건 카카오 로그인하기라고 표시해두면 안됩니다. 그래서 이부분 재현님과 상의후 재현님이 이메일 중복 api에서 카카오/일반 가입자 표시 여부를 보내주시기로 했고, 제가 추후에 카카오 가입자의 중복이메일일 경우에만 위 버튼이 표시되도록 구현해 두기로 했습니다.
<img width="985" height="542" alt="스크린샷 2025-11-14 20 30 36" src="https://github.com/user-attachments/assets/07df158e-e1d3-4041-82c1-795a924905b1" />

## 🤔 Considerations


## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Kakao 통합 회원가입을 위한 신규 가입 페이지 추가 및 새 경로(/signup/combine) 추가

* **Bug Fixes**
  * 이메일 형식 및 중복 검증 개선, 중복 시 사용자 안내(액션 라벨) 처리 향상

* **Style**
  * 작성 페이지들(자유/임시 작성) 상단 컨트롤 레이아웃 재구성 및 제목/드롭다운 스타일 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->