### PR TITLE
FIX: 최근 읽은 포스트 상세 조회 오류 해결

### DIFF
--- a/src/entities/trouble/card.mapper.ts
+++ b/src/entities/trouble/card.mapper.ts
@@ -8,11 +8,14 @@ import {
   mapVisibility,
 } from "@/entities/trouble/lib/troubleMapping";
 
-export type TroublogCardVM = TroublogCardProps & { createdAtIso: string };
+export type TroublogCardVM = TroublogCardProps & {
+  createdAtIso: string;
+  isVisible?: boolean;
+};
 
 type AnySummary = {
   summaryId?: number;
-  summaryType?: string; // "RESUME" | "INTERVIEW" | "BLOG" | "ISSUE_MANAGEMENT"
+  summaryType?: string; // "RESUME" | "INTERVIEW" | "MEMOIRS" | "ISSUE_MANAGEMENT"
   summaryCreatedAt?: string;
 };
 
@@ -54,7 +57,8 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     id: t.id,
     isMine: true, // 서버에 소유자 정보가 오면 교체
     status: mapStatus(t.status),
-    visibility: mapVisibility(t.isVisible as any), // boolean 기반이지만 호환 고려
+    visibility: mapVisibility(t.isVisible as any),
+    isVisible: typeof t.isVisible === "boolean" ? t.isVisible : undefined,
     title: t.title ?? "",
     errorCategory: t.error ?? "",
     createdAt: iso ? formatYYMMDD(iso) : "",

--- a/src/entities/trouble/mappers/communityCard.mapper.ts
+++ b/src/entities/trouble/mappers/communityCard.mapper.ts
@@ -1,16 +1,43 @@
 import type { TroublogCardProps } from "@/entities/trouble/ui/TroublogCard";
 import type { CommunityServerCard } from "@/types/community.model";
