### PR TITLE
FEAT: 마크다운 에디터 라이브러리 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
     "@tailwindcss/typography": "^0.5.16",
+    "@toast-ui/editor": "^3.2.2",
+    "@toast-ui/react-editor": "^3.2.3",
     "@uiw/react-md-editor": "^4.0.7",
     "axios": "^1.10.0",
     "chart.js": "^4.5.0",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,37 +3,16 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-  
-  <!-- 랜딩 페이지 (최우선) -->
   <url>
     <loc>https://troublog.com/</loc>
-    <lastmod>2025-01-27</lastmod>
+    <lastmod>2025-12-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-
-  <!-- 커뮤니티 메인 페이지 -->
   <url>
     <loc>https://troublog.com/user/community</loc>
-    <lastmod>2025-01-27</lastmod>
+    <lastmod>2025-12-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
-
-  <!-- 
-    동적 경로들은 빌드 시 또는 API를 통해 동적으로 생성해야 합니다.
-    
-    동적 경로 예시 (실제 데이터로 교체 필요):
-    - /user/project/{projectId} - 프로젝트 상세 페이지
-    - /user/community/{postId} - 커뮤니티 포스트 (ID 기반)
-    - /user/community/p/{slug} - 커뮤니티 포스트 (슬러그 기반)
-    - /user/mypage/{userId} - 사용자 마이페이지
-    
-    동적 생성 방법:
-    1. 빌드 스크립트로 API 호출하여 생성 (scripts/generate-sitemap.js 참고)
-    2. 서버 사이드에서 런타임 생성
-    3. 정기적으로 업데이트하는 크론 작업
-  -->
-
 </urlset>
-

