### PR TITLE
FIX: 글작성시 next버튼 포커싱 오류 수정, 제목 두줄로 변경 

### DIFF
--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1079,18 +1079,25 @@ export default function FreeFormWritePage() {
 
             {/* 제목/태그 + 상단 액션바 */}
             <div className="flex flex-col items-start gap-[40px]">
-              <input
-                ref={titleInputRef}
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="제목을 입력하세요."
-                className="text-3xl sm:text-4xl md:text-5xl font-bold text-black outline-none w-full leading-tight"
-              />
+              <div
+                contentEditable
+                spellCheck={false}
+                suppressContentEditableWarning
+                onInput={(e) => setTitle(e.currentTarget.textContent || "")}
+                data-placeholder="제목을 입력하세요."
+                className="
+    title-editable
+    w-[1100px] md:w-[1030px]
+    text-2xl sm:text-3xl md:text-4xl lg:text-5xl
+    font-bold text-black outline-none leading-tight
+    whitespace-pre-wrap break-words
+    relative
+  "
+              ></div>
               <div className="flex w-full max-w-[1200px] justify-between gap-3 flex-wrap">
                 <div className="flex flex-col gap-4 w-full">
                   <div className="flex items-end justify-between">
-                    <div className="flex gap-3 items-center flex-wrap w-full lg:w-auto">
+                    <div className="flex gap-3 items-center flex-wrap max-w-[1100px] md:max-w-[900px] lg:w-auto">
                       {/* 프로젝트 선택 */}
                       <DropDownButton
                         options={projectNames}
@@ -1100,8 +1107,8 @@ export default function FreeFormWritePage() {
                             : projectNameById(selectedProjectIdPage) ||
                               "프로젝트를 선택하세요"
                         }
-                        width="w-full sm:w-[200px] lg:w-[220px]"
-                        onSelect={(name) =>
+                        width="w-full sm:w-[170px] md:w-[190px]"
+                        onSelect={(name: string) =>
                           setSelectedProjectIdPage(nameToId.get(name) ?? null)
                         }
                       />
@@ -1112,11 +1119,19 @@ export default function FreeFormWritePage() {
                         placeholder={
                           selectedErrorType ?? "에러 종류를 선택하세요"
                         }
-                        width="w-full sm:w-[200px] lg:w-[240px]"
+                        width="w-full sm:w-[180px] lg:w-[220px]"
                         onSelect={(selectedError) =>
                           setSelectedErrorType(selectedError)
                         }
                       />
+
+                      {/* 태그 */}
+                      <div className="w-full sm:w-auto min-w-[200px]">
+                        <CategoryTag
+                          value={selectedTags}
+                          onChange={setSelectedTags}
+                        />
+                      </div>
                     </div>
 
                     <div className="flex gap-2 w-full lg:w-auto">
@@ -1145,13 +1160,6 @@ export default function FreeFormWritePage() {
                         </button>
                       </div>
                     </div>
-                  </div>
-                  {/* 태그 */}
-                  <div className="w-full sm:w-auto min-w-[200px]">
-                    <CategoryTag
-                      value={selectedTags}
-                      onChange={setSelectedTags}
-                    />
                   </div>
                 </div>
               </div>

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -916,20 +916,32 @@ const TempWritePage = () => {
   const handleAddBlock = useCallback(() => {
     setBlocks((prev) => {
       const nextStep = prev.length;
-      if (nextStep >= questionData.length) return prev;
-      const stepData = questionData[nextStep];
-      const newBlock: BlockData = {
-        id: Date.now(),
-        content: "",
-        checklist: [],
-        checklistItems: stepData.checklistItems ?? [],
-        checklistTitle: stepData.title ?? "",
-        question: stepData.question,
-        isSaved: false,
-      } as any;
-      const next = [...prev, newBlock];
-      setActiveIndex(next.length - 1);
-      return next;
+
+      // 1) 아직 questionData 남아 있는 경우: 새 블록 생성
+      if (nextStep < questionData.length) {
+        const stepData = questionData[nextStep];
+        const newBlock: BlockData = {
+          id: Date.now(),
+          content: "",
+          checklist: [],
+          checklistItems: stepData.checklistItems ?? [],
+          checklistTitle: stepData.title ?? "",
+          question: stepData.question,
+          isSaved: false,
+        } as any;
+
+        const next = [...prev, newBlock];
+        setActiveIndex(next.length - 1); // 새 블록으로 포커싱
+        return next;
+      }
+
+      // 2) 이미 모든 블록이 생성된 경우
+      setActiveIndex((idx) => {
+        const nextIdx = Math.min(idx + 1, prev.length - 1);
+        return nextIdx;
+      });
+
+      return prev;
     });
   }, []);
 
@@ -1117,7 +1129,7 @@ const TempWritePage = () => {
             </div>
           </div>
 
-          <div className="flex flex-col gap-6 sm:gap-8">
+          <div className="flex flex-col pb-2">
             {reversedBlocks.map(({ block, originalIndex }) => (
               <div
                 key={block.id}

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1027,6 +1027,18 @@ const TempWritePage = () => {
     }));
   }, [blocks]);
 
+  // next 누를시에 다음 블록에 자동 포커싱
+  const blockRefs = useRef<(HTMLDivElement | null)[]>([]);
+  useEffect(() => {
+    const el = blockRefs.current[activeIndex];
+    if (el) {
+      el.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [activeIndex]);
+
   // ---------- UI ----------
   return (
     <div className="min-h-screen">
@@ -1099,30 +1111,37 @@ const TempWritePage = () => {
 
           <div className="flex flex-col gap-6 sm:gap-8">
             {reversedBlocks.map(({ block, originalIndex }) => (
-              <EditorBlock
+              <div
                 key={block.id}
-                block={block}
-                index={originalIndex}
-                isActive={originalIndex === activeIndex}
-                isLast={originalIndex === questionData.length - 1}
-                onChange={handleChangeBlockContent}
-                onToggleChecklist={handleToggleChecklist}
-                onAddBlock={handleAddBlock}
-                onEnd={handleEnd}
-                title={title}
-                selectedErrorType={selectedErrorType}
-                onShowSaveAlert={handleShowSaveAlert}
-                onShowAlert={handleShowAlert}
-                onSave={handleClickSave}
-                isSaving={isSaving}
-                canSave={canSave}
-                onActivate={(i) => setActiveIndex(i)}
-                onPasteImage={handlePasteImage}
-                onDropImage={handleDropImage}
-                commandsFilter={(cmd) =>
-                  cmd.keyCommand === "image" ? imageUploadCmd : cmd
-                }
-              />
+                ref={(el) => {
+                  blockRefs.current[originalIndex] = el;
+                }}
+              >
+                <EditorBlock
+                  key={block.id}
+                  block={block}
+                  index={originalIndex}
+                  isActive={originalIndex === activeIndex}
+                  isLast={originalIndex === questionData.length - 1}
+                  onChange={handleChangeBlockContent}
+                  onToggleChecklist={handleToggleChecklist}
+                  onAddBlock={handleAddBlock}
+                  onEnd={handleEnd}
+                  title={title}
+                  selectedErrorType={selectedErrorType}
+                  onShowSaveAlert={handleShowSaveAlert}
+                  onShowAlert={handleShowAlert}
+                  onSave={handleClickSave}
+                  isSaving={isSaving}
+                  canSave={canSave}
+                  onActivate={(i) => setActiveIndex(i)}
+                  onPasteImage={handlePasteImage}
+                  onDropImage={handleDropImage}
+                  commandsFilter={(cmd) =>
+                    cmd.keyCommand === "image" ? imageUploadCmd : cmd
+                  }
+                />
+              </div>
             ))}
           </div>
 

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1062,48 +1062,56 @@ const TempWritePage = () => {
           )}
 
           <div className="flex flex-col gap-6 sm:gap-10">
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="제목을 입력하세요."
-              className="w-[1100px] md:w-[870px] text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-black outline-none leading-tight placeholder:text-neutral-400"
-            />
-            <div className="flex flex-col gap-4">
-              <div className="flex gap-5 items-center flex-wrap w-full lg:w-auto ">
-                <DropDownButton
-                  options={projectNames}
-                  placeholder={
-                    projectsLoading
-                      ? "프로젝트 불러오는 중..."
-                      : projectNameById(selectedProjectIdPage) ||
-                        "프로젝트를 선택하세요"
-                  }
-                  width="w-full sm:w-[200px] md:w-[220px]"
-                  onSelect={(name: string) =>
-                    setSelectedProjectIdPage(nameToId.get(name) ?? null)
-                  }
-                />
+            <div
+              contentEditable
+              spellCheck={false}
+              suppressContentEditableWarning
+              onInput={(e) => setTitle(e.currentTarget.textContent || "")}
+              data-placeholder="제목을 입력하세요."
+              className="
+    title-editable
+    w-[1100px] md:w-[870px]
+    text-2xl sm:text-3xl md:text-4xl lg:text-5xl
+    font-bold text-black outline-none leading-tight
+    whitespace-pre-wrap break-words
+    relative
+  "
+            ></div>
 
-                <DropDownButton
-                  options={[
-                    "Build/Compile Error",
-                    "Runtime Error",
-                    "Dependency/Version Error",
-                    "Network/API Error",
-                    "Authentication/Authorization Error",
-                    "Database Error",
-                    "UI/Rendering Error",
-                    "Configuration Error",
-                    "Timeout/Error Handling",
-                    "Third-Party Library Error",
-                  ]}
-                  placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
-                  width="w-full sm:w-[200px] lg:w-[240px]"
-                  onSelect={(v: string) => setSelectedErrorType(v)}
-                />
-              </div>
-              <div className="w-full sm:w-auto min-w-[200px]">
+            <div className="flex gap-3 items-center flex-wrap max-w-[1100px] md:max-w-[900px] lg:w-auto ">
+              <DropDownButton
+                options={projectNames}
+                placeholder={
+                  projectsLoading
+                    ? "프로젝트 불러오는 중..."
+                    : projectNameById(selectedProjectIdPage) ||
+                      "프로젝트를 선택하세요"
+                }
+                width="w-full sm:w-[170px] md:w-[190px]"
+                onSelect={(name: string) =>
+                  setSelectedProjectIdPage(nameToId.get(name) ?? null)
+                }
+              />
+
+              <DropDownButton
+                options={[
+                  "Build/Compile Error",
+                  "Runtime Error",
+                  "Dependency/Version Error",
+                  "Network/API Error",
+                  "Authentication/Authorization Error",
+                  "Database Error",
+                  "UI/Rendering Error",
+                  "Configuration Error",
+                  "Timeout/Error Handling",
+                  "Third-Party Library Error",
+                ]}
+                placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
+                width="w-full sm:w-[180px] lg:w-[220px]"
+                onSelect={(v: string) => setSelectedErrorType(v)}
+              />
+
+              <div className="w-full sm:w-auto min-w-[180px]">
                 <CategoryTag value={selectedTags} onChange={setSelectedTags} />
               </div>
             </div>

--- a/src/shared/ui/Editor/CategoryTag.tsx
+++ b/src/shared/ui/Editor/CategoryTag.tsx
@@ -27,7 +27,7 @@ const CategoryTag = ({ value, onChange }: CategoryTagProps) => {
 
   return (
     <div className="w-full flex flex-wrap items-center gap-2 sm:gap-[15px]">
-      <div className="flex px-[15px] py-[7px] border border-gray-300 rounded-2xl items-center gap-2 w-full sm:w-[200px] md:w-[220px] flex-shrink-0">
+      <div className="flex px-[15px] py-[7px] border border-gray-300 rounded-2xl items-center gap-2 w-full sm:w-[180px] md:w-[200px] flex-shrink-0">
         <input
           type="text"
           className="w-full text-sm text-gray-700 placeholder-gray-400 outline-none"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -99,3 +99,10 @@
 .wmde-markdown li {
   display: list-item !important;
 }
+
+/* 제목용 placeholder */
+.title-editable[contenteditable][data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  @apply text-neutral-400;
+  pointer-events: none;
+}


### PR DESCRIPTION
## ✅ What to do

- [ ]  next 누를시 다음 블록 자동 포커싱
- [ ] 제목 두줄로 변경 

## 📄 Description

**next 누를시 다음 블록 자동 포커싱**
next 버튼 눌렀을때 블록이 추가만 되고 포커싱은 안되는 문제가 있었는데 수정하였습니다.

**제목 두줄로 변경**
input으로 할때는 아래 사진처럼 길어질경우 두줄 변경이 불가능해서 새로운 스타일로 수정하였습니다. ``contenteditable div`` 로 input 대체하였고 placeholder 적용 위해 global.css에 해당 css 추가했습니다.
<img width="3010" height="470" alt="image" src="https://github.com/user-attachments/assets/85e8270c-42d2-45b7-a128-3e1f78bf88e1" />


## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 작성 페이지에서 활성 블록으로 자동 스크롤 기능 추가
  * 상단 컨트롤 영역에 인라인 태그 편집기 추가

* **UI/스타일 개선**
  * 제목 입력 방식을 리치 텍스트 스타일로 개선
  * 드롭다운 및 상단 컨트롤의 반응형 레이아웃 최적화
  * 제목 필드에 플레이스홀더 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->