### PR TITLE
FEAT: 프리뷰 화면에서 좋아요/댓글 UI 삭제

### DIFF
--- a/src/entities/trouble/mappers/myPostDetail.mapper.ts
+++ b/src/entities/trouble/mappers/myPostDetail.mapper.ts
@@ -16,6 +16,7 @@ export type PostDetailServer = {
   title: string;
   introduction: string | null;
 
+  isVisible?: boolean;
   likeCount: number;
   commentCount: number;
   liked?: boolean | null;

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -626,8 +626,22 @@ export default function CommunityPostDetail() {
           try {
             const myDetail = await getPostDetail(effectiveId);
             const isDraft = (myDetail as any)?.completedAt == null;
-            if (isDraft) await loadMineDraft(effectiveId);
-            else await loadCommunity();
+            if (isDraft) {
+              await loadMineDraft(effectiveId);
+              return;
+            }
+
+            // 완료 문서이지만 비공개라면 커뮤니티 UX를 비활성화
+            if ((myDetail as any)?.isVisible === false) {
+              const vmMine = toPostDetailVM(myDetail as any, viewerId);
+              setPost(vmMine);
+              setIsLiked(vmMine.isLiked);
+              setLikeCounts(vmMine.likeCounts);
+              setIsCommunitySource(false);
+              return;
+            }
+
+            await loadCommunity();
           } catch {
             await loadCommunity();
           }

--- a/src/pages/TempWrite/PreviewPage.tsx
+++ b/src/pages/TempWrite/PreviewPage.tsx
@@ -8,17 +8,11 @@ import {
 import HeaderWoSearch from "@/layouts/Header/HeaderWoSearch";
 import TagList from "@/entities/trouble/ui/TagList";
 import PostGuideMd from "@/entities/trouble/ui/PostGuideMd";
-import PostComment, {
-  type PostCommentProps,
-} from "@/entities/trouble/ui/PostComment";
 import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
 import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import useClickOutside from "@/hooks/useClickOutside";
 import imageIcon from "@/assets/icons/image.svg";
 import starIcon from "@/assets/icons/star.svg";
-import heartIcon from "@/assets/icons/heart.svg";
-import likeEmptyIcon from "@/assets/icons/like_empty.svg";
-import shareIcon from "@/assets/icons/share.svg";
 import { PATH } from "@/shared/config/paths";
 import { getCombinedDetail, getPostDetail } from "@/api/post.api";
 import type {
@@ -44,10 +38,6 @@ type PreviewState = {
   importance?: number;
   questions?: string[];
   contents?: GuideContent[][];
-  isLiked?: boolean;
-  likeCounts?: number;
-  commentCounts?: number;
-  comments?: PostCommentProps[];
   savePrefill?: {
     importance?: number;
     description?: string;
@@ -128,15 +118,6 @@ export default function PreviewPage() {
   const hasAnySection = questions.length > 0 && contents.length > 0;
   const safeDate = data.date ? ymd(new Date(data.date)) : ymd(new Date());
 
-  const seedComments = (data.comments ?? []).map((c) => ({
-    ...c,
-    isReply: !!c.isReply,
-  }));
-  const [isLiked, setIsLiked] = useState<boolean>(data.isLiked ?? false);
-  const [likeCounts, setLikeCounts] = useState<number>(data.likeCounts ?? 0);
-  const [commentInput, setCommentInput] = useState("");
-  const [comments, setComments] = useState<PostCommentProps[]>(seedComments);
-
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
@@ -182,45 +163,6 @@ export default function PreviewPage() {
     if (t) window.scrollTo({ top: t.offsetTop - 180, behavior: "smooth" });
   };
 
-  // 인터랙션
-  const handleToggleLike = () => {
-    setIsLiked((v) => !v);
-    setLikeCounts((c) => (isLiked ? Math.max(0, c - 1) : c + 1));
-  };
-  const handleEdit = (id: string, newContent: string) => {
-    setComments((prev) =>
-      prev.map((c) => (c.id === id ? { ...c, content: newContent } : c))
-    );
-  };
-  const handleDelete = (id: string) => {
-    setComments((prev) => prev.filter((c) => c.id !== id && c.parentId !== id));
-  };
-  const handleReply = (parentId: string, replyContent: string) => {
-    const r: PostCommentProps = {
-      id: `${Date.now()}-r`,
-      name: base.authorName,
-      date: ymd(new Date()),
-      content: replyContent,
-      isMine: true,
-      isReply: true,
-      parentId,
-    };
-    setComments((prev) => [...prev, r]);
-  };
-  const handleCreateComment = () => {
-    const content = commentInput.trim();
-    if (!content) return;
-    const c: PostCommentProps = {
-      id: String(Date.now()),
-      name: base.authorName,
-      date: ymd(new Date()),
-      content,
-      isMine: true,
-      isReply: false,
-    };
-    setComments((prev) => [c, ...prev]);
-    setCommentInput("");
-  };
   const handleProfileClick = () => navigate(PATH.MYPAGE_BASE ?? "/");
 
   // 로딩/에러/빈데이터 처리
@@ -439,92 +381,6 @@ export default function PreviewPage() {
                     ))}
                   </div>
                 </div>
-
-                {/* 좋아요/공유 */}
-                <div className="flex pt-[52px] pb-[20px] items-center self-stretch border-b border-gray1">
-                  <div className="flex items-center gap-[20px]">
-                    <button
-                      className="flex items-center gap-[8px]"
-                      onClick={handleToggleLike}
-                      aria-pressed={isLiked}
-                    >
-                      <img
-                        src={isLiked ? heartIcon : likeEmptyIcon}
-                        alt="like"
-                        className="w-10 h-10"
-                      />
-                      <span className="text-body-20-regular text-gray3">
-                        {likeCounts}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => navigator.share?.()}
-                      aria-label="공유"
-                    >
-                      <img src={shareIcon} alt="share" className="w-10 h-10" />
-                    </button>
-                  </div>
-                </div>
-
-                {/* 댓글 입력 */}
-                <div className="flex flex-col items-end gap-[12px] self-stretch">
-                  <div className="flex flex-col items-start gap-[36px] self-stretch">
-                    <h2 className="text-head-32-semibold">
-                      {comments.filter((c) => !c.isReply).length}개의 댓글
-                    </h2>
-                    <textarea
-                      value={commentInput}
-                      onChange={(e) => setCommentInput(e.target.value)}
-                      placeholder="댓글을 작성해주세요."
-                      className="flex pt-[28px] pl-[32px] pb-[130px] w-full resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
-                    />
-                  </div>
-                  <button
-                    onClick={handleCreateComment}
-                    disabled={!commentInput.trim()}
-                    className={`flex pt-[8px] pl-[32px] pb-[12px] pr-[31px] justify-center items-center rounded-[100px] text-head-20-semibold text-white transition-colors ${
-                      commentInput.trim() ? "bg-primary" : "bg-subColor1"
-                    }`}
-                  >
-                    작성하기
-                  </button>
-                </div>
-
-                {/* 댓글 목록 */}
-                <div className="flex flex-col items-end self-stretch">
-                  {comments
-                    .filter((c) => !c.isReply)
-                    .map((parent) => (
-                      <div key={parent.id} className="w-full">
-                        <PostComment
-                          {...parent}
-                          onEdit={(newContent) =>
-                            handleEdit(parent.id, newContent)
-                          }
-                          onDelete={() => handleDelete(parent.id)}
-                          onReply={(replyContent) =>
-                            handleReply(parent.id, replyContent)
-                          }
-                        />
-                        {comments
-                          .filter((c) => c.parentId === parent.id)
-                          .map((reply) => (
-                            <PostComment
-                              key={reply.id}
-                              {...reply}
-                              onEdit={(newContent) =>
-                                handleEdit(reply.id, newContent)
-                              }
-                              onDelete={() => handleDelete(reply.id)}
-                              onReply={(replyContent) =>
-                                handleReply(reply.id, replyContent)
-                              }
-                            />
-                          ))}
-                      </div>
-                    ))}
-                </div>
               </div>
             </section>
           </main>
@@ -592,12 +448,8 @@ function mapCombinedToPreviewState(
     authorFollowers: toInt(u.followerNum),
     authorBio: u.bio ?? "",
     isMine: true,
-    isLiked: !!d.liked,
-    likeCounts: d.likeCount ?? 0,
-    commentCounts: d.commentCount ?? 0,
     questions: questions.length ? questions : [d.title ?? "내용"],
     contents: questions.length ? contents : [[d.introduction ?? ""]],
-    comments: [],
   };
 }
 function mapPostToPreviewState(d: ViewPostResponse | any): PreviewState {
@@ -615,12 +467,7 @@ function mapPostToPreviewState(d: ViewPostResponse | any): PreviewState {
     authorFollowers: toInt(u.followerNum),
     authorBio: u.bio ?? "",
     isMine: true,
-    isLiked: !!d.liked,
-    likeCounts: d.likeCount ?? 0,
-    commentCounts: d.commentCount ?? 0,
-
     questions: questions.length ? questions : [d.title ?? "내용"],
     contents: questions.length ? contents : [[d.introduction ?? ""]],
-    comments: [],
   };
 }


### PR DESCRIPTION
## 🔥 Issues

- closed #167 

## ✅ What to do

- [x] 프리뷰 화면에서 좋아요/댓글 UI 삭제
- [x] 원본+요약본 합본 조회 화면 & 비공개 포스트 상세 화면에서도 동일하게 좋아요/댓글 UI 삭제

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 공개 여부 필드 추가

* **변경 사항**
  * 드래프트 게시물 처리 흐름 개선
  * 비공개 게시물의 커뮤니티 뷰 로직 업데이트
  * 게시물 미리보기에서 좋아요, 댓글 관련 기능 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->