--- a/src/pages/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/pages/FreeFormWrite/EditorBlockFF.tsx
@@ -36,6 +36,7 @@ const EditorBlock = ({
   isEndDisabled = false,
 }: Props) => {
   const editorRef = useRef<EditorInstance | null>(null);
+  const hookedEditor = useRef<EditorInstance | null>(null);
   const removeDefaultText = useRemoveDefaultText(block.content);
 
   // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
@@ -50,6 +51,10 @@ const EditorBlock = ({
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
+
+    // 인스턴스당 1회만 hook 등록
+    if (hookedEditor.current === editor) return;
+    hookedEditor.current = editor;
 
     editor.addHook(
       "addImageBlobHook",

--- a/src/pages/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/pages/FreeFormWrite/EditorBlockFF.tsx
@@ -1,8 +1,9 @@
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { Editor } from "@toast-ui/react-editor";
 import type EditorInstance from "@toast-ui/editor";
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect } from "react";
 import { uploadImage } from "@/api/image.api";
+import { useRemoveDefaultText } from "@/shared/hooks/useRemoveDefaultText";
 
 export interface BlockData {
   id: number;
@@ -35,32 +36,7 @@ const EditorBlock = ({
   isEndDisabled = false,
 }: Props) => {
   const editorRef = useRef<EditorInstance | null>(null);
-
-  // 에디터 내부 기본 텍스트 제거 함수
-  const removeDefaultText = useCallback((editor: EditorInstance) => {
-    try {
-      const currentMarkdown = editor.getMarkdown();
-      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
-      const trimmedMarkdown = currentMarkdown.trim();
-
-      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
-      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
-        editor.setMarkdown("");
-      } else if (
-        defaultTexts.some((defaultText) =>
-          trimmedMarkdown.startsWith(defaultText)
-        )
-      ) {
-        // 기본 텍스트로 시작하는 경우도 제거
-        const lines = trimmedMarkdown.split("\n");
-        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
-          editor.setMarkdown("");
-        }
-      }
-    } catch {
-      // 에러 발생 시 무시
-    }
-  }, []);
+  const removeDefaultText = useRemoveDefaultText(block.content);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -80,17 +56,14 @@ const EditorBlock = ({
     );
 
     // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+    // 초기값이 비어있을 때만 실행되며, 1회만 실행됨
     removeDefaultText(editor);
     const timer = setTimeout(() => removeDefaultText(editor), 100);
     const timer2 = setTimeout(() => removeDefaultText(editor), 500);
-    const timer3 = setTimeout(() => removeDefaultText(editor), 1000);
-    const timer4 = setTimeout(() => removeDefaultText(editor), 2000);
 
     return () => {
       clearTimeout(timer);
       clearTimeout(timer2);
-      clearTimeout(timer3);
-      clearTimeout(timer4);
     };
   }, [removeDefaultText]);
 
@@ -142,13 +115,7 @@ const EditorBlock = ({
           <Editor
             ref={(editor) => {
               if (editor) {
-                const instance = editor.getInstance();
-                editorRef.current = instance;
-
-                // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
-                setTimeout(() => {
-                  removeDefaultText(instance);
-                }, 0);
+                editorRef.current = editor.getInstance();
               } else {
                 editorRef.current = null;
               }

--- a/src/pages/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/pages/FreeFormWrite/EditorBlockFF.tsx
@@ -40,46 +40,52 @@ const EditorBlock = ({
   const removeDefaultText = useRemoveDefaultText(block.content);
 
   // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
-  const editorRefCallback = useCallback((editor: any) => {
-    if (editor) {
-      editorRef.current = editor.getInstance();
-    } else {
-      editorRef.current = null;
-    }
-  }, []);
+  const handleEditorRef = useCallback(
+    (editor: any | null) => {
+      if (!editor) {
+        editorRef.current = null;
+        return;
+      }
+      const instance = editor.getInstance();
+      editorRef.current = instance;
 
+      // 인스턴스당 1회만 hook 등록
+      if (hookedEditor.current === instance) return;
+      hookedEditor.current = instance;
+
+      // 이미지 업로드 훅 설정
+      instance.addHook(
+        "addImageBlobHook",
+        async (
+          blob: Blob,
+          callback: (url: string, altText?: string) => void
+        ) => {
+          try {
+            const file = blob as File;
+            const url = await uploadImage(file);
+            callback(url, "image");
+          } catch {
+            console.error("이미지 업로드에 실패했습니다.");
+          }
+        }
+      );
+
+      // 최초 세팅 시에만(또는 block.content가 비어있을 때만) 기본 텍스트 제거
+      setTimeout(() => removeDefaultText(instance), 0);
+    },
+    [removeDefaultText]
+  );
+
+  // 외부 content 변경 동기화 (block.content가 외부에서 변경될 때)
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
 
-    // 인스턴스당 1회만 hook 등록
-    if (hookedEditor.current === editor) return;
-    hookedEditor.current = editor;
-
-    editor.addHook(
-      "addImageBlobHook",
-      async (blob: Blob, callback: (url: string, altText?: string) => void) => {
-        try {
-          const file = blob as File;
-          const url = await uploadImage(file);
-          callback(url, "image");
-        } catch {
-          console.error("이미지 업로드에 실패했습니다.");
-        }
-      }
-    );
-
-    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
-    // 초기값이 비어있을 때만 실행되며, 1회만 실행됨
-    removeDefaultText(editor);
-    const timer = setTimeout(() => removeDefaultText(editor), 100);
-    const timer2 = setTimeout(() => removeDefaultText(editor), 500);
-
-    return () => {
-      clearTimeout(timer);
-      clearTimeout(timer2);
-    };
-  }, [removeDefaultText]);
+    const currentMarkdown = editor.getMarkdown();
+    if (currentMarkdown !== block.content) {
+      editor.setMarkdown(block.content);
+    }
+  }, [block.content]);
 
   return (
     <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 pb-6">
@@ -127,7 +133,7 @@ const EditorBlock = ({
         {/* 에디터 */}
         <div className="w-full">
           <Editor
-            ref={editorRefCallback}
+            ref={handleEditorRef}
             initialValue={block.content || ""}
             onChange={() => {
               const editor = editorRef.current;

--- a/src/pages/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/pages/FreeFormWrite/EditorBlockFF.tsx
@@ -1,4 +1,8 @@
-import MDEditor from "@uiw/react-md-editor";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import { Editor } from "@toast-ui/react-editor";
+import type EditorInstance from "@toast-ui/editor";
+import { useRef, useEffect, useCallback } from "react";
+import { uploadImage } from "@/api/image.api";
 
 export interface BlockData {
   id: number;
@@ -30,6 +34,66 @@ const EditorBlock = ({
   onEnd,
   isEndDisabled = false,
 }: Props) => {
+  const editorRef = useRef<EditorInstance | null>(null);
+
+  // 에디터 내부 기본 텍스트 제거 함수
+  const removeDefaultText = useCallback((editor: EditorInstance) => {
+    try {
+      const currentMarkdown = editor.getMarkdown();
+      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+      const trimmedMarkdown = currentMarkdown.trim();
+
+      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
+        editor.setMarkdown("");
+      } else if (
+        defaultTexts.some((defaultText) =>
+          trimmedMarkdown.startsWith(defaultText)
+        )
+      ) {
+        // 기본 텍스트로 시작하는 경우도 제거
+        const lines = trimmedMarkdown.split("\n");
+        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
+          editor.setMarkdown("");
+        }
+      }
+    } catch {
+      // 에러 발생 시 무시
+    }
+  }, []);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    editor.addHook(
+      "addImageBlobHook",
+      async (blob: Blob, callback: (url: string, altText?: string) => void) => {
+        try {
+          const file = blob as File;
+          const url = await uploadImage(file);
+          callback(url, "image");
+        } catch {
+          console.error("이미지 업로드에 실패했습니다.");
+        }
+      }
+    );
+
+    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+    removeDefaultText(editor);
+    const timer = setTimeout(() => removeDefaultText(editor), 100);
+    const timer2 = setTimeout(() => removeDefaultText(editor), 500);
+    const timer3 = setTimeout(() => removeDefaultText(editor), 1000);
+    const timer4 = setTimeout(() => removeDefaultText(editor), 2000);
+
+    return () => {
+      clearTimeout(timer);
+      clearTimeout(timer2);
+      clearTimeout(timer3);
+      clearTimeout(timer4);
+    };
+  }, [removeDefaultText]);
+
   return (
     <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 pb-6">
       <div className="flex flex-col gap-4 w-full max-w-screen-lg mx-auto">
@@ -74,14 +138,33 @@ const EditorBlock = ({
         </div>
 
         {/* 에디터 */}
-        <div data-color-mode="light" className="w-full">
-          <MDEditor
-            value={block.content}
-            onChange={(val) => onChange(index, { content: val || "" })}
-            preview={isActive ? "edit" : "preview"}
-            height={isActive ? 300 : 300}
-            autoFocus={isActive}
-            className="w-full"
+        <div className="w-full">
+          <Editor
+            ref={(editor) => {
+              if (editor) {
+                const instance = editor.getInstance();
+                editorRef.current = instance;
+
+                // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
+                setTimeout(() => {
+                  removeDefaultText(instance);
+                }, 0);
+              } else {
+                editorRef.current = null;
+              }
+            }}
+            initialValue={block.content || ""}
+            onChange={() => {
+              const editor = editorRef.current;
+              if (editor) {
+                const markdown = editor.getMarkdown();
+                onChange(index, { content: markdown });
+              }
+            }}
+            height="300px"
+            initialEditType="markdown"
+            previewStyle="vertical"
+            usageStatistics={false}
           />
         </div>
       </div>

--- a/src/pages/FreeFormWrite/EditorBlockFF.tsx
+++ b/src/pages/FreeFormWrite/EditorBlockFF.tsx
@@ -1,7 +1,7 @@
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { Editor } from "@toast-ui/react-editor";
 import type EditorInstance from "@toast-ui/editor";
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useCallback } from "react";
 import { uploadImage } from "@/api/image.api";
 import { useRemoveDefaultText } from "@/shared/hooks/useRemoveDefaultText";
 
@@ -37,6 +37,15 @@ const EditorBlock = ({
 }: Props) => {
   const editorRef = useRef<EditorInstance | null>(null);
   const removeDefaultText = useRemoveDefaultText(block.content);
+
+  // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
+  const editorRefCallback = useCallback((editor: any) => {
+    if (editor) {
+      editorRef.current = editor.getInstance();
+    } else {
+      editorRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -113,13 +122,7 @@ const EditorBlock = ({
         {/* 에디터 */}
         <div className="w-full">
           <Editor
-            ref={(editor) => {
-              if (editor) {
-                editorRef.current = editor.getInstance();
-              } else {
-                editorRef.current = null;
-              }
-            }}
+            ref={editorRefCallback}
             initialValue={block.content || ""}
             onChange={() => {
               const editor = editorRef.current;

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -978,37 +978,41 @@ export default function FreeFormWritePage() {
     [blocks]
   );
 
-  // 각 블록별 ref 콜백을 메모이제이션하여 불필요한 detach/attach 방지
-  const editorRefCallbacks = useMemo(() => {
-    const callbacks = new Map<number, (editor: any) => void>();
-    blocks.forEach((block) => {
-      callbacks.set(block.id, (editor: any) => {
-        if (editor) {
-          const instance = editor.getInstance();
-          editorRefs.current.set(block.id, instance);
-          setupImageUploadHook(instance);
+  // 각 블록별 ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
+  const createEditorRefCallback = useCallback(
+    (blockId: number) => (editor: any | null) => {
+      if (!editor) {
+        editorRefs.current.delete(blockId);
+        return;
+      }
+      const instance = editor.getInstance();
+      editorRefs.current.set(blockId, instance);
+      setupImageUploadHook(instance);
 
-          // 에디터 인스턴스가 처음 생성될 때만 기본 텍스트 제거 (1회만 실행)
-          // 초기값이 비어있을 때만 실행 (데이터 손실 방지)
-          if (
-            !processedBlocks.current.has(block.id) &&
-            (block.content ?? "").trim().length === 0
-          ) {
-            // 즉시 실행 및 지연 실행 (에디터 렌더링 완료 대기)
-            removeDefaultTextForBlock(block.id);
-            setTimeout(() => removeDefaultTextForBlock(block.id), 100);
-            setTimeout(() => removeDefaultTextForBlock(block.id), 500);
-          } else if (!processedBlocks.current.has(block.id)) {
-            // 초기값이 있으면 처리 완료로 표시
-            processedBlocks.current.add(block.id);
-          }
-        } else {
-          editorRefs.current.delete(block.id);
-        }
-      });
+      // 최초 세팅 시에만(또는 block.content가 비어있을 때만) 기본 텍스트 제거
+      const block = blocks.find((b) => b.id === blockId);
+      if (
+        block &&
+        !processedBlocks.current.has(blockId) &&
+        (block.content ?? "").trim().length === 0
+      ) {
+        setTimeout(() => removeDefaultTextForBlock(blockId), 0);
+      } else if (block && !processedBlocks.current.has(blockId)) {
+        // 초기값이 있으면 처리 완료로 표시
+        processedBlocks.current.add(blockId);
+      }
+    },
+    [blocks, setupImageUploadHook, removeDefaultTextForBlock]
+  );
+
+  // 각 블록별 ref 콜백을 메모이제이션
+  const editorRefCallbacks = useMemo(() => {
+    const callbacks = new Map<number, (editor: any | null) => void>();
+    blocks.forEach((block) => {
+      callbacks.set(block.id, createEditorRefCallback(block.id));
     });
     return callbacks;
-  }, [blocks, setupImageUploadHook, removeDefaultTextForBlock]);
+  }, [blocks, createEditorRefCallback]);
 
   // Editor content 동기화
   useEffect(() => {

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -910,9 +910,14 @@ export default function FreeFormWritePage() {
 
   // ---------- Toast UI Editor refs ----------
   const editorRefs = useRef<Map<number, EditorInstance>>(new Map());
+  const hookedEditors = useRef<WeakSet<object>>(new WeakSet());
 
   // 이미지 업로드 - Toast UI Editor hook 설정
   const setupImageUploadHook = useCallback((editor: EditorInstance) => {
+    // 인스턴스당 1회만 hook 등록
+    if (hookedEditors.current.has(editor as unknown as object)) return;
+    hookedEditors.current.add(editor as unknown as object);
+
     editor.addHook(
       "addImageBlobHook",
       async (blob: Blob, callback: (url: string, altText?: string) => void) => {

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -927,67 +927,73 @@ export default function FreeFormWritePage() {
     );
   }, []);
 
-  // 에디터 내부 기본 텍스트 제거
-  const removeDefaultText = useCallback((editor: EditorInstance) => {
-    try {
-      const currentMarkdown = editor.getMarkdown();
-      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
-      const trimmedMarkdown = currentMarkdown.trim();
+  // 각 블록별로 기본 텍스트 제거 함수 생성 (초기값이 비어있을 때만 실행)
+  const removeDefaultTextForBlock = useCallback(
+    (blockId: number) => {
+      const block = blocks.find((b) => b.id === blockId);
+      if (!block) return;
 
-      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
-      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
-        editor.setMarkdown("");
-      } else if (
-        defaultTexts.some((defaultText) =>
-          trimmedMarkdown.startsWith(defaultText)
-        )
-      ) {
-        // 기본 텍스트로 시작하는 경우도 제거
-        const lines = trimmedMarkdown.split("\n");
-        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
+      const editor = editorRefs.current.get(blockId);
+      if (!editor) return;
+
+      // 초기값이 비어있지 않으면 실행하지 않음 (데이터 손실 방지)
+      if (block.content.trim() !== "") {
+        return;
+      }
+
+      try {
+        const currentMarkdown = editor.getMarkdown();
+        const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+        const trimmedMarkdown = currentMarkdown.trim();
+
+        // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+        const isDefaultText =
+          defaultTexts.some((defaultText) => trimmedMarkdown === defaultText) ||
+          (defaultTexts.some((defaultText) =>
+            trimmedMarkdown.startsWith(defaultText)
+          ) &&
+            trimmedMarkdown.split("\n").length > 0 &&
+            defaultTexts.includes(trimmedMarkdown.split("\n")[0].trim()));
+
+        if (isDefaultText) {
           editor.setMarkdown("");
         }
+      } catch {
+        // 에러 발생 시 무시
       }
-    } catch {
-      // 에러 발생 시 무시
-    }
-  }, []);
+    },
+    [blocks]
+  );
 
   useEffect(() => {
-    // 모든 에디터 인스턴스에 대해 기본 텍스트 제거
-    editorRefs.current.forEach((editor) => {
-      removeDefaultText(editor);
+    // 각 블록에 대해 초기값이 비어있을 때만 기본 텍스트 제거
+    blocks.forEach((block) => {
+      if (block.content.trim() === "") {
+        removeDefaultTextForBlock(block.id);
+      }
     });
 
     // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
     const timer = setTimeout(() => {
-      editorRefs.current.forEach((editor) => {
-        removeDefaultText(editor);
+      blocks.forEach((block) => {
+        if (block.content.trim() === "") {
+          removeDefaultTextForBlock(block.id);
+        }
       });
     }, 100);
     const timer2 = setTimeout(() => {
-      editorRefs.current.forEach((editor) => {
-        removeDefaultText(editor);
+      blocks.forEach((block) => {
+        if (block.content.trim() === "") {
+          removeDefaultTextForBlock(block.id);
+        }
       });
     }, 500);
-    const timer3 = setTimeout(() => {
-      editorRefs.current.forEach((editor) => {
-        removeDefaultText(editor);
-      });
-    }, 1000);
-    const timer4 = setTimeout(() => {
-      editorRefs.current.forEach((editor) => {
-        removeDefaultText(editor);
-      });
-    }, 2000);
 
     return () => {
       clearTimeout(timer);
       clearTimeout(timer2);
-      clearTimeout(timer3);
-      clearTimeout(timer4);
     };
-  }, [blocks, removeDefaultText]);
+  }, [blocks, removeDefaultTextForBlock]);
 
   // Editor content 동기화
   useEffect(() => {
@@ -1174,14 +1180,8 @@ export default function FreeFormWritePage() {
                   <Editor
                     ref={(editor) => {
                       if (editor) {
-                        const instance = editor.getInstance();
-                        editorRefs.current.set(block.id, instance);
-                        setupImageUploadHook(instance);
-
-                        // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
-                        setTimeout(() => {
-                          removeDefaultText(instance);
-                        }, 0);
+                        editorRefs.current.set(block.id, editor.getInstance());
+                        setupImageUploadHook(editor.getInstance());
                       } else {
                         editorRefs.current.delete(block.id);
                       }

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -2,12 +2,9 @@ import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import HeaderWoSearch from "@/layouts/Header/HeaderWoSearch";
 import DropDownButton from "@/shared/ui/Button/DropDownButton";
 import CategoryTag from "@/shared/ui/Editor/CategoryTag";
-import MDEditor, {
-  commands,
-  TextAreaTextApi,
-  type ICommand,
-  type TextState,
-} from "@uiw/react-md-editor";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import { Editor } from "@toast-ui/react-editor";
+import type EditorInstance from "@toast-ui/editor";
 import PostSaveModal, {
   type PostSavePayload,
 } from "@/shared/ui/Modal/PostSaveModal";
@@ -911,187 +908,112 @@ export default function FreeFormWritePage() {
     );
   };
 
-  // ---------- (추가) 오토사이즈 상태/로직 ----------
-  const [editorHeights, setEditorHeights] = useState<Record<number, number>>(
-    {}
-  );
-  const editorWrapRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  // ---------- Toast UI Editor refs ----------
+  const editorRefs = useRef<Map<number, EditorInstance>>(new Map());
 
-  const autosizeFor = useCallback((blockId: number) => {
-    const root = editorWrapRefs.current.get(blockId);
-    if (!root) return;
-
-    const ta = root.querySelector("textarea") as HTMLTextAreaElement | null;
-    if (!ta) return;
-
-    // textarea 실제 내용 높이 측정
-    const prev = ta.style.height;
-    ta.style.height = "auto";
-    const taScrollH = ta.scrollHeight;
-
-    // 크롬(툴바/바텀바/패딩/보더) 높이 합산
-    const editorRoot = ta.closest(".w-md-editor") as HTMLElement | null;
-    const toolbar = editorRoot?.querySelector(
-      ".w-md-editor-toolbar"
-    ) as HTMLElement | null;
-    const bottombar = editorRoot?.querySelector(
-      ".w-md-editor-bar"
-    ) as HTMLElement | null;
-
-    const toolbarH = toolbar?.offsetHeight ?? 0;
-    const bottombarH = bottombar?.offsetHeight ?? 0;
-
-    const taCS = getComputedStyle(ta);
-    const taVPad =
-      (parseFloat(taCS.paddingTop || "0") || 0) +
-      (parseFloat(taCS.paddingBottom || "0") || 0);
-
-    const taWrap = ta.parentElement as HTMLElement | null;
-    const wrapCS = taWrap ? getComputedStyle(taWrap) : null;
-    const wrapVPad = wrapCS
-      ? (parseFloat(wrapCS.paddingTop || "0") || 0) +
-        (parseFloat(wrapCS.paddingBottom || "0") || 0)
-      : 0;
-
-    const rootCS = editorRoot ? getComputedStyle(editorRoot) : null;
-    const rootVPad =
-      (rootCS ? parseFloat(rootCS.paddingTop || "0") : 0) +
-      (rootCS ? parseFloat(rootCS.paddingBottom || "0") : 0);
-    const rootVBorder =
-      (rootCS ? parseFloat(rootCS.borderTopWidth || "0") : 0) +
-      (rootCS ? parseFloat(rootCS.borderBottomWidth || "0") : 0);
-
-    const chrome =
-      toolbarH + bottombarH + taVPad + wrapVPad + rootVPad + rootVBorder + 16;
-
-    const next = Math.max(300, Math.min(30000, taScrollH + chrome));
-    setEditorHeights((prevHeights) =>
-      prevHeights[blockId] === next
-        ? prevHeights
-        : { ...prevHeights, [blockId]: next }
+  // 이미지 업로드 - Toast UI Editor hook 설정
+  const setupImageUploadHook = useCallback((editor: EditorInstance) => {
+    editor.addHook(
+      "addImageBlobHook",
+      async (blob: Blob, callback: (url: string, altText?: string) => void) => {
+        try {
+          const file = blob as File;
+          const url = await uploadImage(file);
+          callback(url, "image");
+        } catch {
+          setStatusMessage("이미지 업로드에 실패했어요.");
+        }
+      }
     );
+  }, []);
 
-    ta.style.height = prev;
+  // 에디터 내부 기본 텍스트 제거
+  const removeDefaultText = useCallback((editor: EditorInstance) => {
+    try {
+      const currentMarkdown = editor.getMarkdown();
+      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+      const trimmedMarkdown = currentMarkdown.trim();
+
+      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
+        editor.setMarkdown("");
+      } else if (
+        defaultTexts.some((defaultText) =>
+          trimmedMarkdown.startsWith(defaultText)
+        )
+      ) {
+        // 기본 텍스트로 시작하는 경우도 제거
+        const lines = trimmedMarkdown.split("\n");
+        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
+          editor.setMarkdown("");
+        }
+      }
+    } catch {
+      // 에러 발생 시 무시
+    }
   }, []);
 
   useEffect(() => {
-    const recalcAll = () => {
-      for (const b of blocks) requestAnimationFrame(() => autosizeFor(b.id));
+    // 모든 에디터 인스턴스에 대해 기본 텍스트 제거
+    editorRefs.current.forEach((editor) => {
+      removeDefaultText(editor);
+    });
+
+    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+    const timer = setTimeout(() => {
+      editorRefs.current.forEach((editor) => {
+        removeDefaultText(editor);
+      });
+    }, 100);
+    const timer2 = setTimeout(() => {
+      editorRefs.current.forEach((editor) => {
+        removeDefaultText(editor);
+      });
+    }, 500);
+    const timer3 = setTimeout(() => {
+      editorRefs.current.forEach((editor) => {
+        removeDefaultText(editor);
+      });
+    }, 1000);
+    const timer4 = setTimeout(() => {
+      editorRefs.current.forEach((editor) => {
+        removeDefaultText(editor);
+      });
+    }, 2000);
+
+    return () => {
+      clearTimeout(timer);
+      clearTimeout(timer2);
+      clearTimeout(timer3);
+      clearTimeout(timer4);
     };
-    window.addEventListener("resize", recalcAll);
-    return () => window.removeEventListener("resize", recalcAll);
-  }, [blocks, autosizeFor]);
+  }, [blocks, removeDefaultText]);
 
+  // Editor content 동기화
   useEffect(() => {
-    // 블록 개수 변경 시 1프레임 뒤 초기 계산
-    for (const b of blocks) requestAnimationFrame(() => autosizeFor(b.id));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blocks.length]);
-
-  // 이미지 업로드 - 드래그 앤 드롭
-  const insertImageMarkdown = (blockId: number, url: string) => {
-    setBlocks((prev) =>
-      prev.map((b) =>
-        b.id === blockId
-          ? { ...b, content: `${b.content?.trim()}\n\n![image](${url})` }
-          : b
-      )
-    );
-  };
-
-  const handlePasteImage = async (
-    blockId: number,
-    e: React.ClipboardEvent<HTMLTextAreaElement>
-  ) => {
-    const files = e.clipboardData?.files;
-    const file = files && files[0];
-    if (file && file.type.startsWith("image/")) {
-      e.preventDefault();
-      try {
-        const url = await uploadImage(file); // onProgress 필요하면 2번째 인자 사용 가능
-        insertImageMarkdown(blockId, url);
-      } catch {
-        setStatusMessage("이미지 업로드에 실패했어요.");
-      } finally {
-        requestAnimationFrame(() => autosizeFor(blockId));
-      }
-    }
-  };
-
-  const handleDropImage = async (
-    blockId: number,
-    e: React.DragEvent<HTMLTextAreaElement>
-  ) => {
-    const file = e.dataTransfer?.files?.[0];
-    if (file && file.type.startsWith("image/")) {
-      e.preventDefault();
-      try {
-        const url = await uploadImage(file);
-        insertImageMarkdown(blockId, url);
-      } catch {
-        setStatusMessage("이미지 업로드에 실패했어요.");
-      } finally {
-        requestAnimationFrame(() => autosizeFor(blockId));
-      }
-    }
-  };
-
-  // 이미지 업로드 - 파일 선택
-  const fileRef = useRef<HTMLInputElement | null>(null);
-
-  // 선택 텍스트를 alt로 쓰고, 없으면 기본 "image" 사용
-  const insertImage = (state: TextState, api: TextAreaTextApi, url: string) => {
-    const alt = state.selectedText?.trim() || "image";
-    const md = `![${alt}](${url})`;
-    api.replaceSelection(md);
-
-    const pos = state.selection.start + md.length;
-    api.setSelectionRange({ start: pos, end: pos });
-  };
-
-  const imageUploadCmd: ICommand = {
-    name: "imageUpload",
-    keyCommand: "image",
-    icon: commands.image.icon, // 기본 이미지 아이콘 재사용
-    buttonProps: { "aria-label": "이미지 업로드" },
-    execute: (state, api) => {
-      const input = fileRef.current;
-      if (!input) return;
-
-      const onPick = async (e: Event) => {
-        input.removeEventListener("change", onPick);
-        const file = (e.target as HTMLInputElement).files?.[0];
-        (e.target as HTMLInputElement).value = ""; // 같은 파일 재선택 허용
-        if (!file) return;
-
-        try {
-          const url = await uploadImage(file);
-          insertImage(state, api, url);
-        } catch {
-          // 필요시 상태 메시지/토스트 처리
+    blocks.forEach((block) => {
+      const editor = editorRefs.current.get(block.id);
+      if (editor) {
+        const currentMarkdown = editor.getMarkdown();
+        if (currentMarkdown !== block.content) {
+          editor.setMarkdown(block.content);
         }
-      };
-
-      input.accept = "image/*";
-      input.addEventListener("change", onPick, { once: true });
-      input.click();
-    },
-  };
+      }
+    });
+  }, [blocks]);
 
   // (기존 함수들 아래에 추가)
 
   const buildEditFormFromMeta = async (
     meta: PostSavePayload,
-    opts?: { mode?: "temp" | "final" | "summary" } // temp: 임시 저장, final: 최종 저장, summary: 요약 시작 직전 저장
+    opts?: { mode?: "temp" | "final" | "summary" }
   ) => {
     const tags = await canonicalizeTags(selectedTags);
     const mode = opts?.mode ?? "temp";
     const nextStatus: "WRITING" | "COMPLETED" | "SUMMARIZED" = (() => {
-      // 최종 저장이거나 요약 시작 직전에는 COMPLETED로 고정(단, 기존이 SUMMARIZED면 유지)
       if (mode === "final" || mode === "summary") {
         return initialPostStatus === "SUMMARIZED" ? "SUMMARIZED" : "COMPLETED";
       }
-      // 임시 저장은 기존 정책 유지
       return wasEverCompleted ? initialPostStatus ?? "COMPLETED" : "WRITING";
     })();
     return buildForm(nextStatus, meta, tags);
@@ -1104,7 +1026,7 @@ export default function FreeFormWritePage() {
       const form = await buildEditFormFromMeta(previewMeta, { mode: "final" });
       await editPost(resumePostId, toEditPostRequest(form) as any);
       setDraftPostId(resumePostId);
-      setCreatedPostId(resumePostId); // 이후 미리보기/네비에 활용
+      setCreatedPostId(resumePostId);
       setShowSaveAlert(true);
       setTimeout(() => setShowSaveAlert(false), 1000);
     } catch (e) {
@@ -1248,51 +1170,35 @@ export default function FreeFormWritePage() {
                   )}
                 </div>
 
-                {/* 🔹 오토사이즈 래퍼 + height 주입 */}
-                <div
-                  ref={(el) => {
-                    if (el) editorWrapRefs.current.set(block.id, el);
-                    else editorWrapRefs.current.delete(block.id);
-                    requestAnimationFrame(() => autosizeFor(block.id));
-                  }}
-                  className="mt-2"
-                >
-                  <div data-color-mode="light">
-                    <MDEditor
-                      value={block.content}
-                      onChange={(val?: string) => {
-                        handleChangeBlock(block.id, "content", val ?? "");
-                        requestAnimationFrame(() => autosizeFor(block.id));
-                      }}
-                      preview="edit"
-                      height={editorHeights[block.id] ?? 300}
-                      textareaProps={{
-                        onPaste: (
-                          e: React.ClipboardEvent<HTMLTextAreaElement>
-                        ) => {
-                          handlePasteImage(block.id, e);
-                          requestAnimationFrame(() => autosizeFor(block.id));
-                        },
-                        onDrop: (e: React.DragEvent<HTMLTextAreaElement>) => {
-                          handleDropImage(block.id, e);
-                          requestAnimationFrame(() => autosizeFor(block.id));
-                        },
-                        onInput: () =>
-                          requestAnimationFrame(() => autosizeFor(block.id)),
-                        onDragOver: (
-                          e: React.DragEvent<HTMLTextAreaElement>
-                        ) => {
-                          if (e.dataTransfer?.types?.includes("Files")) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }
-                        },
-                      }}
-                      commandsFilter={(cmd: ICommand): ICommand =>
-                        cmd.keyCommand === "image" ? imageUploadCmd : cmd
+                <div className="mt-2">
+                  <Editor
+                    ref={(editor) => {
+                      if (editor) {
+                        const instance = editor.getInstance();
+                        editorRefs.current.set(block.id, instance);
+                        setupImageUploadHook(instance);
+
+                        // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
+                        setTimeout(() => {
+                          removeDefaultText(instance);
+                        }, 0);
+                      } else {
+                        editorRefs.current.delete(block.id);
                       }
-                    />
-                  </div>
+                    }}
+                    initialValue={block.content || ""}
+                    onChange={() => {
+                      const editor = editorRefs.current.get(block.id);
+                      if (editor) {
+                        const markdown = editor.getMarkdown();
+                        handleChangeBlock(block.id, "content", markdown);
+                      }
+                    }}
+                    height="300px"
+                    initialEditType="markdown"
+                    previewStyle="vertical"
+                    usageStatistics={false}
+                  />
                 </div>
               </div>
             ))}
@@ -1433,8 +1339,6 @@ export default function FreeFormWritePage() {
           </div>
         </div>
       </div>
-
-      <input ref={fileRef} type="file" hidden />
     </div>
   );
 }

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -927,6 +927,23 @@ export default function FreeFormWritePage() {
     );
   }, []);
 
+  // 각 블록별 ref 콜백을 메모이제이션하여 불필요한 detach/attach 방지
+  const editorRefCallbacks = useMemo(() => {
+    const callbacks = new Map<number, (editor: any) => void>();
+    blocks.forEach((block) => {
+      callbacks.set(block.id, (editor: any) => {
+        if (editor) {
+          const instance = editor.getInstance();
+          editorRefs.current.set(block.id, instance);
+          setupImageUploadHook(instance);
+        } else {
+          editorRefs.current.delete(block.id);
+        }
+      });
+    });
+    return callbacks;
+  }, [blocks, setupImageUploadHook]);
+
   // 각 블록별로 기본 텍스트 제거 함수 생성 (초기값이 비어있을 때만 실행)
   const removeDefaultTextForBlock = useCallback(
     (blockId: number) => {
@@ -1178,14 +1195,7 @@ export default function FreeFormWritePage() {
 
                 <div className="mt-2">
                   <Editor
-                    ref={(editor) => {
-                      if (editor) {
-                        editorRefs.current.set(block.id, editor.getInstance());
-                        setupImageUploadHook(editor.getInstance());
-                      } else {
-                        editorRefs.current.delete(block.id);
-                      }
-                    }}
+                    ref={editorRefCallbacks.get(block.id)}
                     initialValue={block.content || ""}
                     onChange={() => {
                       const editor = editorRefs.current.get(block.id);

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -947,8 +947,8 @@ export default function FreeFormWritePage() {
       const editor = editorRefs.current.get(blockId);
       if (!editor) return;
 
-      // 초기값이 비어있지 않으면 실행하지 않음 (데이터 손실 방지)
-      if (block.content.trim() !== "") {
+      // 이미 초기값이 있으면 절대 지우지 않기 (데이터 손실 방지)
+      if ((block.content ?? "").trim().length > 0) {
         processedBlocks.current.add(blockId); // 처리 완료로 표시
         return;
       }
@@ -989,9 +989,10 @@ export default function FreeFormWritePage() {
           setupImageUploadHook(instance);
 
           // 에디터 인스턴스가 처음 생성될 때만 기본 텍스트 제거 (1회만 실행)
+          // 초기값이 비어있을 때만 실행 (데이터 손실 방지)
           if (
             !processedBlocks.current.has(block.id) &&
-            block.content.trim() === ""
+            (block.content ?? "").trim().length === 0
           ) {
             // 즉시 실행 및 지연 실행 (에디터 렌더링 완료 대기)
             removeDefaultTextForBlock(block.id);

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -932,26 +932,15 @@ export default function FreeFormWritePage() {
     );
   }, []);
 
-  // 각 블록별 ref 콜백을 메모이제이션하여 불필요한 detach/attach 방지
-  const editorRefCallbacks = useMemo(() => {
-    const callbacks = new Map<number, (editor: any) => void>();
-    blocks.forEach((block) => {
-      callbacks.set(block.id, (editor: any) => {
-        if (editor) {
-          const instance = editor.getInstance();
-          editorRefs.current.set(block.id, instance);
-          setupImageUploadHook(instance);
-        } else {
-          editorRefs.current.delete(block.id);
-        }
-      });
-    });
-    return callbacks;
-  }, [blocks, setupImageUploadHook]);
+  // 각 블록별로 기본 텍스트 제거 처리 여부 추적
+  const processedBlocks = useRef<Set<number>>(new Set());
 
-  // 각 블록별로 기본 텍스트 제거 함수 생성 (초기값이 비어있을 때만 실행)
+  // 기본 텍스트 제거 함수 (에디터 인스턴스가 처음 생성될 때만 실행)
   const removeDefaultTextForBlock = useCallback(
     (blockId: number) => {
+      // 이미 처리한 블록은 건너뛰기
+      if (processedBlocks.current.has(blockId)) return;
+
       const block = blocks.find((b) => b.id === blockId);
       if (!block) return;
 
@@ -960,6 +949,7 @@ export default function FreeFormWritePage() {
 
       // 초기값이 비어있지 않으면 실행하지 않음 (데이터 손실 방지)
       if (block.content.trim() !== "") {
+        processedBlocks.current.add(blockId); // 처리 완료로 표시
         return;
       }
 
@@ -980,6 +970,7 @@ export default function FreeFormWritePage() {
         if (isDefaultText) {
           editor.setMarkdown("");
         }
+        processedBlocks.current.add(blockId); // 처리 완료로 표시
       } catch {
         // 에러 발생 시 무시
       }
@@ -987,35 +978,36 @@ export default function FreeFormWritePage() {
     [blocks]
   );
 
-  useEffect(() => {
-    // 각 블록에 대해 초기값이 비어있을 때만 기본 텍스트 제거
+  // 각 블록별 ref 콜백을 메모이제이션하여 불필요한 detach/attach 방지
+  const editorRefCallbacks = useMemo(() => {
+    const callbacks = new Map<number, (editor: any) => void>();
     blocks.forEach((block) => {
-      if (block.content.trim() === "") {
-        removeDefaultTextForBlock(block.id);
-      }
+      callbacks.set(block.id, (editor: any) => {
+        if (editor) {
+          const instance = editor.getInstance();
+          editorRefs.current.set(block.id, instance);
+          setupImageUploadHook(instance);
+
+          // 에디터 인스턴스가 처음 생성될 때만 기본 텍스트 제거 (1회만 실행)
+          if (
+            !processedBlocks.current.has(block.id) &&
+            block.content.trim() === ""
+          ) {
+            // 즉시 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+            removeDefaultTextForBlock(block.id);
+            setTimeout(() => removeDefaultTextForBlock(block.id), 100);
+            setTimeout(() => removeDefaultTextForBlock(block.id), 500);
+          } else if (!processedBlocks.current.has(block.id)) {
+            // 초기값이 있으면 처리 완료로 표시
+            processedBlocks.current.add(block.id);
+          }
+        } else {
+          editorRefs.current.delete(block.id);
+        }
+      });
     });
-
-    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
-    const timer = setTimeout(() => {
-      blocks.forEach((block) => {
-        if (block.content.trim() === "") {
-          removeDefaultTextForBlock(block.id);
-        }
-      });
-    }, 100);
-    const timer2 = setTimeout(() => {
-      blocks.forEach((block) => {
-        if (block.content.trim() === "") {
-          removeDefaultTextForBlock(block.id);
-        }
-      });
-    }, 500);
-
-    return () => {
-      clearTimeout(timer);
-      clearTimeout(timer2);
-    };
-  }, [blocks, removeDefaultTextForBlock]);
+    return callbacks;
+  }, [blocks, setupImageUploadHook, removeDefaultTextForBlock]);
 
   // Editor content 동기화
   useEffect(() => {

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -34,12 +34,6 @@ import {
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
-import {
-  commands,
-  TextAreaTextApi,
-  type ICommand,
-  type TextState,
-} from "@uiw/react-md-editor";
 import { isAxiosError } from "axios";
 import { startRefresh } from "@/api/axios";
 
@@ -1001,49 +995,6 @@ const TempWritePage = () => {
     }
   };
 
-  // 이미지 업로드 - 파일 선택
-  const fileRef = useRef<HTMLInputElement | null>(null);
-
-  // 선택 텍스트를 alt로 쓰고, 없으면 기본 "image" 사용
-  const insertImage = (state: TextState, api: TextAreaTextApi, url: string) => {
-    const alt = state.selectedText?.trim() || "image";
-    const md = `![${alt}](${url})`;
-    api.replaceSelection(md);
-
-    const pos = state.selection.start + md.length;
-    api.setSelectionRange({ start: pos, end: pos });
-  };
-
-  const imageUploadCmd: ICommand = {
-    name: "imageUpload",
-    keyCommand: "image",
-    icon: commands.image.icon, // 기본 이미지 아이콘 재사용
-    buttonProps: { "aria-label": "이미지 업로드" },
-    execute: (state, api) => {
-      const input = fileRef.current;
-      if (!input) return;
-
-      const onPick = async (e: Event) => {
-        input.removeEventListener("change", onPick);
-        const file = (e.target as HTMLInputElement).files?.[0];
-        (e.target as HTMLInputElement).value = ""; // 같은 파일 재선택 허용
-        if (!file) return;
-
-        try {
-          const url = await uploadImage(file);
-          insertImage(state, api, url);
-        } catch {
-          // 필요시 상태 메시지/토스트 처리
-          // setStatusMessage("이미지 업로드에 실패했어요.");
-        }
-      };
-
-      input.accept = "image/*";
-      input.addEventListener("change", onPick, { once: true });
-      input.click();
-    },
-  };
-
   const reversedBlocks = useMemo(() => {
     return [...blocks].reverse().map((block, index) => ({
       block,
@@ -1169,9 +1120,6 @@ const TempWritePage = () => {
                   onActivate={(i) => setActiveIndex(i)}
                   onPasteImage={handlePasteImage}
                   onDropImage={handleDropImage}
-                  commandsFilter={(cmd) =>
-                    cmd.keyCommand === "image" ? imageUploadCmd : cmd
-                  }
                 />
               </div>
             ))}
@@ -1257,8 +1205,6 @@ const TempWritePage = () => {
           )}
         </div>
       </div>
-
-      <input ref={fileRef} type="file" accept="image/*" hidden />
     </div>
   );
 };

--- a/src/shared/hooks/useRemoveDefaultText.ts
+++ b/src/shared/hooks/useRemoveDefaultText.ts
@@ -13,8 +13,8 @@ export function useRemoveDefaultText(initialContent: string) {
 
   const removeDefaultText = useCallback(
     (editor: EditorInstance) => {
-      // 초기값이 비어있지 않으면 실행하지 않음 (데이터 손실 방지)
-      if (initialContent.trim() !== "") {
+      // 이미 초기값이 있으면 절대 지우지 않기 (데이터 손실 방지)
+      if ((initialContent ?? "").trim().length > 0) {
         return;
       }
 

--- a/src/shared/hooks/useRemoveDefaultText.ts
+++ b/src/shared/hooks/useRemoveDefaultText.ts
@@ -1,0 +1,52 @@
+import { useRef, useCallback } from "react";
+import type EditorInstance from "@toast-ui/editor";
+
+/**
+ * Toast UI Editor의 기본 텍스트("Write", "Preview", "Markdown", "WYSIWYG")를 제거하는 훅
+ * 초기값이 비어있을 때만 1회 실행되도록 가드가 포함되어 있습니다.
+ *
+ * @param initialContent - 에디터의 초기 콘텐츠 (비어있을 때만 기본 텍스트 제거)
+ * @returns removeDefaultText 함수
+ */
+export function useRemoveDefaultText(initialContent: string) {
+  const hasRemovedRef = useRef(false);
+
+  const removeDefaultText = useCallback(
+    (editor: EditorInstance) => {
+      // 초기값이 비어있지 않으면 실행하지 않음 (데이터 손실 방지)
+      if (initialContent.trim() !== "") {
+        return;
+      }
+
+      // 이미 실행했으면 다시 실행하지 않음 (1회만 실행)
+      if (hasRemovedRef.current) {
+        return;
+      }
+
+      try {
+        const currentMarkdown = editor.getMarkdown();
+        const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+        const trimmedMarkdown = currentMarkdown.trim();
+
+        // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+        const isDefaultText =
+          defaultTexts.some((defaultText) => trimmedMarkdown === defaultText) ||
+          (defaultTexts.some((defaultText) =>
+            trimmedMarkdown.startsWith(defaultText)
+          ) &&
+            trimmedMarkdown.split("\n").length > 0 &&
+            defaultTexts.includes(trimmedMarkdown.split("\n")[0].trim()));
+
+        if (isDefaultText) {
+          editor.setMarkdown("");
+          hasRemovedRef.current = true; // 1회만 실행되도록 표시
+        }
+      } catch {
+        // 에러 발생 시 무시
+      }
+    },
+    [initialContent]
+  );
+
+  return removeDefaultText;
+}

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -82,47 +82,49 @@ const EditorBlock = ({
   const removeDefaultText = useRemoveDefaultText(block.content);
 
   // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
-  const editorRefCallback = useCallback((editor: any) => {
-    if (editor) {
-      editorRef.current = editor.getInstance();
-    } else {
-      editorRef.current = null;
-    }
-  }, []);
+  const handleEditorRef = useCallback(
+    (editor: any | null) => {
+      if (!editor) {
+        editorRef.current = null;
+        return;
+      }
+      const instance = editor.getInstance();
+      editorRef.current = instance;
 
+      // 인스턴스당 1회만 hook 등록
+      if (hookedEditor.current === instance) return;
+      hookedEditor.current = instance;
+
+      // 이미지 업로드 훅 설정
+      instance.addHook(
+        "addImageBlobHook",
+        async (blob: Blob, callback: (url: string, altText?: string) => void) => {
+          try {
+            const file = blob as File;
+            const url = await uploadImage(file);
+            callback(url, "image");
+          } catch {
+            console.error("이미지 업로드에 실패했습니다.");
+          }
+        }
+      );
+
+      // 최초 세팅 시에만(또는 block.content가 비어있을 때만) 기본 텍스트 제거
+      setTimeout(() => removeDefaultText(instance), 0);
+    },
+    [removeDefaultText]
+  );
+
+  // 외부 content 변경 동기화 (block.content가 외부에서 변경될 때)
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
 
-    // 인스턴스당 1회만 hook 등록
-    if (hookedEditor.current === editor) return;
-    hookedEditor.current = editor;
-
-    // 이미지 업로드 훅 설정
-    editor.addHook(
-      "addImageBlobHook",
-      async (blob: Blob, callback: (url: string, altText?: string) => void) => {
-        try {
-          const file = blob as File;
-          const url = await uploadImage(file);
-          callback(url, "image");
-        } catch {
-          console.error("이미지 업로드에 실패했습니다.");
-        }
-      }
-    );
-
-    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
-    // 초기값이 비어있을 때만 실행되며, 1회만 실행됨
-    removeDefaultText(editor);
-    const timer = setTimeout(() => removeDefaultText(editor), 100);
-    const timer2 = setTimeout(() => removeDefaultText(editor), 500);
-
-    return () => {
-      clearTimeout(timer);
-      clearTimeout(timer2);
-    };
-  }, [removeDefaultText]);
+    const currentMarkdown = editor.getMarkdown();
+    if (currentMarkdown !== block.content) {
+      editor.setMarkdown(block.content);
+    }
+  }, [block.content]);
 
   return (
     <div
@@ -186,7 +188,7 @@ const EditorBlock = ({
         {/* 편집 / 프리뷰 분리 */}
         <div className="w-full rounded-md border border-gray-200">
           <Editor
-            ref={editorRefCallback}
+            ref={handleEditorRef}
             initialValue={block.content || ""}
             onChange={() => {
               const editor = editorRef.current;

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -78,6 +78,7 @@ const EditorBlock = ({
   void _onDropImage;
 
   const editorRef = useRef<EditorInstance | null>(null);
+  const hookedEditor = useRef<EditorInstance | null>(null);
   const removeDefaultText = useRemoveDefaultText(block.content);
 
   // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
@@ -92,6 +93,10 @@ const EditorBlock = ({
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
+
+    // 인스턴스당 1회만 hook 등록
+    if (hookedEditor.current === editor) return;
+    hookedEditor.current = editor;
 
     // 이미지 업로드 훅 설정
     editor.addHook(

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -7,7 +7,7 @@ import { useRemoveDefaultText } from "@/shared/hooks/useRemoveDefaultText";
 import alertIcon from "@/assets/icons/alerticon.svg";
 import checkBoxIcon from "@/assets/icons/checkedbox.svg";
 import nonCheckBoxIcon from "@/assets/icons/noncheckedbox.svg";
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useCallback } from "react";
 
 export interface BlockData {
   id: number;
@@ -79,6 +79,15 @@ const EditorBlock = ({
 
   const editorRef = useRef<EditorInstance | null>(null);
   const removeDefaultText = useRemoveDefaultText(block.content);
+
+  // ref 콜백을 useCallback으로 고정하여 불필요한 detach/attach 방지
+  const editorRefCallback = useCallback((editor: any) => {
+    if (editor) {
+      editorRef.current = editor.getInstance();
+    } else {
+      editorRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -172,13 +181,7 @@ const EditorBlock = ({
         {/* 편집 / 프리뷰 분리 */}
         <div className="w-full rounded-md border border-gray-200">
           <Editor
-            ref={(editor) => {
-              if (editor) {
-                editorRef.current = editor.getInstance();
-              } else {
-                editorRef.current = null;
-              }
-            }}
+            ref={editorRefCallback}
             initialValue={block.content || ""}
             onChange={() => {
               const editor = editorRef.current;

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -2,11 +2,12 @@ import "@toast-ui/editor/dist/toastui-editor.css";
 import { Editor } from "@toast-ui/react-editor";
 import type EditorInstance from "@toast-ui/editor";
 import { uploadImage } from "@/api/image.api";
+import { useRemoveDefaultText } from "@/shared/hooks/useRemoveDefaultText";
 
 import alertIcon from "@/assets/icons/alerticon.svg";
 import checkBoxIcon from "@/assets/icons/checkedbox.svg";
 import nonCheckBoxIcon from "@/assets/icons/noncheckedbox.svg";
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect } from "react";
 
 export interface BlockData {
   id: number;
@@ -77,32 +78,7 @@ const EditorBlock = ({
   void _onDropImage;
 
   const editorRef = useRef<EditorInstance | null>(null);
-
-  // 에디터 내부 기본 텍스트 제거 함수
-  const removeDefaultText = useCallback((editor: EditorInstance) => {
-    try {
-      const currentMarkdown = editor.getMarkdown();
-      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
-      const trimmedMarkdown = currentMarkdown.trim();
-
-      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
-      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
-        editor.setMarkdown("");
-      } else if (
-        defaultTexts.some((defaultText) =>
-          trimmedMarkdown.startsWith(defaultText)
-        )
-      ) {
-        // 기본 텍스트로 시작하는 경우도 제거
-        const lines = trimmedMarkdown.split("\n");
-        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
-          editor.setMarkdown("");
-        }
-      }
-    } catch {
-      // 에러 발생 시 무시
-    }
-  }, []);
+  const removeDefaultText = useRemoveDefaultText(block.content);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -123,17 +99,14 @@ const EditorBlock = ({
     );
 
     // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+    // 초기값이 비어있을 때만 실행되며, 1회만 실행됨
     removeDefaultText(editor);
     const timer = setTimeout(() => removeDefaultText(editor), 100);
     const timer2 = setTimeout(() => removeDefaultText(editor), 500);
-    const timer3 = setTimeout(() => removeDefaultText(editor), 1000);
-    const timer4 = setTimeout(() => removeDefaultText(editor), 2000);
 
     return () => {
       clearTimeout(timer);
       clearTimeout(timer2);
-      clearTimeout(timer3);
-      clearTimeout(timer4);
     };
   }, [removeDefaultText]);
 
@@ -201,13 +174,7 @@ const EditorBlock = ({
           <Editor
             ref={(editor) => {
               if (editor) {
-                const instance = editor.getInstance();
-                editorRef.current = instance;
-
-                // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
-                setTimeout(() => {
-                  removeDefaultText(instance);
-                }, 0);
+                editorRef.current = editor.getInstance();
               } else {
                 editorRef.current = null;
               }

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -98,7 +98,10 @@ const EditorBlock = ({
       // 이미지 업로드 훅 설정
       instance.addHook(
         "addImageBlobHook",
-        async (blob: Blob, callback: (url: string, altText?: string) => void) => {
+        async (
+          blob: Blob,
+          callback: (url: string, altText?: string) => void
+        ) => {
           try {
             const file = blob as File;
             const url = await uploadImage(file);

--- a/src/shared/ui/Editor/EditorBlock.tsx
+++ b/src/shared/ui/Editor/EditorBlock.tsx
@@ -1,17 +1,12 @@
-import MDEditor, { type ICommand } from "@uiw/react-md-editor";
-import "@uiw/react-md-editor/markdown-editor.css";
-import "@uiw/react-markdown-preview/markdown.css";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import { Editor } from "@toast-ui/react-editor";
+import type EditorInstance from "@toast-ui/editor";
+import { uploadImage } from "@/api/image.api";
 
 import alertIcon from "@/assets/icons/alerticon.svg";
 import checkBoxIcon from "@/assets/icons/checkedbox.svg";
 import nonCheckBoxIcon from "@/assets/icons/noncheckedbox.svg";
-import {
-  useLayoutEffect,
-  useRef,
-  useState,
-  useEffect,
-  useCallback,
-} from "react";
+import { useRef, useEffect, useCallback } from "react";
 
 export interface BlockData {
   id: number;
@@ -52,14 +47,7 @@ export type EditorBlockProps = {
     blockId: number,
     e: React.DragEvent<HTMLTextAreaElement>
   ) => void;
-
-  commandsFilter?: (command: ICommand, isExtra: boolean) => false | ICommand;
 };
-
-const MIN_H = 300;
-const MAX_H = 20000;
-const clamp = (n: number, lo: number, hi: number) =>
-  Math.max(lo, Math.min(hi, n));
 
 const EditorBlock = ({
   block,
@@ -78,106 +66,76 @@ const EditorBlock = ({
   onSave,
   isSaving,
   canSave,
-  onPasteImage,
-  onDropImage,
-  commandsFilter,
+  onPasteImage: _onPasteImage,
+  onDropImage: _onDropImage,
   checklistWidthClass,
   nowrapChecklistItems,
 }: EditorBlockProps) => {
-  const [editorHeight, setEditorHeight] = useState<number>(MIN_H);
+  // Toast UI Editor handles image uploads internally via addImageBlobHook
+  // These props are kept for type compatibility but are no longer used
+  void _onPasteImage;
+  void _onDropImage;
 
-  const taRef = useRef<HTMLTextAreaElement | null>(null);
-  const editorWrapRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<EditorInstance | null>(null);
 
-  const autosize = useCallback(() => {
-    const ta = taRef.current;
-    if (!ta) return;
-    const prevTaH = ta.style.height;
-    ta.style.height = "auto";
+  // 에디터 내부 기본 텍스트 제거 함수
+  const removeDefaultText = useCallback((editor: EditorInstance) => {
+    try {
+      const currentMarkdown = editor.getMarkdown();
+      const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+      const trimmedMarkdown = currentMarkdown.trim();
 
-    const taScrollH = ta.scrollHeight;
-
-    const editorRoot = ta.closest(".w-md-editor") as HTMLElement | null;
-    const toolbar = editorRoot?.querySelector(
-      ".w-md-editor-toolbar"
-    ) as HTMLElement | null;
-    const bottombar = editorRoot?.querySelector(
-      ".w-md-editor-bar"
-    ) as HTMLElement | null;
-
-    const toolbarH = toolbar?.offsetHeight ?? 0;
-    const bottombarH = bottombar?.offsetHeight ?? 0;
-
-    // textarea
-    const taCS = getComputedStyle(ta);
-    const taVPad =
-      (parseFloat(taCS.paddingTop || "0") || 0) +
-      (parseFloat(taCS.paddingBottom || "0") || 0);
-
-    // textarea 부모
-    const taWrap = ta.parentElement as HTMLElement | null;
-    const wrapCS = taWrap ? getComputedStyle(taWrap) : null;
-    const wrapVPad = wrapCS
-      ? (parseFloat(wrapCS.paddingTop || "0") || 0) +
-        (parseFloat(wrapCS.paddingBottom || "0") || 0)
-      : 0;
-
-    // 에디터 루트 보더/패딩
-    const rootCS = editorRoot ? getComputedStyle(editorRoot) : null;
-    const rootVPad =
-      (rootCS ? parseFloat(rootCS.paddingTop || "0") : 0) +
-      (rootCS ? parseFloat(rootCS.paddingBottom || "0") : 0);
-    const rootVBorder =
-      (rootCS ? parseFloat(rootCS.borderTopWidth || "0") : 0) +
-      (rootCS ? parseFloat(rootCS.borderBottomWidth || "0") : 0);
-
-    // 여유분(렌더 오차/간격용)
-    const fudge = 16;
-
-    const chrome =
-      toolbarH +
-      bottombarH +
-      taVPad +
-      wrapVPad +
-      rootVPad +
-      rootVBorder +
-      fudge;
-
-    const next = clamp(taScrollH + chrome, MIN_H, MAX_H);
-    setEditorHeight((h) => (h === next ? h : next));
-
-    ta.style.height = prevTaH;
+      // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+      if (defaultTexts.some((defaultText) => trimmedMarkdown === defaultText)) {
+        editor.setMarkdown("");
+      } else if (
+        defaultTexts.some((defaultText) =>
+          trimmedMarkdown.startsWith(defaultText)
+        )
+      ) {
+        // 기본 텍스트로 시작하는 경우도 제거
+        const lines = trimmedMarkdown.split("\n");
+        if (lines.length > 0 && defaultTexts.includes(lines[0].trim())) {
+          editor.setMarkdown("");
+        }
+      }
+    } catch {
+      // 에러 발생 시 무시
+    }
   }, []);
 
-  const attachTextareaRef = useCallback(() => {
-    if (taRef.current) return;
-    const root = editorWrapRef.current;
-    if (!root) return;
-
-    const ta = root.querySelector("textarea") as HTMLTextAreaElement | null;
-
-    if (ta) {
-      taRef.current = ta;
-      requestAnimationFrame(autosize);
-    }
-  }, [autosize]);
-
-  useLayoutEffect(() => {
-    const id = requestAnimationFrame(() => {
-      attachTextareaRef();
-      autosize();
-    });
-    return () => cancelAnimationFrame(id);
-  }, [attachTextareaRef, autosize, isActive, block.content]);
-
   useEffect(() => {
-    const target = editorWrapRef.current;
-    if (!target || !("ResizeObserver" in window)) return;
+    const editor = editorRef.current;
+    if (!editor) return;
 
-    const ro = new ResizeObserver(() => requestAnimationFrame(autosize));
-    ro.observe(target);
-    return () => ro.disconnect();
-  }, [autosize]);
+    // 이미지 업로드 훅 설정
+    editor.addHook(
+      "addImageBlobHook",
+      async (blob: Blob, callback: (url: string, altText?: string) => void) => {
+        try {
+          const file = blob as File;
+          const url = await uploadImage(file);
+          callback(url, "image");
+        } catch {
+          console.error("이미지 업로드에 실패했습니다.");
+        }
+      }
+    );
+
+    // 초기 실행 및 지연 실행 (에디터 렌더링 완료 대기)
+    removeDefaultText(editor);
+    const timer = setTimeout(() => removeDefaultText(editor), 100);
+    const timer2 = setTimeout(() => removeDefaultText(editor), 500);
+    const timer3 = setTimeout(() => removeDefaultText(editor), 1000);
+    const timer4 = setTimeout(() => removeDefaultText(editor), 2000);
+
+    return () => {
+      clearTimeout(timer);
+      clearTimeout(timer2);
+      clearTimeout(timer3);
+      clearTimeout(timer4);
+    };
+  }, [removeDefaultText]);
 
   return (
     <div
@@ -239,58 +197,35 @@ const EditorBlock = ({
         </div>
 
         {/* 편집 / 프리뷰 분리 */}
-        {isActive ? (
-          <div
-            ref={editorWrapRef}
-            className="w-full overflow-visible rounded-md border border-gray-200"
-          >
-            <MDEditor
-              value={block.content}
-              data-color-mode="light"
-              onChange={(val) => {
-                onChange(index, { content: val || "" });
-                requestAnimationFrame(autosize);
-              }}
-              height={editorHeight}
-              preview="edit"
-              visibleDragbar={false}
-              style={{
-                width: "100%",
-                border: "none",
-                overflow: "visible",
-                minHeight: `${editorHeight}px`,
-                maxHeight: "none",
-              }}
-              autoFocus
-              commandsFilter={commandsFilter}
-              textareaProps={{
-                onInput: () => requestAnimationFrame(autosize),
-                onPaste: (e) => {
-                  onPasteImage?.(block.id, e);
-                  requestAnimationFrame(autosize);
-                },
-                onDrop: (e) => {
-                  onDropImage?.(block.id, e);
-                  requestAnimationFrame(autosize);
-                },
-                onDragOver: (e) => {
-                  if (e.dataTransfer?.types?.includes("Files"))
-                    e.preventDefault();
-                },
-              }}
-            />
-          </div>
-        ) : (
-          <div data-color-mode="light">
-            <div className="w-full rounded-md border border-gray-200 p-3 min-h-[250px]  ">
-              <MDEditor.Markdown
-                source={block.content || ""}
-                data-color-mode="light"
-                className="!bg-white !text-black wmde-markdown-light"
-              />
-            </div>
-          </div>
-        )}
+        <div className="w-full rounded-md border border-gray-200">
+          <Editor
+            ref={(editor) => {
+              if (editor) {
+                const instance = editor.getInstance();
+                editorRef.current = instance;
+
+                // 에디터 인스턴스가 설정되는 즉시 기본 텍스트 제거
+                setTimeout(() => {
+                  removeDefaultText(instance);
+                }, 0);
+              } else {
+                editorRef.current = null;
+              }
+            }}
+            initialValue={block.content || ""}
+            onChange={() => {
+              const editor = editorRef.current;
+              if (editor) {
+                const markdown = editor.getMarkdown();
+                onChange(index, { content: markdown });
+              }
+            }}
+            height="300px"
+            initialEditType="markdown"
+            previewStyle="vertical"
+            usageStatistics={false}
+          />
+        </div>
       </div>
 
       {/* 체크리스트 */}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -25,7 +25,6 @@ interface ImportMeta {
 }
 
 declare module "@toast-ui/editor" {
-  export type { Editor };
   export default class Editor {
     constructor(options: any);
     getMarkdown(): string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,21 +1,47 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_KAKAO_CLIENT_ID: string;
-  // 카카오 SDK용 키(필수)
-  readonly VITE_KAKAO_JS_SDK_KEY: string;
-  // 배포 환경: local | dev | prod (필수)
-  readonly VITE_ENV_TYPE: "local" | "dev" | "prod";
-  // OAuth 리디렉트 URI (필수)
-  readonly VITE_APP_REDIRECT_URI: string;
-  // 기본 API 경로: 설정 없으면 '/api'로 폴백
-  readonly VITE_API_BASE_URL?: string;
-  // axios에서 폴백할 때 사용
-  readonly VITE_BASE_URL?: string;
-  // API 모킹 on/off
-  readonly VITE_API_MOCKING?: "true" | "false";
+  readonly VITE_API_BASE_URL: string;
+  readonly VITE_ENV: string;
+  readonly VITE_BASE_URL: string;
+  readonly VITE_KAKAO_LOGIN_REST_API_KEY: string;
+  readonly VITE_KAKAO_LOGIN_REDIRECT_URI: string;
+  readonly VITE_GITHUB_LOGIN_CLIENT_ID: string;
+  readonly VITE_GITHUB_LOGIN_REDIRECT_URI: string;
+  readonly VITE_GITHUB_LOGIN_CLIENT_SECRET: string;
+  readonly VITE_BASE_URL_DEV: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+declare module "@toast-ui/editor" {
+  export type { Editor };
+  export default class Editor {
+    constructor(options: any);
+    getMarkdown(): string;
+    setMarkdown(markdown: string): void;
+    addHook(type: string, handler: (...args: any[]) => void): void;
+    // 필요한 다른 메서드들...
+  }
+}
+
+declare module "@toast-ui/react-editor" {
+  import type { Editor as EditorType } from "@toast-ui/editor";
+  import { Component } from "react";
+
+  export interface EditorProps {
+    initialValue?: string;
+    initialEditType?: "markdown" | "wysiwyg";
+    previewStyle?: "tab" | "vertical";
+    height?: string;
+    usageStatistics?: boolean;
+    onChange?: () => void;
+    ref?: any;
+  }
+
+  export class Editor extends Component<EditorProps> {
+    getInstance(): EditorType;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz"
   integrity sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.26.10":
+"@babel/core@^7.26.10":
   version "7.27.4"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz"
   integrity sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==
@@ -138,11 +138,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2":
-  version "7.27.6"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz"
-  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
-
 "@babel/runtime@7.1.2":
   version "7.1.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz"
@@ -163,6 +158,11 @@
   integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
   dependencies:
     regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2":
+  version "7.27.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz"
+  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
 
 "@babel/template@^7.27.2":
   version "7.27.2"
@@ -216,10 +216,135 @@
     "@types/tough-cookie" "^4.0.5"
     tough-cookie "^4.1.4"
 
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
+
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
+
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
+
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
+
 "@esbuild/darwin-arm64@0.25.10":
   version "0.25.10"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz"
   integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
+
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
+
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
+
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
+
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
+
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
+
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
+
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
+
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
+
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
+
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
+
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
+
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
+
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
+
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
+
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
+
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
+
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
+
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
+
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
+
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
+
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
   version "4.7.0"
@@ -269,7 +394,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@^9.25.0", "@eslint/js@9.28.0":
+"@eslint/js@9.28.0", "@eslint/js@^9.25.0":
   version "9.28.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz"
   integrity sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==
@@ -421,7 +546,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -462,10 +587,105 @@
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz"
   integrity sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==
 
+"@rollup/rollup-android-arm-eabi@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz#f39f09f60d4a562de727c960d7b202a2cf797424"
+  integrity sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==
+
+"@rollup/rollup-android-arm64@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz#d19af7e23760717f1d879d4ca3d2cd247742dff2"
+  integrity sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==
+
 "@rollup/rollup-darwin-arm64@4.41.1":
   version "4.41.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz"
   integrity sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==
+
+"@rollup/rollup-darwin-x64@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz#aa66d2ba1a25e609500e13bef06dc0e71cc0c0d4"
+  integrity sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==
+
+"@rollup/rollup-freebsd-arm64@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz#df10a7b6316a0ef1028c6ca71a081124c537e30d"
+  integrity sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==
+
+"@rollup/rollup-freebsd-x64@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz#a3fdce8a05e95b068cbcb46e4df5185e407d0c35"
+  integrity sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz#49f766c55383bd0498014a9d76924348c2f3890c"
+  integrity sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==
+
+"@rollup/rollup-linux-arm-musleabihf@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz#1d4d7d32fc557e17d52e1857817381ea365e2959"
+  integrity sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==
+
+"@rollup/rollup-linux-arm64-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz#f4fc317268441e9589edad3be8f62b6c03009bc1"
+  integrity sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==
+
+"@rollup/rollup-linux-arm64-musl@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz#63a1f1b0671cb17822dabae827fef0e443aebeb7"
+  integrity sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==
+
+"@rollup/rollup-linux-loongarch64-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz#c659b01cc6c0730b547571fc3973e1e955369f98"
+  integrity sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==
+
+"@rollup/rollup-linux-powerpc64le-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz#612e746f9ad7e58480f964d65e0d6c3f4aae69a8"
+  integrity sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==
+
+"@rollup/rollup-linux-riscv64-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz#4610dbd1dcfbbae32fbc10c20ae7387acb31110c"
+  integrity sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==
+
+"@rollup/rollup-linux-riscv64-musl@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz#054911fab40dc83fafc21e470193c058108f19d8"
+  integrity sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==
+
+"@rollup/rollup-linux-s390x-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz#98896eca8012547c7f04bd07eaa6896825f9e1a5"
+  integrity sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==
+
+"@rollup/rollup-linux-x64-gnu@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz#01cf56844a1e636ee80dfb364e72c2b7142ad896"
+  integrity sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==
+
+"@rollup/rollup-linux-x64-musl@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz#e67c7531df6dff0b4c241101d4096617fbca87c3"
+  integrity sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz#7eeada98444e580674de6989284e4baacd48ea65"
+  integrity sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz#516c4b54f80587b4a390aaf4940b40870271d35d"
+  integrity sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==
+
+"@rollup/rollup-win32-x64-msvc@4.41.1":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz#848f99b0d9936d92221bb6070baeff4db6947a30"
+  integrity sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==
 
 "@tailwindcss/typography@^0.5.16":
   version "0.5.16"
@@ -476,6 +696,27 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
+
+"@toast-ui/editor@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@toast-ui/editor/-/editor-3.2.2.tgz#1f2837271c5c9c3e29e090d7440bfc6ab23fb4c4"
+  integrity sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==
+  dependencies:
+    dompurify "^2.3.3"
+    prosemirror-commands "^1.1.9"
+    prosemirror-history "^1.1.3"
+    prosemirror-inputrules "^1.1.3"
+    prosemirror-keymap "^1.1.4"
+    prosemirror-model "^1.14.1"
+    prosemirror-state "^1.3.4"
+    prosemirror-view "^1.18.7"
+
+"@toast-ui/react-editor@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@toast-ui/react-editor/-/react-editor-3.2.3.tgz#e335f99595709b5b1961d3d77a0338a07c419a32"
+  integrity sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==
+  dependencies:
+    "@toast-ui/editor" "^3.2.2"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -529,7 +770,7 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@1.0.7":
+"@types/estree@*", "@types/estree@1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.7"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
@@ -573,7 +814,7 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^24.0.7", "@types/node@>=18":
+"@types/node@^24.0.7":
   version "24.0.7"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz"
   integrity sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==
@@ -590,7 +831,7 @@
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz"
   integrity sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==
 
-"@types/react@*", "@types/react@^19.0.0", "@types/react@^19.1.2", "@types/react@>=18", "@types/react@>=18.0.0":
+"@types/react@*", "@types/react@^19.1.2":
   version "19.1.6"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz"
   integrity sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==
@@ -621,12 +862,7 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/unist@^2":
-  version "2.0.11"
-  resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz"
-  integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
-
-"@types/unist@^2.0.0":
+"@types/unist@^2", "@types/unist@^2.0.0":
   version "2.0.11"
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
@@ -646,7 +882,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@^8.33.1", "@typescript-eslint/parser@8.33.1":
+"@typescript-eslint/parser@8.33.1":
   version "8.33.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz"
   integrity sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==
@@ -674,7 +910,7 @@
     "@typescript-eslint/types" "8.33.1"
     "@typescript-eslint/visitor-keys" "8.33.1"
 
-"@typescript-eslint/tsconfig-utils@^8.33.1", "@typescript-eslint/tsconfig-utils@8.33.1":
+"@typescript-eslint/tsconfig-utils@8.33.1", "@typescript-eslint/tsconfig-utils@^8.33.1":
   version "8.33.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz"
   integrity sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==
@@ -689,7 +925,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@^8.33.1", "@typescript-eslint/types@8.33.1":
+"@typescript-eslint/types@8.33.1", "@typescript-eslint/types@^8.33.1":
   version "8.33.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz"
   integrity sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==
@@ -792,20 +1028,10 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.14.0:
+acorn@^8.14.0:
   version "8.14.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
-
-ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ajv@6.10.0:
   version "6.10.0"
@@ -813,6 +1039,16 @@ ajv@6.10.0:
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -1077,7 +1313,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.4, "browserslist@>= 4.21.0":
+browserslist@^4.24.0, browserslist@^4.24.4:
   version "4.25.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz"
   integrity sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==
@@ -1148,14 +1384,6 @@ ccount@^2.0.0:
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz"
@@ -1164,6 +1392,14 @@ chalk@2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
@@ -1185,7 +1421,7 @@ character-reference-invalid@^2.0.0:
   resolved "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
-chart.js@^4.1.1, chart.js@^4.5.0:
+chart.js@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz"
   integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==
@@ -1240,15 +1476,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1311,7 +1547,7 @@ content-disposition@0.5.2:
   resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
   integrity sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==
 
-content-type@~1.0.4, content-type@1.0.4:
+content-type@1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -1326,6 +1562,11 @@ cookie-signature@1.0.6:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+  integrity sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==
+
 cookie@^0.7.2:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
@@ -1335,11 +1576,6 @@ cookie@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
-
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-  integrity sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -1433,19 +1669,19 @@ date-fns@^4.1.0:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
-  dependencies:
-    ms "^2.1.3"
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
+  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  dependencies:
+    ms "^2.1.3"
 
 decode-named-character-reference@^1.0.0:
   version "1.2.0"
@@ -1518,6 +1754,11 @@ dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
+dompurify@^2.3.3:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
+  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
 
 draht@1.0.1:
   version "1.0.1"
@@ -1763,7 +2004,7 @@ eslint-visitor-keys@^4.2.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz"
   integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
 
-"eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.25.0, eslint@>=8.40:
+eslint@^9.25.0:
   version "9.28.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz"
   integrity sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==
@@ -2140,7 +2381,7 @@ github-slugger@^2.0.0:
   resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz"
   integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2153,13 +2394,6 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob@^10.3.10:
   version "10.4.5"
@@ -2486,7 +2720,7 @@ html-void-elements@^3.0.0:
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
-http-errors@~1.6.2, http-errors@~1.6.3, http-errors@1.6.3:
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
   integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
@@ -2526,7 +2760,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inherits@^2.0.3, inherits@~2.0.1, inherits@2.0.3:
+inherits@2.0.3, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
@@ -2787,15 +3021,15 @@ is-weakset@^2.0.3:
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
 
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2811,7 +3045,7 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
-jiti@*, jiti@^1.21.6, jiti@>=1.21.0:
+jiti@^1.21.6:
   version "1.21.7"
   resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
@@ -3503,7 +3737,7 @@ micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-"mime-db@>= 1.43.0 < 2", mime-db@1.52.0:
+mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
@@ -3555,15 +3789,15 @@ morgan@1.9.1:
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 
-ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 msw@^2.10.4:
   version "2.10.4"
@@ -3726,6 +3960,11 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+orderedmap@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.1.1.tgz#61481269c44031c449915497bf5a4ad273c512d2"
+  integrity sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==
+
 outvariant@^1.4.0, outvariant@^1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz"
@@ -3824,15 +4063,15 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"
-  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
-
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path@^0.12.7:
   version "0.12.7"
@@ -3852,7 +4091,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.2:
+picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
@@ -3903,26 +4142,18 @@ postcss-nested@^6.2.0:
   dependencies:
     postcss-selector-parser "^6.1.1"
 
-postcss-selector-parser@^6.1.1:
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
-
-postcss-selector-parser@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
-
 postcss-selector-parser@6.0.10:
   version "6.0.10"
   resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz"
   integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
+  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -3932,7 +4163,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.21, postcss@^8.4.47, postcss@^8.5.3, postcss@^8.5.6, postcss@>=8.0.9:
+postcss@^8.4.47, postcss@^8.5.3, postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
@@ -3972,6 +4203,73 @@ property-information@^7.0.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+
+prosemirror-commands@^1.1.9:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz#d101fef85618b1be53d5b99ea17bee5600781b38"
+  integrity sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.10.2"
+
+prosemirror-history@^1.1.3:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-history/-/prosemirror-history-1.5.0.tgz#ee21fc5de85a1473e3e3752015ffd6d649a06859"
+  integrity sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==
+  dependencies:
+    prosemirror-state "^1.2.2"
+    prosemirror-transform "^1.0.0"
+    prosemirror-view "^1.31.0"
+    rope-sequence "^1.3.0"
+
+prosemirror-inputrules@^1.1.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz#d2e935f6086e3801486b09222638f61dae89a570"
+  integrity sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-keymap@^1.1.4:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz#c0f6ab95f75c0b82c97e44eb6aaf29cbfc150472"
+  integrity sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    w3c-keyname "^2.2.0"
+
+prosemirror-model@^1.0.0, prosemirror-model@^1.14.1, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0:
+  version "1.25.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.25.4.tgz#8ebfbe29ecbee9e5e2e4048c4fe8e363fcd56e7c"
+  integrity sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==
+  dependencies:
+    orderedmap "^2.0.0"
+
+prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.4.4.tgz#72b5e926f9e92dcee12b62a05fcc8a2de3bf5b39"
+  integrity sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-transform "^1.0.0"
+    prosemirror-view "^1.27.0"
+
+prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.10.2:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz#4cf9fe5dcbdbfebd62499f24386e7cec9bc9979b"
+  integrity sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==
+  dependencies:
+    prosemirror-model "^1.21.0"
+
+prosemirror-view@^1.18.7, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0:
+  version "1.41.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.41.4.tgz#4e1b3e90accc0eebe3bddb497a40ce54e4de722d"
+  integrity sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==
+  dependencies:
+    prosemirror-model "^1.20.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
 
 proxy-addr@~2.0.4:
   version "2.0.7"
@@ -4038,7 +4336,7 @@ react-circular-progressbar@^2.2.0:
   resolved "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.2.0.tgz"
   integrity sha512-cgyqEHOzB0nWMZjKfWN3MfSa1LV3OatcDjPz68lchXQUEiBD5O1WsAtoVK4/DSL0B4USR//cTdok4zCBkq8X5g==
 
-react-dom@^19.1.0, react-dom@>=16.8.0, react-dom@>=18:
+react-dom@^19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
@@ -4108,7 +4406,7 @@ react-router@7.6.3:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"
 
-react@*, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^19.1.0, react@>=0.14.0, react@>=16.8.0, react@>=18, react@>=18.0.0:
+react@^19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
@@ -4120,15 +4418,6 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-readable-stream@^3.0.0:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 "readable-stream@1.x >=1.1.9":
   version "1.1.14"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
@@ -4138,6 +4427,15 @@ readable-stream@^3.0.0:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.0.0:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -4230,10 +4528,10 @@ rehype-parse@^9.0.0:
     hast-util-from-html "^2.0.0"
     unified "^11.0.0"
 
-rehype-prism-plus@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.1.tgz"
-  integrity sha512-Wglct0OW12tksTUseAPyWPo3srjBOY7xKlql/DPKi7HbsdZTyaLCAoO58QBKSczFQxElTsQlOY3JDOFzB/K++Q==
+rehype-prism-plus@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.0.tgz"
+  integrity sha512-FeM/9V2N7EvDZVdR2dqhAzlw5YI49m9Tgn7ZrYJeYHIahM6gcXpH0K1y2gNnKanZCydOMluJvX2cB9z3lhY8XQ==
   dependencies:
     hast-util-to-string "^3.0.0"
     parse-numeric-range "^1.3.0"
@@ -4242,10 +4540,10 @@ rehype-prism-plus@~2.0.0:
     unist-util-filter "^5.0.0"
     unist-util-visit "^5.0.0"
 
-rehype-prism-plus@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.0.tgz"
-  integrity sha512-FeM/9V2N7EvDZVdR2dqhAzlw5YI49m9Tgn7ZrYJeYHIahM6gcXpH0K1y2gNnKanZCydOMluJvX2cB9z3lhY8XQ==
+rehype-prism-plus@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.1.tgz"
+  integrity sha512-Wglct0OW12tksTUseAPyWPo3srjBOY7xKlql/DPKi7HbsdZTyaLCAoO58QBKSczFQxElTsQlOY3JDOFzB/K++Q==
   dependencies:
     hast-util-to-string "^3.0.0"
     parse-numeric-range "^1.3.0"
@@ -4422,6 +4720,11 @@ rollup@^4.34.9:
     "@rollup/rollup-win32-x64-msvc" "4.41.1"
     fsevents "~2.3.2"
 
+rope-sequence@^1.3.0:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/rope-sequence/-/rope-sequence-1.3.4.tgz#df85711aaecd32f1e756f76e43a415171235d425"
+  integrity sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -4440,7 +4743,7 @@ safe-array-concat@^1.1.2, safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@^5.0.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4646,20 +4949,15 @@ stack-trace@0.0.10:
   resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
   integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
+"statuses@>= 1.4.0 < 2", statuses@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
+
 statuses@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
-
-"statuses@>= 1.4.0 < 2":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
-  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
-
-statuses@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
-  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
 stethoskop@1.0.0:
   version "1.0.0"
@@ -4681,18 +4979,6 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
-
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -4702,16 +4988,7 @@ string_decoder@~0.10.x:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4760,6 +5037,18 @@ string.prototype.trimstart@^1.0.8:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
 stringify-entities@^4.0.0:
   version "4.0.4"
@@ -4883,7 +5172,7 @@ tailwind@^4.0.0:
     uuidv4 "3.0.1"
     ws "6.2.0"
 
-tailwindcss@^3.4.17, "tailwindcss@>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1":
+tailwindcss@^3.4.17:
   version "3.4.17"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz"
   integrity sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==
@@ -5059,7 +5348,7 @@ typescript-eslint@^8.30.1:
     "@typescript-eslint/parser" "8.33.1"
     "@typescript-eslint/utils" "8.33.1"
 
-typescript@^5.8.3, "typescript@>= 4.8.x", typescript@>=4.8.4, "typescript@>=4.8.4 <5.9.0":
+typescript@^5.8.3:
   version "5.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
@@ -5144,7 +5433,7 @@ universalify@^0.2.0:
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unpipe@~1.0.0, unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -5256,7 +5545,7 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-"vite@^4.2.0 || ^5.0.0 || ^6.0.0", vite@^6.3.5:
+vite@^6.3.5:
   version "6.3.5"
   resolved "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz"
   integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
@@ -5269,6 +5558,11 @@ vfile@^6.0.0:
     tinyglobby "^0.2.13"
   optionalDependencies:
     fsevents "~2.3.3"
+
+w3c-keyname@^2.2.0:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 web-namespaces@^2.0.0:
   version "2.0.1"
@@ -5393,7 +5687,7 @@ yallist@^3.0.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.3.4, yaml@^2.4.2:
+yaml@^2.3.4:
   version "2.8.0"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==


### PR DESCRIPTION
## 🔥 Issues

- closed #180 

## ✅ What to do

- [x] 마크다운 에디터 라이브러리 `Toast UI Editor`로 변경

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 에디터를 새 UI 라이브러리로 전환하여 편집 경험 개선 및 기본 텍스트 자동 제거
  * 에디터 내 이미지 업로드 훅 통합으로 이미지 삽입 흐름 안정화

* **Bug Fixes**
  * 초기 플레이스홀더(기본 안내문) 자동 삭제로 불필요한 텍스트 제거

* **Dependencies**
  * 새로운 에디터 라이브러리 패키지 2종 추가

* **Chores**
  * 파일 업로드 버튼 제거 — 이미지 업로드는 드래그/붙여넣이로만 동작

* **Docs**
  * 사이트맵 수정(일부 URL의 수정일 업데이트)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->