### PR TITLE
REFACTOR: 마이페이지 요약본 포스트 매핑 수정

### DIFF
--- a/src/layouts/MyPageLayout.tsx
+++ b/src/layouts/MyPageLayout.tsx
@@ -84,26 +84,22 @@ const MyPageLayout = () => {
   const counts = useMemo(() => {
     const mine = cards.filter((c) => c.isMine);
 
+    // 1) 작성 중: 그대로
     const inProgress = mine.filter((c) => c.status === "inProgress").length;
 
-    // created 중에서 요약본이 정말 존재하는 것만
-    const created = mine.filter((c) => {
-      if (c.status !== "created") return false;
+    // 2) 원본: complete + created 전부 포함
+    const complete = mine.filter(
+      (c) => c.status === "complete" || c.status === "created"
+    ).length;
+
+    // 3) 요약본: summaries 전체 개수(포스트 단위 X)
+    const created = mine.reduce((acc, c) => {
       const summaries = Array.isArray(c.summaries) ? c.summaries : [];
-      return summaries.length > 0;
-    }).length;
+      return acc + summaries.length;
+    }, 0);
 
-    // complete = "원본만" + "요약본 없는 created"
-    const complete = mine.filter((c) => {
-      if (c.status === "complete") return true;
-      if (c.status === "created") {
-        const summaries = Array.isArray(c.summaries) ? c.summaries : [];
-        return summaries.length === 0; // 요약본이 없으면 complete로 포함
-      }
-      return false;
-    }).length;
-
-    const all = inProgress + complete + created;
+    // 4) 전체: “포스트 개수” 기준 유지
+    const all = mine.length;
 
     return {
       all,

--- a/src/widgets/mypage/TroubleShootingList.tsx
+++ b/src/widgets/mypage/TroubleShootingList.tsx
@@ -8,6 +8,7 @@ import { PATH } from "@/shared/config/paths";
 import { useViewerId } from "@/store/auth";
 import { decideCombined } from "@/entities/trouble/lib/combinedRoute";
 import { makePostSlug } from "@/shared/lib/slug";
+import { mapSummaryType } from "@/entities/trouble/lib/troubleMapping";
 
 interface OutletContextType {
   isMyPage: boolean;
@@ -85,7 +86,35 @@ const TroubleShootingList = () => {
     return tagFiltered.filter((c) => c.status === selectedStatus);
   }, [tagFiltered, isMyPage, selectedStatus]);
 
-  const sortedCards = statusFiltered;
+  const sortedCards = useMemo(() => {
+    // 요약본 탭 + 내 마이페이지일 때만 flatten
+    if (isMyPage && selectedStatus === "created") {
+      const flat: any[] = [];
+
+      for (const post of statusFiltered) {
+        const summaries = Array.isArray((post as any).summaries)
+          ? (post as any).summaries
+          : [];
+
+        // summaries가 여러 개면 post를 복제해서 summaryId/summaryType만 바꿔줌
+        for (const summary of summaries) {
+          flat.push({
+            ...post,
+            summaryId: summary.summaryId,
+            summaryType: summary.summaryType,
+            summaryCreatedAt: summary.summaryCreatedAt,
+            // 필요하면 summary 자체를 붙여놓을 수도 있음
+            summary,
+          });
+        }
+      }
+
+      return flat;
+    }
+
+    // 그 외 탭은 포스트 단위 그대로
+    return statusFiltered;
+  }, [statusFiltered, isMyPage, selectedStatus]);
 
   const emptyMessage = useMemo(() => {
     if (isLoading) return null;
@@ -141,11 +170,23 @@ const TroubleShootingList = () => {
         )}
 
         {sortedCards.map((card) => {
-          const vm = mapToTroubleShootingCard(card);
+          // 1) 기본 VM 생성
+          const baseVm = mapToTroubleShootingCard(card);
+
+          // 2) summaryType을 서버 raw 값(or 기존 값)에서 한글 라벨로 매핑
+          const summaryTypeLabel = mapSummaryType(
+            // flatten된 요약본 카드라면 card.summaryType에 서버 enum(RESUME 등)이 들어있음
+            (card as any).summaryType ?? baseVm.summaryType
+          );
+
+          const vm = {
+            ...baseVm,
+            summaryType: summaryTypeLabel,
+          };
 
           return (
             <TroubleShootingCard
-              key={card.id}
+              key={(card as any).summaryId ?? card.id} // 요약본 탭에서 summaryId 기준으로 유니크 키 주면 더 안전
               {...vm}
               onDeleted={handleDeleted}
               onClick={() => {
@@ -183,7 +224,7 @@ const TroubleShootingList = () => {
                     return;
                   }
 
-                  // (옵션) 합본 실패 시 요약본 상세로 보내고 싶다면:
+                  // (옵션) 합본 실패 시 요약본 상세로
                   if (summaryIdFromList != null) {
                     navigate(PATH.POST_SUMMARY(summaryIdFromList), {
                       state: { from: "mypage", ownerId: ownerIdForState },
@@ -192,7 +233,7 @@ const TroubleShootingList = () => {
                   }
                 }
 
-                // 2) 그 외 탭(전체/작성중/원본)은 항상 원본 상세로 이동
+                // 2) 그 외 탭은 항상 원본 상세
                 navigate(`${PATH.COMMUNITY_POST_SLUG(slug)}?${qs.toString()}`, {
                   state: {
                     from: "mypage",


### PR DESCRIPTION
## 🔥 Issues

- closed #174 

## ✅ What to do

- [x]  마이페이지 내 포스트 목록 조회 API 응답 <-> 화면 매핑 로직 수정

## 📄 Description

- 기존에 한 포스트에 대한 요약본 개수가 여러 개일 시 한 개만 보여줬던 문제 개선
- 원본 탭의 포스트 개수 = 원본 상태 포스트 + 생성 완료 상태 포스트

## 🤔 Considerations

- 새로 개발된 `user/troubles` API 아직 불필요해서 도입 X

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 마이페이지의 게시물 통계 계산 로직을 개선하여 더 정확한 카운트 표시

* **개선 사항**
  * 마이페이지에서 요약본을 가진 게시물을 더 명확하게 구분하여 표시
  * 요약본의 타입 정보를 라벨로 추가하여 사용자 인지도 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->