### PR TITLE
FEAT: 카카오 통합 연동 API 연결

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -14,6 +14,7 @@ import {
   type FindPasswordResponse,
   type CheckCodeRequest,
   type ChangePasswordRequest,
+  type KakaoIntegrationRequest,
 } from "@/models/auth.model";
 import api from "./axios";
 
@@ -115,6 +116,15 @@ export const postCheckCode = (payload: CheckCodeRequest) =>
 export const postChangePassword = (payload: ChangePasswordRequest) =>
   getAPIResponseData<string, ChangePasswordRequest>({
     url: "/auth/change-password",
+    method: "POST",
+    data: payload,
+    headers: getAuthHeaders(),
+  });
+
+// 카카오 통합 연동 API
+export const postKakaoIntegration = (payload: KakaoIntegrationRequest) =>
+  getAPIResponseData<string, KakaoIntegrationRequest>({
+    url: "/auth/integration/kakao",
     method: "POST",
     data: payload,
     headers: getAuthHeaders(),

--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -22,7 +22,7 @@ const KakaoIntegration = lazy(() => import("@/pages/Login/KakaoIntegration"));
 const TermsDetailPage = lazy(() => import("@/pages/Login/TermsDetailPage"));
 const SignPageOauth = lazy(() => import("@/pages/Login/SignPageOauth"));
 
-const OAuthPopupKakao = lazy(() => import("@/pages/Login/OAuthPopupKakao"));
+// const OAuthPopupKakao = lazy(() => import("@/pages/Login/OAuthPopupKakao"));
 
 const FindPassword = lazy(() => import("@/pages/Login/FindPassword"));
 
@@ -74,10 +74,10 @@ export const router = createBrowserRouter(
     { path: PATH.TERMS_FOOTER, element: <TermsPublicPage /> },
     { path: PATH.SIGNUP_OAUTH, element: <SignPageOauth /> },
     { path: PATH.COMBINE_SIGNUP, element: <CombineSignPage /> },
-    { path: PATH.KAKAO_INTEGRATION, element: <KakaoIntegration /> },
+    // { path: PATH.KAKAO_INTEGRATION, element: <KakaoIntegration /> },
 
     // 콜백 브릿지
-    { path: PATH.OAUTH_REGISTER, element: <OAuthPopupKakao /> },
+    { path: PATH.OAUTH_REGISTER, element: <KakaoIntegration /> },
 
     // 비밀번호 찾기
     { path: PATH.FIND_PASSWORD, element: <FindPassword /> },

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -120,3 +120,11 @@ export interface ChangePasswordRequest {
   email: string;
   password: string;
 }
+
+// 카카오 통합
+export interface KakaoIntegrationRequest {
+  email: string;
+  password: string;
+  socialId: string;
+  proflImgUrl: string;
+}

--- a/src/pages/Login/KakaoIntegration.tsx
+++ b/src/pages/Login/KakaoIntegration.tsx
@@ -7,9 +7,14 @@ import { postKakaoIntegration } from "@/api/auth.api";
 
 type Step = "confirm" | "input" | "complete";
 
+interface KakaoIntegrationLocationState {
+  socialId?: string;
+  profileImgUrl?: string;
+}
+
 const KakaoIntegration = () => {
   const navigate = useNavigate();
-  const location = useLocation() as any;
+  const location = useLocation() as { state?: KakaoIntegrationLocationState };
 
   // 카카오 로그인 단계어서 넘겨주는 정보
   const socialId: string = location?.state?.socialId ?? "";

--- a/src/pages/Login/KakaoIntegration.tsx
+++ b/src/pages/Login/KakaoIntegration.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import Input from "./Input";
 import onboarding_image from "../../assets/images/onboarding_image.png";
 import { PATH } from "@/shared/config/paths";
+import { postKakaoIntegration } from "@/api/auth.api";
 
 type Step = "confirm" | "input" | "complete";
 
 const KakaoIntegration = () => {
   const navigate = useNavigate();
+  const location = useLocation() as any;
+
+  // 카카오 로그인 단계어서 넘겨주는 정보
+  const socialId: string = location?.state?.socialId ?? "";
+  const profileImgUrl: string = location?.state?.profileImgUrl ?? "";
 
   const [step, setStep] = useState<Step>("confirm");
 
@@ -73,17 +79,30 @@ const KakaoIntegration = () => {
     const pwValid = validatePassword(password);
     if (!emailValid || !pwValid) return;
 
+    if (!socialId) {
+      setFormError("카카오 계정 정보가 유효하지 않습니다. 다시 시도해주세요.");
+      return;
+    }
+
     try {
       setLoading(true);
 
-      // TODO: 이메일 + 비밀번호 검증 및 실제 연동 API
-      // await postCheckAccountAndIntegrate({ email, password });
+      await postKakaoIntegration({
+        email,
+        password,
+        socialId,
+        proflImgUrl: profileImgUrl,
+      });
 
       // 검증/연동 성공 시 3단계로 이동
       setStep("complete");
-    } catch (error) {
+    } catch (error: any) {
       console.error(error);
-      setFormError("계정 확인 중 오류가 발생했습니다.");
+
+      const message =
+        error?.response?.data?.error?.message ??
+        "계정 확인 중 오류가 발생했습니다.";
+      setFormError(message);
     } finally {
       setLoading(false);
     }

--- a/src/shared/config/paths.ts
+++ b/src/shared/config/paths.ts
@@ -9,7 +9,7 @@ export const PATH = {
   SIGNUP_OAUTH: "/signup/oauth",
   OAUTH_REGISTER: "/auth/oauth-register",
   COMBINE_SIGNUP: "/signup/combine",
-  KAKAO_INTEGRATION: "/kakao-integration",
+  // KAKAO_INTEGRATION: "/kakao-integration",
   FIND_PASSWORD: "/find-password",
 
   USER: "/user",


### PR DESCRIPTION
## ✅ What to do

- [x] 카카오 통합 연동하기 API 연결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카카오 통합 인증을 위한 신규 연동 흐름 도입 (소셜 정보 기반 통합 가입 지원)
  * 통합 가입 시 서버로 이메일·비밀번호·소셜ID·프로필 이미지 전송 지원

* **버그 수정**
  * 인증 실패 시 서버 응답을 반영한 보다 상세한 오류 메시지 제공
  * 통합 인증 흐름에서 소셜 정보 누락 시 적절한 입력 검증 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->