### PR TITLE
FIX: 원본 / 요약본 포스트 상세 조회 로직 명확히 분리

### DIFF
--- a/src/entities/trouble/card.mapper.ts
+++ b/src/entities/trouble/card.mapper.ts
@@ -11,6 +11,7 @@ import {
 export type TroublogCardVM = TroublogCardProps & {
   createdAtIso: string;
   isVisible?: boolean;
+  hasSummary?: boolean;
 };
 
 type AnySummary = {
@@ -53,6 +54,11 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
   const enumType = pickDisplaySummaryType(t);
   const label = enumType ? mapSummaryType(enumType) : undefined;
 
+  // 요약 존재 여부 계산
+  const hasSummary =
+    t.status === "SUMMARIZED" ||
+    (Array.isArray(t.summaries) && t.summaries.length > 0);
+
   return {
     id: t.id,
     isMine: true, // 서버에 소유자 정보가 오면 교체
@@ -74,6 +80,8 @@ export const toTroublogCardVM = (t: TroubleListItem): TroublogCardVM => {
     summaryId: pickLatestSummaryId(t) ?? undefined,
     postSummaryId: t.postSummaryId ?? undefined,
     summaries: t.summaries ?? [],
+
+    hasSummary,
   };
 };
 

--- a/src/features/mypage/useTroubleCards.ts
+++ b/src/features/mypage/useTroubleCards.ts
@@ -324,8 +324,18 @@ export default function useTroubleCards(source: Source, options: Options = {}) {
 
       if (seqRef.current !== mySeq) return;
 
-      idSetRef.current = new Set(list.map((x) => x.id));
-      setCards(toTroublogCardVMs(list));
+      // 원본 탭(COMPLETED)에서 받은 리스트라면
+      // 서버 status "SUMMARIZED" → 클라에서는 "COMPLETED"로 정규화
+      const normalizedList =
+        source.type === "project" && source.query.status === "COMPLETED"
+          ? list.map((item) => ({
+              ...item,
+              status: item.status === "SUMMARIZED" ? "COMPLETED" : item.status,
+            }))
+          : list;
+
+      idSetRef.current = new Set(normalizedList.map((x) => x.id));
+      setCards(toTroublogCardVMs(normalizedList)); // ← 여기서부터는 항상 VMs만 봄
       setHasNext(false); // 페이징 없음
       setPage(1);
     } catch (e: any) {

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -83,11 +83,20 @@ const MyPageLayout = () => {
 
   const counts = useMemo(() => {
     const mine = cards.filter((c) => c.isMine);
+
+    const inProgress = mine.filter((c) => c.status === "inProgress").length;
+    const complete = mine.filter(
+      (c) => c.status === "complete" || c.status === "created"
+    ).length;
+    const created = mine.filter((c) => c.status === "created").length;
+
+    const allForSidebar = inProgress + complete + created;
+
     return {
-      all: mine.length,
-      inProgress: mine.filter((c) => c.status === "inProgress").length,
-      complete: mine.filter((c) => c.status === "complete").length,
-      created: mine.filter((c) => c.status === "created").length,
+      all: allForSidebar,
+      inProgress,
+      complete,
+      created,
     };
   }, [cards]);
 

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -257,37 +257,33 @@ export default function ProjectDetailPage() {
                       const qs = new URLSearchParams({ from: "project" });
                       if (ownerId != null) qs.set("ownerId", String(ownerId));
 
-                      // '요약본'면 합본이 아니라 요약본 상세로 이동
-                      // - 현재 탭이 'created'이거나, 카드 자체 상태가 created인 경우
-                      // - summaryId 가 있을 때만 동작
-                      if (
-                        (selectedStatus === "created" ||
-                          card.status === "created") &&
-                        card.summaryId
-                      ) {
+                      // 1) '요약본' 탭인 경우에만 → 요약본 상세로 이동
+                      if (selectedStatus === "created" && card.summaryId) {
                         navigate(PATH.POST_SUMMARY(card.summaryId), {
                           state: { from: "project", ownerId },
                         });
                         return;
                       }
 
-                      // 요약본가 아닌 경우에는 합본 분기/커뮤 상세/힌트 전달
-                      const { goCombined, summaryId } = decideCombined(
-                        card,
-                        viewerId
-                      );
-                      if (goCombined && summaryId != null) {
-                        navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
-                          state: { from: "project", ownerId },
-                        });
-                        return;
+                      // 2) **원본 탭이 아닐 때만** 합본 여부 판단
+                      if (selectedStatus !== "complete") {
+                        const { goCombined, summaryId } = decideCombined(
+                          card,
+                          viewerId
+                        );
+                        if (goCombined && summaryId != null) {
+                          navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
+                            state: { from: "project", ownerId },
+                          });
+                          return;
+                        }
                       }
 
-                      // 홈 화면과 동일한 힌트 전달 (비공개/작성중 분기용)
+                      // 3) 나머지는 무조건 원본 상세로 이동
                       const statusFromList = card.status; // 'inProgress' | 'complete' | 'created'
-                      const isVisibleFromList = card.visibility === "public"; // boolean
-                      const summaryIdFromList = card.summaryId ?? undefined; // number | undefined
-                      const isMineFromList = true; // 항상 true
+                      const isVisibleFromList = card.visibility === "public";
+                      const summaryIdFromList = card.summaryId ?? undefined;
+                      const isMineFromList = true;
 
                       navigate(
                         `${PATH.COMMUNITY_POST_ID(

--- a/src/widgets/mypage/TroubleShootingList.tsx
+++ b/src/widgets/mypage/TroubleShootingList.tsx
@@ -61,13 +61,19 @@ const TroubleShootingList = () => {
     [base, isMyPage, selectedTag]
   );
 
-  const statusFiltered = useMemo(
-    () =>
-      isMyPage && selectedStatus !== "all"
-        ? tagFiltered.filter((c) => c.status === selectedStatus)
-        : tagFiltered,
-    [tagFiltered, isMyPage, selectedStatus]
-  );
+  const statusFiltered = useMemo(() => {
+    if (!isMyPage || selectedStatus === "all") return tagFiltered;
+
+    // '원본' 탭: COMPLETED + SUMMARIZED 모두 포함
+    if (selectedStatus === "complete") {
+      return tagFiltered.filter(
+        (c) => c.status === "complete" || c.status === "created"
+      );
+    }
+
+    // 나머지(inProgress, created)는 기존 방식 유지
+    return tagFiltered.filter((c) => c.status === selectedStatus);
+  }, [tagFiltered, isMyPage, selectedStatus]);
 
   const sortedCards = statusFiltered;
 
@@ -125,7 +131,7 @@ const TroubleShootingList = () => {
         )}
 
         {sortedCards.map((card) => {
-          const vm = mapToTroubleShootingCard(card); // 한 번만 만들고 아래에서 재사용
+          const vm = mapToTroubleShootingCard(card);
 
           return (
             <TroubleShootingCard
@@ -133,11 +139,6 @@ const TroubleShootingList = () => {
               {...vm}
               onDeleted={handleDeleted}
               onClick={() => {
-                // 1) 합본 분기(기존 유지)
-                const { goCombined, summaryId } = decideCombined(
-                  card,
-                  viewerId
-                );
                 const ownerIdForState = isMyPage
                   ? viewerId != null
                     ? Number(viewerId)
@@ -146,26 +147,42 @@ const TroubleShootingList = () => {
                   ? Number(card.authorId)
                   : undefined;
 
-                if (goCombined && summaryId != null) {
-                  navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
-                    state: { from: "mypage", ownerId: ownerIdForState },
-                  });
-                  return;
-                }
-
-                // 2) CPD 힌트(state)로 확정값 전달
-                const statusFromList = vm.status; // 'inProgress' | 'complete' | 'created'
+                const statusFromList = vm.status;
                 const isVisibleFromList = vm.visibility === "public";
                 const summaryIdFromList = vm.summaryId ?? undefined;
                 const isMineFromList = !!vm.isMine || !!isMyPage;
 
                 const qs = new URLSearchParams({ from: "mypage" });
-                if (ownerIdForState != null)
+                if (ownerIdForState != null) {
                   qs.set("ownerId", String(ownerIdForState));
+                }
 
-                // 슬러그 생성
                 const slug = makePostSlug(vm.title, card.id);
 
+                // 1) 내 마이페이지 + '원본+요약본' 탭일 때만 합본 라우팅
+                if (isMyPage && selectedStatus === "created") {
+                  const { goCombined, summaryId } = decideCombined(
+                    card,
+                    viewerId
+                  );
+
+                  if (goCombined && summaryId != null) {
+                    navigate(PATH.COMBINED_DETAIL(card.id, summaryId), {
+                      state: { from: "mypage", ownerId: ownerIdForState },
+                    });
+                    return;
+                  }
+
+                  // (옵션) 합본 실패 시 요약본 상세로 보내고 싶다면:
+                  if (summaryIdFromList != null) {
+                    navigate(PATH.POST_SUMMARY(summaryIdFromList), {
+                      state: { from: "mypage", ownerId: ownerIdForState },
+                    });
+                    return;
+                  }
+                }
+
+                // 2) 그 외 탭(전체/작성중/원본)은 항상 원본 상세로 이동
                 navigate(`${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`, {
                   state: {
                     from: "mypage",


### PR DESCRIPTION
## ✅ What to do

- [x] 프로젝트 내 원본 탭에서 원본 포스트 조회 시 요약본이 아닌 원본 상세 내용 조회 가능하도록 수정
- [x] 마이페이지에서 요약본 생성된 포스트의 경우 원본탭에도 추가하기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요약본 존재 여부를 추적할 수 있는 기능 추가

* **버그 수정**
  * 마이페이지 통계 카운트 계산 로직 수정

* **개선 사항**
  * 상태별 필터링 및 네비게이션 로직 개선
  * 요약본/원본 탭 전환 시 카드 클릭 동작 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->