### PR TITLE
FIX: 토스트 메시지 위치 수정

### DIFF
--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1071,27 +1071,27 @@ export default function FreeFormWritePage() {
           <div className="flex-1 flex w-full max-w-[1200px] mx-auto flex-col gap-3">
             {/* Alerts */}
             {showAlert && (
-              <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
                 제목, 프로젝트, 에러 종류, 첫 블록 내용을 모두 입력해주세요.
               </div>
             )}
             {showBlockAlert && (
-              <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
                 첫 번째 블록의 내용이 비어있습니다.
               </div>
             )}
             {showSaveAlert && (
-              <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
                 저장되었습니다.
               </div>
             )}
             {showCancelAlert && (
-              <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
                 요약 작업이 중단되었어요.
               </div>
             )}
             {showSubtitleAlert && (
-              <div className="fixed top-[120px] left-1/2 -translate-x-1/2 z-50 bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
                 소제목을 입력해주세요.
               </div>
             )}

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1021,17 +1021,17 @@ const TempWritePage = () => {
       <div className="w-full max-w-[1680px] sm:pl-64 lg:pl-64 pt-8 sm:pt-12">
         <div className="mx-auto w-full max-w-[1680px] flex flex-col gap-8 sm:gap-9">
           {showAlert && (
-            <div className="fixed top-20 left-1/2 -translate-x-1/2 z-50 max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
               제목, 프로젝트, 에러 종류, 첫 번째 블록 내용을 모두 입력해주세요.
             </div>
           )}
           {showSaveAlert && (
-            <div className="fixed top-20 left-1/2 -translate-x-1/2 z-50 max-w-[92vw] bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
               저장되었습니다.
             </div>
           )}
           {showCancelAlert && (
-            <div className="fixed top-20 left-1/2 -translate-x-1/2 z-50 max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow">
+            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
               요약 작업이 중단되었어요.
             </div>
           )}

--- a/src/shared/hooks/useRemoveDefaultText 2.ts
+++ b/src/shared/hooks/useRemoveDefaultText 2.ts
@@ -1,0 +1,52 @@
+import { useRef, useCallback } from "react";
+import type EditorInstance from "@toast-ui/editor";
+
+/**
+ * Toast UI Editor의 기본 텍스트("Write", "Preview", "Markdown", "WYSIWYG")를 제거하는 훅
+ * 초기값이 비어있을 때만 1회 실행되도록 가드가 포함되어 있습니다.
+ *
+ * @param initialContent - 에디터의 초기 콘텐츠 (비어있을 때만 기본 텍스트 제거)
+ * @returns removeDefaultText 함수
+ */
+export function useRemoveDefaultText(initialContent: string) {
+  const hasRemovedRef = useRef(false);
+
+  const removeDefaultText = useCallback(
+    (editor: EditorInstance) => {
+      // 이미 초기값이 있으면 절대 지우지 않기 (데이터 손실 방지)
+      if ((initialContent ?? "").trim().length > 0) {
+        return;
+      }
+
+      // 이미 실행했으면 다시 실행하지 않음 (1회만 실행)
+      if (hasRemovedRef.current) {
+        return;
+      }
+
+      try {
+        const currentMarkdown = editor.getMarkdown();
+        const defaultTexts = ["Write", "Preview", "Markdown", "WYSIWYG"];
+        const trimmedMarkdown = currentMarkdown.trim();
+
+        // 기본 텍스트만 있거나, 기본 텍스트로 시작하는 경우 제거
+        const isDefaultText =
+          defaultTexts.some((defaultText) => trimmedMarkdown === defaultText) ||
+          (defaultTexts.some((defaultText) =>
+            trimmedMarkdown.startsWith(defaultText)
+          ) &&
+            trimmedMarkdown.split("\n").length > 0 &&
+            defaultTexts.includes(trimmedMarkdown.split("\n")[0].trim()));
+
+        if (isDefaultText) {
+          editor.setMarkdown("");
+          hasRemovedRef.current = true; // 1회만 실행되도록 표시
+        }
+      } catch {
+        // 에러 발생 시 무시
+      }
+    },
+    [initialContent]
+  );
+
+  return removeDefaultText;
+}


### PR DESCRIPTION
## 🔥 Issues

- closed #185 

## ✅ What to do

- [x] 포스트 작성 화면에서 토스트 메시지 고정 위치로 보여지도록 수정

## 📄 Description

상세 설명

## 🤔 Considerations

고민한 부분

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 알림 메시지의 위치를 상단으로 개선하여 가시성 향상
  * 알림에 부드러운 애니메이션 효과 및 강화된 시각적 표현 추가

* **New Features**
  * 편집기의 기본 자리표시자 텍스트를 자동으로 감지 및 제거하는 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->