### PR TITLE
STYLES: 카카오 회원가입 정보 입력 페이지 크기 조절

### DIFF
--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -245,8 +245,8 @@ const SignPageOauth = () => {
         alt="signup visual"
       />
 
-      {/* 우측 폼 (SignPageTwo와 동일 구조/간격) */}
-      <div className="w-full lg:w-1/2 h-full px-6 sm:px-16 lg:px-[200px] py-12 sm:py-24 lg:py-[281px] flex flex-col justify-center items-center">
+      {/* 우측 폼 래퍼 */}
+      <div className="w-full lg:w-1/2 h-full scale-[0.8] px-6 sm:px-16 lg:px-[200px] py-12 sm:py-24 lg:py-[281px] flex flex-col justify-center items-center">
         <div className="w-full max-w-[560px] flex flex-col items-center gap-10">
           <h2 className="text-black text-3xl sm:text-4xl lg:text-[36px] font-bold w-full font-pretendard">
             회원가입
@@ -254,93 +254,95 @@ const SignPageOauth = () => {
 
           <form
             onSubmit={handleSubmit}
-            className="flex flex-col items-start w-full gap-4"
+            className="flex flex-col items-start gap-4 w-full"
           >
-            <Input
-              label="닉네임"
-              type="text"
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-              placeholder="닉네임을 입력해주세요."
-              error={nicknameError}
-              name="nickname"
-            />
-            <Input
-              label="관심 분야"
-              type="text"
-              value={field}
-              onChange={(e) => setField(e.target.value)}
-              placeholder="관심 분야를 입력해주세요."
-              error={fieldError}
-              name="field"
-            />
-            <Input
-              label="한 줄 소개"
-              type="text"
-              value={bio}
-              onChange={(e) => setBio(e.target.value)}
-              placeholder="한 줄 소개를 입력해주세요. (50자 이내)"
-              error={bioError}
-              name="bio"
-            />
-            <Input
-              label="깃허브 주소(선택)"
-              type="url"
-              value={githubad}
-              onChange={(e) => setGithubad(e.target.value)}
-              placeholder="깃허브 주소를 입력해주세요."
-              name="githubad"
-            />
+            <div className="flex flex-col items-start w-full">
+              <Input
+                label="닉네임"
+                type="text"
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder="닉네임을 입력해주세요."
+                error={nicknameError}
+                name="nickname"
+              />
+              <Input
+                label="관심 분야"
+                type="text"
+                value={field}
+                onChange={(e) => setField(e.target.value)}
+                placeholder="관심 분야를 입력해주세요."
+                error={fieldError}
+                name="field"
+              />
+              <Input
+                label="한 줄 소개"
+                type="text"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                placeholder="한 줄 소개를 입력해주세요. (50자 이내)"
+                error={bioError}
+                name="bio"
+              />
+              <Input
+                label="깃허브 주소(선택)"
+                type="url"
+                value={githubad}
+                onChange={(e) => setGithubad(e.target.value)}
+                placeholder="깃허브 주소를 입력해주세요."
+                name="githubad"
+              />
 
-            {/* 약관/개인정보 동의 영역 (SignPageTwo와 동일 플로우) */}
-            <TermsField
-              label="이용약관 및 개인정보처리방침"
-              onOpen={() => {
-                const formDraft = {
-                  userId,
-                  nickname,
-                  field,
-                  bio,
-                  githubad,
-                  termsAgreements: agreeMap,
-                };
-                sessionStorage.setItem(DRAFT_KEY, JSON.stringify(formDraft));
-                navigate(PATH.TERMS, {
-                  state: {
-                    returnTo: location.pathname,
-                    formDraft,
-                  },
-                });
-              }}
-              error={agreeError}
-              describedBy="terms-error"
-            />
+              {/* 약관/개인정보 동의 영역 */}
+              <TermsField
+                label="이용약관 및 개인정보처리방침"
+                onOpen={() => {
+                  const formDraft = {
+                    userId,
+                    nickname,
+                    field,
+                    bio,
+                    githubad,
+                    termsAgreements: agreeMap,
+                  };
+                  sessionStorage.setItem(DRAFT_KEY, JSON.stringify(formDraft));
+                  navigate(PATH.TERMS, {
+                    state: {
+                      returnTo: location.pathname,
+                      formDraft,
+                    },
+                  });
+                }}
+                error={agreeError}
+                describedBy="terms-error"
+              />
 
-            {/* 단일 '동의합니다' 체크 → 두 약관 모두 동기화 */}
-            <div className="w-full -mt-6 mb-4 flex items-center justify-end">
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={agreeMap["1"] && agreeMap["2"]}
-                  onChange={(e) => {
-                    const v = e.target.checked;
-                    setAgreeMap({ "1": v, "2": v });
-                    if (v) setAgreeError("");
-                  }}
-                  className="w-5 h-5 accent-[#9737fd]"
-                  aria-invalid={!!agreeError}
-                  aria-describedby="terms-error"
-                />
-                <span className="text-sm md:text-base text-gray-700">
-                  동의합니다.
-                </span>
-              </label>
+              {/* 단일 '동의합니다' 체크 → 두 약관 모두 동기화 */}
+              <div className="w-full -mt-6 mb-4 flex items-center justify-end">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={agreeMap["1"] && agreeMap["2"]}
+                    onChange={(e) => {
+                      const v = e.target.checked;
+                      setAgreeMap({ "1": v, "2": v });
+                      if (v) setAgreeError("");
+                    }}
+                    className="w-5 h-5 accent-[#9737fd]"
+                    aria-invalid={!!agreeError}
+                    aria-describedby="terms-error"
+                  />
+                  <span className="text-sm md:text-base text-gray-700">
+                    동의합니다.
+                  </span>
+                </label>
+              </div>
             </div>
 
             {/* 상단 폼 에러 */}
             {formError && (
               <p
-                className="text-sm text-red-500 mt-1 min-h-[10px]"
+                className="text-red-500 text-[16px] mt-1"
                 aria-live="polite"
                 role="alert"
               >
@@ -348,24 +350,25 @@ const SignPageOauth = () => {
               </p>
             )}
 
-            <button
-              type="submit"
-              className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-50"
-              disabled={submitting || !isFormValid}
-            >
-              <span className="text-white text-lg sm:text-xl font-semibold font-pretendard">
-                {submitting ? "가입 처리 중..." : "회원가입"}
-              </span>
-            </button>
+            <div className="flex flex-col items-start gap-4 w-full">
+              <button
+                type="submit"
+                className="w-full h-12 bg-[#9737fd] rounded-lg flex justify-center items-center disabled:opacity-50"
+                disabled={submitting || !isFormValid}
+              >
+                <span className="text-white text-[20px] font-semibold font-pretendard">
+                  {submitting ? "가입 처리 중..." : "회원가입"}
+                </span>
+              </button>
+            </div>
           </form>
 
-          {/* 하단 로그인 링크 (우측 정렬) */}
           <div className="flex flex-row items-end self-end gap-4">
-            <h2 className="text-sm sm:text-base md:text-lg text-gray-500 font-pretendard">
+            <h2 className="text-[18px] text-gray-500 font-pretendard">
               이미 계정이 있으신가요?
             </h2>
             <button
-              className="text-sm sm:text-base md:text-lg text-[#9737fd] underline font-pretendard"
+              className="text-[18px] text-[#9737fd] underline font-pretendard"
               onClick={() => navigate(PATH.LOGIN)}
             >
               로그인


### PR DESCRIPTION
## ✅ What to do

- [x] 카카오 회원가입 시 정보 입력 페이지(`SignPageOauth`) 컴포넌트 크기 조절

## 📄 Description

- 기본 회원가입 페이지(`SignPageTwo`)와 동일하게 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* 로그인 페이지 UI 개선
  - 폼 레이아웃 및 시각적 크기 조정
  - 입력 필드 그룹화 및 배치 개선
  - 에러 메시지 및 버튼 스타일 강화
  - 네비게이션 텍스트 표시 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->