### PR TITLE
FEAT: 요약본 삭제 API 연동

### DIFF
--- a/src/api/post.api.ts
+++ b/src/api/post.api.ts
@@ -110,6 +110,13 @@ export const getPostSummary = (summaryId: number) =>
     method: "GET",
   });
 
+// 요약본 영구 삭제
+export const hardDeleteSummary = (summaryId: number) =>
+  getAPIResponseData<void>({
+    url: `/troubles/summary/${summaryId}`,
+    method: "DELETE",
+  });
+
 // 합본 상세 (postId + summaryId)
 export const getCombinedDetail = (postId: number, summaryId: number) =>
   getAPIResponseData<ViewCombinedResponse>({

--- a/src/entities/trouble/ui/CardHeaderRight.tsx
+++ b/src/entities/trouble/ui/CardHeaderRight.tsx
@@ -13,6 +13,10 @@ interface CardHeaderRightProps {
   onAvatarClick?: () => void;
   onDelete?: () => void;
   deleting?: boolean;
+
+  hasSummary?: boolean;
+  onDeleteSummary?: () => void;
+  summaryDeleting?: boolean;
 }
 
 export default function CardHeaderRight({
@@ -22,6 +26,9 @@ export default function CardHeaderRight({
   onAvatarClick,
   onDelete,
   deleting = false,
+  hasSummary,
+  onDeleteSummary,
+  summaryDeleting = false,
 }: CardHeaderRightProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
@@ -55,23 +62,37 @@ export default function CardHeaderRight({
     );
   }
 
+  const options: { label: string; onClick: () => void }[] = [];
+
+  if (hasSummary && onDeleteSummary) {
+    options.push({
+      label: summaryDeleting ? "요약본 삭제 중..." : "요약본 삭제",
+      onClick: () => {
+        if (!summaryDeleting) onDeleteSummary();
+      },
+    });
+  }
+
+  options.push({
+    label: deleting ? "삭제 중..." : "삭제",
+    onClick: () => {
+      if (!deleting) onDelete?.();
+    },
+  });
+
   return (
     <div className="relative flex gap-1 sm:gap-2" ref={menuRef}>
       <StatusDot status={status} />
       <div className="relative" {...stopCardClick}>
-        <KebabMenuButton onClick={() => setShowMenu((v) => !v)} />
+        <KebabMenuButton
+          onClick={() => {
+            if (deleting || summaryDeleting) return;
+            setShowMenu((v) => !v);
+          }}
+        />
         {showMenu && (
           <div {...stopCardClick}>
-            <KebabDropdown
-              options={[
-                {
-                  label: deleting ? "삭제 중..." : "삭제",
-                  onClick: () => {
-                    if (!deleting) onDelete?.();
-                  },
-                },
-              ]}
-            />
+            <KebabDropdown options={options} />
           </div>
         )}
       </div>

--- a/src/entities/trouble/ui/CardPreviewArea.tsx
+++ b/src/entities/trouble/ui/CardPreviewArea.tsx
@@ -10,6 +10,10 @@ interface CardPreviewAreaProps {
   onRequestDelete?: () => void;
   deleting?: boolean;
   imageUrl?: string;
+
+  hasSummary?: boolean;
+  onRequestDeleteSummary?: () => void;
+  summaryDeleting?: boolean;
 }
 
 export default function CardPreviewArea({
@@ -21,6 +25,9 @@ export default function CardPreviewArea({
   onRequestDelete,
   deleting,
   imageUrl,
+  hasSummary,
+  onRequestDeleteSummary,
+  summaryDeleting,
 }: CardPreviewAreaProps) {
   const hasImage = !!imageUrl;
 
@@ -43,6 +50,9 @@ export default function CardPreviewArea({
           onAvatarClick={onAvatarClick}
           onDelete={onRequestDelete}
           deleting={deleting}
+          hasSummary={hasSummary}
+          onDeleteSummary={onRequestDeleteSummary}
+          summaryDeleting={summaryDeleting}
         />
       </div>
     </div>

--- a/src/entities/trouble/ui/TroubleShootingCard.tsx
+++ b/src/entities/trouble/ui/TroubleShootingCard.tsx
@@ -10,7 +10,7 @@ import privateIcon from "@/assets/icons/private.svg";
 import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import commentIcon from "@/assets/icons/comment.svg";
-import { hardDeletePost } from "@/api/post.api";
+import { hardDeletePost, hardDeleteSummary } from "@/api/post.api";
 
 import emptyThumbnail from "@/assets/images/thumbnail_empty.png";
 
@@ -38,6 +38,8 @@ export interface TroubleShootingCardProps {
   summaryId?: number | null;
   postSummaryId?: number | null;
   summaries?: any[];
+
+  onSummaryDeleted?: (summaryId: number) => void;
 }
 
 const TroubleShootingCard = ({
@@ -60,9 +62,12 @@ const TroubleShootingCard = ({
   onDeleted,
   onClick,
   disabled,
+  summaryId,
+  onSummaryDeleted,
 }: TroubleShootingCardProps) => {
   const [showMenu, setShowMenu] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [summaryDeleting, setSummaryDeleting] = useState(false);
   const handleCloseMenu = useCallback(() => setShowMenu(false), []);
   const menuRef = useClickOutside(handleCloseMenu);
 
@@ -102,6 +107,34 @@ const TroubleShootingCard = ({
       );
     } finally {
       setDeleting(false);
+      setShowMenu(false);
+    }
+  };
+
+  // 요약본 삭제 핸들러
+  const handleDeleteSummary = async () => {
+    if (!summaryId) return;
+
+    if (
+      !window.confirm(
+        "이 문서의 요약본을 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setSummaryDeleting(true);
+      await hardDeleteSummary(summaryId);
+      onSummaryDeleted?.(summaryId);
+      console.log("요약본이 영구 삭제되었습니다.");
+    } catch (err: any) {
+      console.error(err);
+      alert(
+        err?.response?.data?.message ??
+          "요약본 삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setSummaryDeleting(false);
       setShowMenu(false);
     }
   };
@@ -253,16 +286,28 @@ const TroubleShootingCard = ({
           onKeyDown={(e) => e.stopPropagation()}
         >
           <KebabMenuButton
-            onClick={() => !deleting && setShowMenu(!showMenu)}
+            onClick={() =>
+              !(deleting || summaryDeleting) && setShowMenu(!showMenu)
+            }
           />
           {showMenu && (
             <KebabDropdown
-              options={[
-                {
-                  label: deleting ? "삭제 중..." : "삭제",
-                  onClick: deleting ? () => {} : handleDelete,
-                },
-              ]}
+              options={
+                [
+                  // 요약본이 있고, 내가 쓴 글이면서 요약 상태일 때만 요약 삭제 노출
+                  summaryId &&
+                    shouldShowSummaryType && {
+                      label: summaryDeleting
+                        ? "요약본 삭제 중..."
+                        : "요약본 삭제",
+                      onClick: summaryDeleting ? () => {} : handleDeleteSummary,
+                    },
+                  {
+                    label: deleting ? "삭제 중..." : "문서 삭제",
+                    onClick: deleting ? () => {} : handleDelete,
+                  },
+                ].filter(Boolean) as { label: string; onClick: () => void }[]
+              }
             />
           )}
         </div>

--- a/src/entities/trouble/ui/TroublogCard.tsx
+++ b/src/entities/trouble/ui/TroublogCard.tsx
@@ -6,7 +6,7 @@ import TagList from "@/entities/trouble/ui/TagList";
 import type { StatusType, VisibilityType } from "@/types/project";
 import { PATH } from "@/shared/config/paths";
 import { useCallback, useState } from "react";
-import { hardDeletePost } from "@/api/post.api";
+import { hardDeletePost, hardDeleteSummary } from "@/api/post.api";
 
 import emptyThumbnail from "@/assets/images/thumbnail_empty.png";
 
@@ -35,6 +35,7 @@ export interface TroublogCardProps {
   summaries?: object[];
   imageUrl?: string;
   compact?: boolean;
+  onSummaryDeleted?: (summaryId: number) => void;
 }
 
 export default function TroublogCard({
@@ -56,9 +57,13 @@ export default function TroublogCard({
   onDeleted,
   imageUrl,
   compact = false,
+  summaryId,
+  onSummaryDeleted,
 }: TroublogCardProps) {
   const navigate = useNavigate();
   const [deleting, setDeleting] = useState(false);
+  const [summaryDeleting, setSummaryDeleting] = useState(false);
+  const hasSummary = typeof summaryId === "number";
 
   const handleRootClick = () => {
     if (typeof onClick === "function") onClick(id);
@@ -96,6 +101,32 @@ export default function TroublogCard({
     }
   }, [id, isMine, onDeleted]);
 
+  const handleRequestDeleteSummary = useCallback(async () => {
+    if (!isMine) return;
+    if (!summaryId) return;
+
+    if (
+      !window.confirm(
+        "이 문서의 요약본을 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setSummaryDeleting(true);
+      await hardDeleteSummary(summaryId);
+      onSummaryDeleted?.(summaryId);
+    } catch (err: any) {
+      console.error(err);
+      alert(
+        err?.response?.data?.message ??
+          "요약본 삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setSummaryDeleting(false);
+    }
+  }, [isMine, summaryId, onSummaryDeleted]);
+
   const rootSizeClass = compact
     ? // 10% 축소: 300→270, 330→297, 384→346 근사
       "max-w-[346px] h-[270px] sm:h-[297px]"
@@ -129,6 +160,9 @@ export default function TroublogCard({
           onRequestDelete={handleRequestDelete}
           deleting={deleting}
           imageUrl={imageUrl || emptyThumbnail}
+          hasSummary={hasSummary}
+          onRequestDeleteSummary={handleRequestDeleteSummary}
+          summaryDeleting={summaryDeleting}
         />
       </div>
 

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -108,6 +108,7 @@ const Header = () => {
 
   useEffect(() => {
     const path = location.pathname;
+
     if (path.startsWith(PATH.SEARCH)) {
       const sp = new URLSearchParams(location.search);
       const scope = sp.get("scope");
@@ -132,31 +133,62 @@ const Header = () => {
       return;
     }
 
-    const mypageMatch = path.match(/^\/user\/mypage\/([^/]+)/);
-    const pageUserId = mypageMatch?.[1];
+    // 마이페이지 경로 처리
+    if (path.startsWith(PATH.MYPAGE_BASE)) {
+      const segments = path.split("/").filter(Boolean);
+      const third = segments[2];
 
-    if (path === PATH.MYPAGE_BASE) {
-      setPlaceholder(
-        "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
-      );
-    } else if (path.startsWith(PATH.MYPAGE_BASE + "/")) {
+      // 내 닉네임 (viewedUser가 나 자신일 때)
+      const myDisplayName =
+        viewerId != null &&
+        viewedUser?.id === Number(viewerId) &&
+        viewedUser?.nickname
+          ? viewedUser.nickname
+          : null;
+
+      // 1) 내 마이페이지
       if (
-        (pageUserId && myUserIdStr && pageUserId === myUserIdStr) ||
-        path.endsWith("editprofile")
+        !third ||
+        third === "statistics" ||
+        third === "troubles" ||
+        third === "likes" ||
+        third === "editprofile"
       ) {
-        setPlaceholder(
-          "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
-        );
-      } else {
+        if (myDisplayName) {
+          setPlaceholder(
+            `키워드나 태그 등의 검색어를 통해 ${myDisplayName}님의 트러블슈팅을 검색해보세요!`
+          );
+        } else {
+          setPlaceholder(
+            "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
+          );
+        }
+        return;
+      }
+
+      // 2) 다른 사용자의 마이페이지
+      if (/^\d+$/.test(third)) {
+        const pageUserId = third;
         const displayName =
           viewedUser?.id === Number(pageUserId) && viewedUser?.nickname
             ? viewedUser.nickname
-            : pageUserId ?? "사용자";
+            : pageUserId;
+
         setPlaceholder(
           `키워드나 태그 등의 검색어를 통해 ${displayName}님의 트러블슈팅을 검색해보세요!`
         );
+        return;
       }
-    } else if (
+
+      // 3) 그 외 예외적인 경로는 일단 "다른 사람들"로 처리
+      setPlaceholder(
+        "키워드나 태그 등의 검색어를 통해 다른 사람들의 트러블슈팅을 검색해보세요!"
+      );
+      return;
+    }
+
+    // 홈 / 프로젝트 상세 → '내 트러블슈팅' 위주
+    if (
       path.startsWith(PATH.HOME) ||
       path.startsWith(PATH.PROJECT_DETAIL(""))
     ) {
@@ -164,15 +196,16 @@ const Header = () => {
         "키워드나 태그 등의 검색어를 통해 내 트러블슈팅을 검색해보세요!"
       );
     } else {
+      // 그 외 페이지: 커뮤니티 등
       setPlaceholder(
         "키워드나 태그 등의 검색어를 통해 다른 사람들의 트러블슈팅을 검색해보세요!"
       );
     }
   }, [
     location.pathname,
-    setPlaceholder,
-    myUserIdStr,
     location.search,
+    setPlaceholder,
+    viewerId,
     viewedUser?.id,
     viewedUser?.nickname,
   ]);

--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -85,15 +85,28 @@ const MyPageLayout = () => {
     const mine = cards.filter((c) => c.isMine);
 
     const inProgress = mine.filter((c) => c.status === "inProgress").length;
-    const complete = mine.filter(
-      (c) => c.status === "complete" || c.status === "created"
-    ).length;
-    const created = mine.filter((c) => c.status === "created").length;
 
-    const allForSidebar = inProgress + complete + created;
+    // created 중에서 요약본이 정말 존재하는 것만
+    const created = mine.filter((c) => {
+      if (c.status !== "created") return false;
+      const summaries = Array.isArray(c.summaries) ? c.summaries : [];
+      return summaries.length > 0;
+    }).length;
+
+    // complete = "원본만" + "요약본 없는 created"
+    const complete = mine.filter((c) => {
+      if (c.status === "complete") return true;
+      if (c.status === "created") {
+        const summaries = Array.isArray(c.summaries) ? c.summaries : [];
+        return summaries.length === 0; // 요약본이 없으면 complete로 포함
+      }
+      return false;
+    }).length;
+
+    const all = inProgress + complete + created;
 
     return {
-      all: allForSidebar,
+      all,
       inProgress,
       complete,
       created,

--- a/src/widgets/mypage/TroubleShootingList.tsx
+++ b/src/widgets/mypage/TroubleShootingList.tsx
@@ -71,6 +71,16 @@ const TroubleShootingList = () => {
       );
     }
 
+    // '원본+요약본' 탭: status === "created" 이면서 summaries가 비어있지 않은 것만
+    if (selectedStatus === "created") {
+      return tagFiltered.filter((c) => {
+        if (c.status !== "created") return false;
+
+        const summaries = (c as any).summaries;
+        return Array.isArray(summaries) && summaries.length > 0;
+      });
+    }
+
     // 나머지(inProgress, created)는 기존 방식 유지
     return tagFiltered.filter((c) => c.status === selectedStatus);
   }, [tagFiltered, isMyPage, selectedStatus]);


### PR DESCRIPTION
## 🔥 Issues

- #171 closed

## ✅ What to do

- [x] 요약본 삭제 API 연동 및 요약본 삭제 기능 추가 (`TroublogCard`, `TroubleShootingList`)
- [x] 마이페이지 내 포스트 목록 불러올 때 `summaries[]` 배열 비어있는 경우 '원본+요약본' 탭에 포함 X
- [x] 마이페이지 헤더 검색창 placeholder 처리 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 요약본 삭제 기능 추가: 사용자가 생성한 요약본을 삭제할 수 있는 옵션 제공

* **Improvements**
  * 마이페이지 검색 기능의 플레이스홀더 로직 개선
  * 트러블슈팅 아이템의 상태별 카운팅 및 필터링 로직 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->