+import type { StatusType, VisibilityType } from "@/types/project";
+
+// 한글 postStatus → 내부 StatusType 매핑
+const mapStatus = (raw?: string | null): StatusType => {
+  if (!raw) return "complete";
+  switch (raw) {
+    case "작성 중":
+      return "inProgress";
+    case "작성 완료":
+      return "complete";
+    case "요약 완료":
+      return "created";
+    default:
+      return "complete";
+  }
+};
 
 export const toCommunityCard = (s: CommunityServerCard): TroublogCardProps => {
   const owner = s.postCardUserInfoResDto ?? s.userInfo ?? null;
 
   const createdAt = s.completedAt ?? s.createdAt ?? "";
 
+  // recent 응답일 때만 isVisible, postStatus가 채워져 있음
+  const visibility: VisibilityType | undefined =
+    typeof s.isVisible === "boolean"
+      ? s.isVisible
+        ? "public"
+        : "private"
+      : "public";
+
+  const status: StatusType =
+    s.postStatus != null ? mapStatus(s.postStatus) : "complete";
+
   return {
     id: s.id,
     isMine: false,
-    status: "complete",
-    visibility: "public",
+    status,
+    visibility,
     errorCategory: s.errorTag ?? "",
     title: s.title ?? "",
     createdAt,
@@ -20,6 +47,7 @@ export const toCommunityCard = (s: CommunityServerCard): TroublogCardProps => {
     likeCount: s.likeCount ?? 0,
     commentCount: s.commentCount ?? 0,
     imageUrl: s.thumbnailUrl ?? "",
+    isVisible: s.isVisible,
   };
 };
 

--- a/src/entities/trouble/ui/TroublogCard.tsx
+++ b/src/entities/trouble/ui/TroublogCard.tsx
@@ -15,6 +15,7 @@ export interface TroublogCardProps {
   isMine: boolean;
   status: StatusType;
   visibility?: VisibilityType;
+  isVisible?: boolean;
   errorCategory: string;
   title: string;
   createdAt: string;

--- a/src/pages/Community/CommunityPage.tsx
+++ b/src/pages/Community/CommunityPage.tsx
@@ -129,18 +129,34 @@ export default function CommunityPage() {
                 const qs = new URLSearchParams({ from: "community" });
                 if (ownerId != null) qs.set("ownerId", String(ownerId));
 
+                const isVisibleFromList =
+                  typeof card.isVisible === "boolean"
+                    ? card.isVisible
+                    : card.visibility === "public"
+                    ? true
+                    : card.visibility === "private"
+                    ? false
+                    : undefined;
+
+                const statePayload = {
+                  from: "community" as const,
+                  ownerId,
+                  statusFromList: card.status,
+                  isVisibleFromList,
+                  isMineFromList: card.isMine,
+                };
+
                 const { goCombined, summaryId } = decideCombined(card);
                 if (goCombined && summaryId != null) {
                   navigate(PATH.COMBINED_DETAIL(id, summaryId), {
-                    state: { from: "community", ownerId },
+                    state: statePayload,
                   });
                 } else {
-                  // 제목 기반 슬러그 이동
                   const slug = makePostSlug(card.title, id);
                   navigate(
                     `${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`,
                     {
-                      state: { from: "community", ownerId },
+                      state: statePayload,
                     }
                   );
                 }

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -510,6 +510,26 @@ export default function CommunityPostDetail() {
           from,
         } = detailCtx;
 
+        // 0. 목록 힌트 기준: 비공개로 내려온 글이면 무조건 내 상세 API 우선
+        if (isVisibleFromList === false) {
+          const myDetail = await getPostDetail(effectiveId);
+          const completedAt = (myDetail as any)?.completedAt ?? null;
+          const isDraft = completedAt == null;
+
+          if (isDraft) {
+            // 작성 중이면 기존 드래프트 로직 재사용
+            await loadMineDraft(effectiveId);
+          } else {
+            // 완료 문서 비공개 → 내 상세 화면으로만 세팅
+            const vmMine = toPostDetailVM(myDetail as any, viewerId);
+            setPost(vmMine);
+            setIsLiked(vmMine.isLiked);
+            setLikeCounts(vmMine.likeCounts);
+            setIsCommunitySource(false); // 좋아요/댓글 비활성
+          }
+          return;
+        }
+
         // ProjectDetail → 원본 탭에서 온 글은 항상 /troubles만
         if (from === "project") {
           const myDetail = await getPostDetail(effectiveId);
@@ -640,15 +660,19 @@ export default function CommunityPostDetail() {
 
   useEffect(() => {
     if (!post) return;
+
+    // 비공개/내 글(/troubles 기반)일 때는 slug 정규화 X
+    if (!isCommunitySource) return;
+
     const canonical =
       PATH.COMMUNITY_POST_SLUG(
         makePostSlug(post.title, postId ?? effectiveId)
       ) + window.location.search;
-    // slug 경로가 아니면 슬러그로 교체
+
     if (!slug || slug !== makePostSlug(post.title, effectiveId)) {
       navigate(canonical, { replace: true });
     }
-  }, [post, slug, effectiveId, navigate, postId]);
+  }, [post, slug, effectiveId, navigate, postId, isCommunitySource]);
 
   const navigatingRef = useRef(false);
 

--- a/src/types/community.model.ts
+++ b/src/types/community.model.ts
@@ -23,6 +23,19 @@ export interface CommunityServerCard {
   postTags: string[];
   likeCount: number;
   commentCount: number;
+
+  // /community/recent 전용 필드
+  isVisible?: boolean;
+  isSummaryCreated?: boolean;
+  isDeleted?: boolean;
+  postStatus?: string; // "작성 완료", "요약 완료" 등
+  starRating?: string | null;
+  templateType?: string | null;
+  checklistError?: number[];
+  checklistReason?: number[];
+  updatedAt?: string;
+  projectId?: number;
+  contents?: TroubleContentBlock[];
 }
 
 export type GetCommunityListResponse = PaginatedResponse<CommunityServerCard>;


### PR DESCRIPTION
## ✅ What to do

- [x] 최근 읽은 포스트 탭에서 비공개 글 상세 조회 -> 커뮤니티 포스트 상세 조회 API 호출하는 문제 해결



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 비공개 게시물 및 초안 게시물의 상세 보기 라우팅 개선
  * 게시물 가시성 및 상태 처리 로직 강화

* **새로운 기능**
  * 커뮤니티 게시물 카드에 작성자 정보 및 태그 추가
  * 게시물 상태 동적 매핑 및 가시성 계산 로직 개선
  * 서버 데이터 모델 확장으로 더욱 풍부한 게시물 정보 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->