### PR TITLE
FIX: 모바일에서 카카오 회원가입 오류 나는 부분 수정

### DIFF
--- a/src/pages/Login/SignPageOauth.tsx
+++ b/src/pages/Login/SignPageOauth.tsx
@@ -49,24 +49,28 @@ const SignPageOauth = () => {
   const [submitting, setSubmitting] = useState(false);
   const hydratedRef = useRef(false);
 
-  // 새로고침 폴백: oauth_payload에서 userId 복구
   useEffect(() => {
     if (userId != null && kakaoNickname != null) return;
     try {
       const raw = sessionStorage.getItem("oauth_payload");
-      if (raw) {
-        const p = JSON.parse(raw) as {
-          userId?: number;
-          kakaoNickname?: string;
-        };
-        if (p?.userId && !userId) setUserId(p.userId);
-        if (p?.kakaoNickname && !kakaoNickname)
-          setKakaoNickname(p.kakaoNickname);
+      if (!raw) return;
+
+      const p = JSON.parse(raw) as {
+        userId?: number;
+        nickname?: string;
+      };
+
+      if (p.userId && !userId) {
+        setUserId(p.userId);
+      }
+      if (p.nickname && !kakaoNickname) {
+        // oauth_payload.nickname 을 카카오 원본 닉네임으로 사용
+        setKakaoNickname(p.nickname);
       }
     } catch {
       /* noop */
     }
-  }, [userId]);
+  }, [userId, kakaoNickname]);
 
   // 약관 상세 → 복귀 시 상태 반영 + 최초 진입 시 draft 복구
   useEffect(() => {


### PR DESCRIPTION
## ✅ What to do

- [x] 카카오 닉네임 받아오는 부분 수정

## 📄 Description

- `SignPageOauth`의 새로고침 폴백 effect에서 `p.kakaoNickname` 대신 `p.nickname`을 읽도록 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * OAuth 로그인 시 세션 복구 로직을 개선하여 사용자 계정 정보가 더 안정적으로 복구됩니다.
  * 사용자 프로필 정보 처리 과정을 최적화하여 로그인 경험을 향상시켰습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->