### PR TITLE
FIX: 프로필 수정 시 기존 프로필 이미지 받아오기

### DIFF
--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -4,6 +4,8 @@ export interface ProfileData {
   field: string;
   bio: string;
   githubUrl: string;
+  profileUrl?: string | null;
+  profileImageUrl?: string | null;
 }
 
 export interface UpdatedProfileData {
@@ -19,6 +21,7 @@ export interface UserInfoData {
   userId: number;
   nickname: string;
   profileUrl: string;
+  profileImgUrl?: string | null;
   bio: string;
   followerNum: number;
   followingNum: number;

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -93,8 +93,13 @@ const EditProfile = () => {
           getMyProfile(),
           id ? getUserInfo(Number(id)) : Promise.resolve(null as any),
         ]);
+
         const serverProfileUrl =
-          (userInfo && userInfo.profileUrl) || (me as any)?.profileUrl || "";
+          userInfo?.profileImgUrl ||
+          userInfo?.profileUrl ||
+          (me as any)?.profileImgUrl ||
+          (me as any)?.profileUrl ||
+          "";
 
         if (!alive) return;
 
@@ -106,6 +111,7 @@ const EditProfile = () => {
           githubUrl: me.githubUrl,
           profileUrl: serverProfileUrl,
         });
+
         setProfileImage(serverProfileUrl || userIcon);
       } catch (error) {
         console.error("정보를 불러오는 데 실패했습니다", error);


### PR DESCRIPTION
## ✅ What to do

- [x] 프로필 수정 페이지에서 기존 프로필 이미지 화면에 띄워줄 수 있도록 수정

## 📄 Description

- 변경된 API 응답에 맞춰 `profileImgUrl` 필드 이용해서 프로필 이미지 띄우기

