### PR TITLE
[REFACTOR] CommunityPostDetail 리팩토링

### DIFF
--- a/src/entities/trouble/mappers/myPostDetail.mapper.ts
+++ b/src/entities/trouble/mappers/myPostDetail.mapper.ts
@@ -1,7 +1,8 @@
+import type { ViewPostResponse } from "@/models/post.model";
 import type { CommunityPostDetailProps } from "@/pages/Community/CommunityPostDetail";
 
-// getPostDetail의 data 형태(래퍼 제거 후)
-export type PostDetailServer = {
+/** ViewPostResponse와 호환되는 선택적 확장 (userInfoResDto, liked, checklistError/Reason 별칭) */
+export type PostDetailServerInput = ViewPostResponse & {
   userInfoResDto?: {
     userId: number;
     nickname: string;
@@ -11,39 +12,9 @@ export type PostDetailServer = {
     followingNum: number;
     isFollowed: boolean;
   } | null;
-
-  id: number;
-  title: string;
-  introduction: string | null;
-
-  isVisible?: boolean;
-  likeCount: number;
-  commentCount: number;
   liked?: boolean | null;
-
-  isSummaryCreated: boolean;
-  postStatus: string;
-  starRating: number | string;
-  templateType?: "FREE_FORM" | "GUIDELINE" | string;
-
-  checklistError: number[];
-  checklistReason: number[];
-
-  createdAt: string;
-  updatedAt: string;
-  completedAt: string | null;
-
-  errorTag: string;
-  postTags: string[];
-
-  contents: Array<{
-    id: number;
-    subTitle: string;
-    body: string;
-    sequence: number;
-  }>;
-
-  thumbnailUrl?: string | null;
+  checklistError?: number[];
+  checklistReason?: number[];
 };
 
 // ISO -> "YY.MM.DD"
@@ -84,12 +55,11 @@ const starToNumber = (v: string | number | undefined): number => {
 
 // getPostDetail(data) -> CommunityPostDetailProps
 export function toPostDetailVM(
-  src: PostDetailServer,
+  src: PostDetailServerInput,
   viewerId: number | string | null
 ): CommunityPostDetailProps {
   const author = src.userInfoResDto ?? null;
-  const authorId = author?.userId;
-
+  const authorId = author?.userId ?? src.userId;
   const isMine =
     viewerId != null &&
     authorId != null &&
@@ -98,6 +68,8 @@ export function toPostDetailVM(
   const sorted = [...(src.contents ?? [])].sort(
     (a, b) => (a?.sequence ?? 0) - (b?.sequence ?? 0)
   );
+  const checklistErr = src.checklistError ?? src.checkListError ?? [];
+  const checklistReasonVal = src.checklistReason ?? src.checkListReason ?? [];
 
   return {
     errorType: src.errorTag ?? "",
@@ -124,7 +96,7 @@ export function toPostDetailVM(
 
     isFollowed: author?.isFollowed ?? false,
 
-    checklistError: src.checklistError ?? [],
-    checklistReason: src.checklistReason ?? [],
+    checklistError: checklistErr,
+    checklistReason: checklistReasonVal,
   };
 }

--- a/src/hooks/useDetailContext.ts
+++ b/src/hooks/useDetailContext.ts
@@ -1,0 +1,72 @@
+import { useLocation } from "react-router-dom";
+import { useViewerId } from "@/store/auth";
+
+export type DetailFromSource =
+  | "home"
+  | "community"
+  | "search"
+  | "mypage"
+  | "project"
+  | undefined;
+
+export type DetailSearchScope = "my" | "community" | undefined;
+
+export interface UseDetailContextReturn {
+  from: DetailFromSource;
+  ownerId: number | undefined;
+  viewerId: number | null;
+  searchScope: DetailSearchScope;
+  statusFromList: "inProgress" | "complete" | "created" | undefined;
+  isVisibleFromList: boolean | undefined;
+  summaryIdFromList: number | undefined;
+  isMineFromList: boolean | undefined;
+}
+
+/**
+ * 상세 페이지에서 location.state / query 로 전달된 출처·소유자·목록 힌트 등을 읽는 훅
+ */
+export function useDetailContext(): UseDetailContextReturn {
+  const location = useLocation();
+  const viewerIdInStore = useViewerId();
+
+  const stateFrom = (location.state as Record<string, unknown>)?.from as DetailFromSource | undefined;
+  const stateOwnerId = (location.state as Record<string, unknown>)?.ownerId as number | undefined;
+
+  const qs = new URLSearchParams(location.search);
+  const qsFrom = (qs.get("from") as DetailFromSource) || undefined;
+  const qsOwnerId = qs.get("ownerId");
+  const ownerId = stateOwnerId ?? (qsOwnerId ? Number(qsOwnerId) : undefined);
+  const from = stateFrom ?? qsFrom;
+
+  const stateScope = (location.state as Record<string, unknown>)?.searchScope as
+    | DetailSearchScope
+    | undefined;
+  const qsScope = (qs.get("scope") as DetailSearchScope) || undefined;
+  const searchScope = stateScope ?? qsScope;
+
+  const statusFromList = (location.state as Record<string, unknown>)?.statusFromList as
+    | "inProgress"
+    | "complete"
+    | "created"
+    | undefined;
+  const isVisibleFromList = (location.state as Record<string, unknown>)?.isVisibleFromList as
+    | boolean
+    | undefined;
+  const summaryIdFromList = (location.state as Record<string, unknown>)?.summaryIdFromList as
+    | number
+    | undefined;
+  const isMineFromList = (location.state as Record<string, unknown>)?.isMineFromList as
+    | boolean
+    | undefined;
+
+  return {
+    from,
+    ownerId,
+    viewerId: viewerIdInStore,
+    searchScope,
+    statusFromList,
+    isVisibleFromList,
+    summaryIdFromList,
+    isMineFromList,
+  };
+}

--- a/src/hooks/useDetailContext.ts
+++ b/src/hooks/useDetailContext.ts
@@ -35,7 +35,10 @@ export function useDetailContext(): UseDetailContextReturn {
   const qs = new URLSearchParams(location.search);
   const qsFrom = (qs.get("from") as DetailFromSource) || undefined;
   const qsOwnerId = qs.get("ownerId");
-  const ownerId = stateOwnerId ?? (qsOwnerId ? Number(qsOwnerId) : undefined);
+  const parsedQsOwnerId = qsOwnerId ? Number(qsOwnerId) : NaN;
+  const ownerId =
+    stateOwnerId ??
+    (Number.isFinite(parsedQsOwnerId) ? parsedQsOwnerId : undefined);
   const from = stateFrom ?? qsFrom;
 
   const stateScope = (location.state as Record<string, unknown>)?.searchScope as

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -65,6 +65,8 @@ export interface ViewPostResponse extends PostBasicResFields, PostServerMeta {
   contents: PostContent[];
   checkListError: number[];
   checkListReason: number[];
+  postSummaryId?: number;
+  summaryId?: number;
 }
 
 // 생성/수정

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -1,18 +1,12 @@
-import TagList from "@/entities/trouble/ui/TagList";
-import PostComment from "@/entities/trouble/ui/PostComment";
-import PostGuideMd from "@/entities/trouble/ui/PostGuideMd";
-import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
-import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import ReportModal from "@/shared/ui/Modal/ReportModal";
+import { PostDetailContent } from "./components/PostDetailContent";
+import { PostDetailHeader } from "./components/PostDetailHeader";
+import { PostDetailComments } from "./components/PostDetailComments";
+import { PostDetailSidebar } from "./components/PostDetailSidebar";
 import { PATH } from "@/shared/config/paths";
 import { useDetailContext } from "@/hooks/useDetailContext";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import imageIcon from "@/assets/icons/image.svg";
-import starIcon from "@/assets/icons/star.svg";
-import heartIcon from "@/assets/icons/heart.svg";
-import likeEmptyIcon from "@/assets/icons/like_empty.svg";
-import shareIcon from "@/assets/icons/share.svg";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 import { usePostDetail } from "./hooks/usePostDetail";
 import { usePostComments } from "./hooks/usePostComments";
@@ -302,334 +296,72 @@ export default function CommunityPostDetail() {
           ref={contentColRef}
           className={`${CONTENT_WIDTH_CLASS} flex flex-col items-start gap-8 sm:gap-[56px] mb-24 sm:mb-[224px]`}
         >
-          {/* 상단 영역 */}
-          <div className="flex w-full pt-20 sm:pt-[180px] pb-[18px] items-center border-b border-gray1">
-            <div className="flex flex-col items-start gap-8 sm:gap-[44px] w-full">
-              <div className="flex flex-col items-start gap-8 sm:gap-[53px] w-full">
-                <div className="flex flex-col items-start gap-[10px] w-full">
-                  {/* 에러 종류 & (케밥 버튼) */}
-                  <div className="flex w-full justify-between items-start gap-2">
-                    <span className="text-head-20-semibold">
-                      {post.errorType}
-                    </span>
-                    <div className="relative shrink-0" ref={menuRef}>
-                      <KebabMenuButton onClick={() => setShowMenu(!showMenu)} />
-                      {showMenu && (
-                        <KebabDropdown
-                          options={
-                            post.isMine
-                              ? [
-                                  {
-                                    label: "포스트 수정",
-                                    onClick: () => void goEditWithPrefill(),
-                                  },
-                                  {
-                                    label: deleting ? "삭제 중..." : "삭제",
-                                    onClick: () =>
-                                      !deleting && handleDeletePost(),
-                                  },
-                                ]
-                              : [
-                                  {
-                                    label: "신고하기",
-                                    onClick: () => {
-                                      setShowMenu(false);
-                                      setReportTarget({
-                                        type: "post",
-                                        postId: effectiveId,
-                                      });
-                                      setReportModalOpen(true);
-                                    },
-                                  },
-                                ]
-                          }
-                        />
-                      )}
-                    </div>
-                  </div>
+          <PostDetailHeader
+            post={post}
+            menuRef={menuRef}
+            showMenu={showMenu}
+            setShowMenu={setShowMenu}
+            deleting={deleting}
+            onEdit={goEditWithPrefill}
+            onDelete={handleDeletePost}
+            onReport={() => {
+              setShowMenu(false);
+              setReportTarget({ type: "post", postId: effectiveId });
+              setReportModalOpen(true);
+            }}
+            onAuthorClick={handleProfileClick}
+          />
 
-                  {/* 포스트 제목 */}
-                  <div className="text-head-48 break-words">{post.title}</div>
-                </div>
+          <PostDetailContent
+            post={post}
+            contentWidthClass={CONTENT_WIDTH_CLASS}
+            headerOffset={HEADER_OFFSET}
+            sectionRefs={sectionRefs}
+            onProfileClick={handleProfileClick}
+            onFollow={handleFollow}
+            onUnfollow={handleUnfollow}
+            isCommunitySource={isCommunitySource}
+            isLiked={isLiked}
+            isLiking={isLiking}
+            likeCounts={likeCounts}
+            onToggleLike={handleToggleLike}
+            onCopyLink={handleCopyLink}
+            commentInput={commentInput}
+            setCommentInput={setCommentInput}
+            onSubmitComment={handleSubmitComment}
+            isCommentPosting={isCommentPosting}
+          />
 
-                {/* 태그 & 작성일 */}
-                <div className="flex flex-wrap items-center gap-[12px] sm:gap-[16px]">
-                  <TagList tags={post.tags} variant="post" />
-                  <div className="text-body-16-regular text-gray3">·</div>
-                  <div className="text-body-20-regular text-gray3">
-                    {post.date}
-                  </div>
-                </div>
-              </div>
-
-              {/* 작성자 정보 & 중요도 */}
-              <div className="flex w-full flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                <div
-                  className="flex items-center gap-[14px] sm:gap-[20px] cursor-pointer"
-                  onClick={() =>
-                    navigate(PATH.MYPAGE_ID(String(post.authorId)))
-                  }
-                >
-                  <img
-                    src={post.authorProfile || imageIcon}
-                    onError={(e) => (e.currentTarget.src = imageIcon)}
-                    alt="profile"
-                    className="w-12 h-12 sm:w-[66px] sm:h-[66px] rounded-full object-cover"
-                  />
-                  <div className="text-head-24-bold">{post.authorName}</div>
-                </div>
-
-                {post.isMine && post.importance !== 0 && (
-                  <div className="flex items-center gap-[8px]">
-                    <img
-                      src={starIcon}
-                      alt="importance"
-                      className="w-5 h-5 sm:w-[24px] sm:h-[24px]"
-                    />
-                    <div className="text-body-20-regular text-gray3">
-                      {post.importance}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* 하단 영역 */}
-          <div className="flex w-full flex-col items-start gap-[8px]">
-            {/* 메인 */}
-            <div className="flex flex-col items-start gap-[36px] self-stretch">
-              {/* 포스트 내용 */}
-              <div className="flex flex-col items-start gap-[48px] self-stretch">
-                {post.questions.map((q, idx) => (
-                  <div
-                    id={`section-${idx}`}
-                    key={idx}
-                    ref={(el) => {
-                      sectionRefs.current[idx] = el;
-                    }}
-                    style={{ scrollMarginTop: HEADER_OFFSET + 1 }}
-                    className="scroll-mt-28 md:scroll-mt-[520px]"
-                  >
-                    <PostGuideMd
-                      question={q}
-                      content={post.contents[idx]}
-                      widthClass={CONTENT_WIDTH_CLASS}
-                    />
-                  </div>
-                ))}
-
-                {/* 작성자 정보 카드 */}
-                <div className="flex py-[24px] sm:py-[32px] px-5 sm:px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[24px] sm:rounded-[36px] bg-[#F2F2F2]">
-                  <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center self-stretch gap-4">
-                    <div
-                      className="flex items-center gap-4 sm:gap-[28px] cursor-pointer"
-                      onClick={handleProfileClick}
-                    >
-                      <img
-                        src={post.authorProfile || imageIcon}
-                        onError={(e) => (e.currentTarget.src = imageIcon)}
-                        alt="profile"
-                        className="w-20 h-20 sm:w-[131px] sm:h-[131px] rounded-full object-cover"
-                      />
-                      <div className="flex flex-col items-start gap-[10px] sm:gap-[13px]">
-                        <div className="flex flex-col items-start gap-[2px]">
-                          <div className="text-head-24-bold">
-                            {post.authorName}
-                          </div>
-                          <div className="text-body-16-regular">
-                            {post.authorFollowers} 팔로워
-                          </div>
-                        </div>
-                        <div className="text-body-20-regular">
-                          {post.authorBio}
-                        </div>
-                      </div>
-                    </div>
-
-                    {!post.isMine &&
-                      (post.isFollowed ? (
-                        <button
-                          onClick={() => handleUnfollow()}
-                          className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-subColor1 text-head-20-semibold text-white"
-                        >
-                          팔로잉
-                        </button>
-                      ) : (
-                        <button
-                          onClick={() => handleFollow()}
-                          className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white"
-                        >
-                          팔로우
-                        </button>
-                      ))}
-                  </div>
-                </div>
-              </div>
-
-              {/* 좋아요/공유 */}
-              {isCommunitySource && (
-                <div className="flex pt-8 sm:pt-[52px] pb-5 sm:pb-[20px] items-center self-stretch border-b border-gray1">
-                  <div className="flex items-center gap-4 sm:gap-[20px]">
-                    <button
-                      type="button"
-                      aria-pressed={isLiked}
-                      aria-busy={isLiking}
-                      disabled={isLiking}
-                      onClick={handleToggleLike}
-                      className={`flex items-center gap-2 sm:gap-[8px] ${
-                        isLiking
-                          ? "opacity-60 cursor-not-allowed"
-                          : "cursor-pointer"
-                      }`}
-                    >
-                      <img
-                        src={isLiked ? heartIcon : likeEmptyIcon}
-                        alt="like"
-                        className="w-8 h-8 sm:w-10 sm:h-10"
-                      />
-                      <div className="text-body-20-regular text-gray3">
-                        {likeCounts}
-                      </div>
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={handleCopyLink}
-                      className="cursor-pointer"
-                      aria-label="현재 페이지 링크 복사"
-                    >
-                      <img
-                        src={shareIcon}
-                        alt="share"
-                        className="w-8 h-8 sm:w-10 sm:h-10"
-                      />
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* 댓글 작성 */}
-              {isCommunitySource && (
-                <div className="flex flex-col items-end gap-[12px] self-stretch">
-                  <div className="flex flex-col items-start gap-6 sm:gap-[36px] self-stretch">
-                    <div className="text-head-32-semibold">
-                      {post.commentCounts}개의 댓글
-                    </div>
-                    <textarea
-                      value={commentInput}
-                      onChange={(e) => setCommentInput(e.target.value)}
-                      placeholder="댓글을 작성해주세요."
-                      className="flex p-4 sm:pt-[28px] sm:pl-[32px] pb-24 sm:pb-[130px] w-full resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
-                    />
-                  </div>
-
-                  <button
-                    disabled={!commentInput.trim() || isCommentPosting}
-                    onClick={handleSubmitComment}
-                    className={`inline-flex items-center justify-center rounded-[100px] px-6 sm:px-8
-              py-2 sm:py-3 text-white transition-colors
-              ${
-                commentInput.trim() && !isCommentPosting
-                  ? "bg-primary"
-                  : "bg-subColor1"
-              }`}
-                  >
-                    <span className="text-head-20-semibold leading-none">
-                      {isCommentPosting ? "작성 중…" : "작성하기"}
-                    </span>
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* 댓글 목록 */}
-            {isCommunitySource && (
-              <div className="flex flex-col items-end self-stretch">
-                {comments
-                  .filter((c) => !c.isReply)
-                  .map((parent) => (
-                    <div key={parent.id} className="w-full">
-                      <PostComment
-                        {...parent}
-                        onEdit={(newContent) =>
-                          handleEdit(parent.id, newContent)
-                        }
-                        onDelete={() => handleDelete(parent.id)}
-                        onReply={(replyContent) =>
-                          handleReply(parent.id, replyContent)
-                        }
-                        onReport={(commentId) => {
-                          setReportTarget({
-                            type: "comment",
-                            commentId,
-                          });
-                          setReportModalOpen(true);
-                        }}
-                      />
-                      {comments
-                        .filter((c) => c.parentId === parent.id)
-                        .map((reply) => (
-                          <PostComment
-                            key={reply.id}
-                            {...reply}
-                            onEdit={(newContent) =>
-                              handleEdit(reply.id, newContent)
-                            }
-                            onDelete={() => handleDelete(reply.id)}
-                            onReport={(commentId) => {
-                              setReportTarget({
-                                type: "comment",
-                                commentId,
-                              });
-                              setReportModalOpen(true);
-                            }}
-                          />
-                        ))}
-                    </div>
-                  ))}
-
-                {cHasNext && Number.isFinite(effectiveId) && (
-                  <button
-                    disabled={cLoading}
-                    onClick={() =>
-                      loadComments(
-                        effectiveId,
-                        cPage,
-                        detailCtx.viewerId ?? null,
-                      )
-                    }
-                    className={`mt-4 px-6 py-2 rounded-full text-white ${
-                      cLoading ? "bg-gray-300" : "bg-primary"
-                    }`}
-                  >
-                    {cLoading ? "불러오는 중…" : "댓글 더 보기"}
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
+          {isCommunitySource && (
+            <PostDetailComments
+              comments={comments}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onReply={handleReply}
+              onReport={(commentId) => {
+                setReportTarget({ type: "comment", commentId });
+                setReportModalOpen(true);
+              }}
+              onLoadMore={() =>
+                loadComments(
+                  effectiveId,
+                  cPage,
+                  detailCtx.viewerId ?? null,
+                )
+              }
+              hasNext={cHasNext && Number.isFinite(effectiveId)}
+              loading={cLoading}
+            />
+          )}
         </div>
 
-        {/* 목차(TOC): 큰 화면에서만 보이되, 본문과 함께 중앙 정렬 그룹에 포함 */}
-        <aside
-          className="hidden xl:block h-fit w-[220px] 2xl:w-[280px] sticky"
-          style={{ top: HEADER_OFFSET, marginTop: asideOffset }}
-        >
-          <div className="flex flex-col items-start gap-[16px] border-l border-gray3 pl-[12px] pr-[8px] text-body-20-regular text-gray3 w-full">
-            {post.questions.map((q, idx) => (
-              <button
-                key={idx}
-                onClick={() => scrollToSection(idx)}
-                className={`text-left ${
-                  currentSection === idx ? "text-black" : ""
-                }`}
-              >
-                {idx + 1}. {q}
-              </button>
-            ))}
-          </div>
-        </aside>
+        <PostDetailSidebar
+          questions={post.questions}
+          currentSection={currentSection}
+          onSectionClick={scrollToSection}
+          headerOffset={HEADER_OFFSET}
+          asideOffset={asideOffset}
+        />
       </div>
 
       {/* 공유 토스트 */}

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -9,7 +9,6 @@ import ReportModal from "@/shared/ui/Modal/ReportModal";
 import { PATH } from "@/shared/config/paths";
 import useClickOutside from "@/hooks/useClickOutside";
 import { useDetailContext } from "@/hooks/useDetailContext";
-import { parseApiError } from "@/shared/utils/apiErrorParser";
 import {
   buildFreeformPrefill,
   buildTemplatePrefill,
@@ -24,45 +23,22 @@ import shareIcon from "@/assets/icons/share.svg";
 import {
   createCommunityComment,
   getCommunityComments,
-  getCommunityPostDetail,
   likeCommunityPost,
   replyCommunityComment,
   softDeleteCommunityComment,
   updateCommunityComment,
 } from "@/api/community.api";
-import { toCommunityPostVM } from "@/entities/trouble/mappers/communityPostDetail.mapper";
 import {
   makeOptimisticComment,
   toPostComment,
   toPostComments,
 } from "@/entities/trouble/mappers/communityComment.mapper";
 import { getPostDetail, hardDeletePost } from "@/api/post.api";
-import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
 import { postFollow, postUnfollow } from "@/api/user.api";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
+import { usePostDetail } from "./hooks/usePostDetail";
 
-export interface CommunityPostDetailProps {
-  errorType: string;
-  title: string;
-  tags: string[];
-  date: string;
-  isMine: boolean;
-  authorId?: number;
-  authorProfile?: string;
-  authorName: string;
-  authorFollowers: number;
-  authorBio: string;
-  isFollowed: boolean;
-  importance: number;
-  questions: string[];
-  contents: (string | { type: "image"; src: string; alt?: string })[][];
-  isLiked: boolean;
-  likeCounts: number;
-  commentCounts: number;
-  comments: PostCommentProps[];
-  checklistError?: number[];
-  checklistReason?: number[];
-}
+export type { CommunityPostDetailProps } from "./types";
 
 export default function CommunityPostDetail() {
   const HEADER_OFFSET = 100;
@@ -74,31 +50,81 @@ export default function CommunityPostDetail() {
   const { postId, slug } = useParams<{ postId?: string; slug?: string }>();
   const navigate = useNavigate();
 
-  const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<ReturnType<typeof parseApiError> | null>(null);
+  const effectiveId = useMemo(() => {
+    if (postId && Number.isFinite(Number(postId))) return Number(postId);
+    if (slug) return extractIdFromSlug(slug);
+    return NaN;
+  }, [postId, slug]);
 
-  // 좋아요/댓글 로컬 상태
-  const [isLiked, setIsLiked] = useState(false);
-  const [likeCounts, setLikeCounts] = useState(0);
-  const [isLiking, setIsLiking] = useState(false);
-  const likeLockRef = useRef(false);
+  const detailCtx = useDetailContext();
+  const resumePromptShownRef = useRef<Record<number, boolean>>({});
+
   const [commentInput, setCommentInput] = useState("");
   const [comments, setComments] = useState<PostCommentProps[]>([]);
-
-  // 댓글 작성 상태
   const [isCommentPosting, setIsCommentPosting] = useState(false);
-
-  // 댓글 페이징 상태
   const [cPage, setCPage] = useState(1);
   const [cHasNext, setCHasNext] = useState(false);
   const [cLoading, setCLoading] = useState(false);
 
-  // 케밥 메뉴
+  const onLoadStartRef = useRef<() => void>(() => {});
+  const onCommunityLoadedRef = useRef<(postId: number, viewerId: number | null) => void>(() => {});
+
+  const {
+    post,
+    setPost,
+    loading,
+    loadError,
+    isCommunitySource,
+    isLiked,
+    likeCounts,
+    setIsLiked,
+    setLikeCounts,
+  } = usePostDetail(effectiveId, detailCtx, navigate, {
+    onLoadStart: useCallback(() => {
+      onLoadStartRef.current();
+    }, []),
+    onCommunityLoaded: useCallback((id: number, viewerId: number | null) => {
+      onCommunityLoadedRef.current(id, viewerId);
+    }, []),
+    resumePromptShownRef,
+  });
+
+  onLoadStartRef.current = () => {
+    setComments([]);
+    setCPage(1);
+    setCHasNext(false);
+  };
+
+  const loadComments = useCallback(
+    async (id: number, page1: number, currentViewerId: number | null) => {
+      setCLoading(true);
+      try {
+        const resp = await getCommunityComments(id, page1, 10);
+        const mapped = toPostComments(resp.content, currentViewerId);
+        setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
+        const nextPage1 = typeof resp.page === "number" ? resp.page + 1 : page1;
+        setCPage(nextPage1);
+        setCHasNext(!!resp.hasNext);
+        setPost((prev) =>
+          prev
+            ? { ...prev, commentCounts: resp.totalElements ?? prev.commentCounts }
+            : prev
+        );
+      } finally {
+        setCLoading(false);
+      }
+    },
+    [setPost]
+  );
+  onCommunityLoadedRef.current = (id: number, viewerId: number | null) => {
+    loadComments(id, 1, viewerId);
+  };
+
+  const [isLiking, setIsLiking] = useState(false);
+  const likeLockRef = useRef(false);
+
   const [showMenu, setShowMenu] = useState(false);
   const [deleting, setDeleting] = useState(false);
-
-  // 신고 모달 (포스트 또는 댓글)
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const [reportTarget, setReportTarget] = useState<
     | { type: "post"; postId: number }
@@ -108,20 +134,10 @@ export default function CommunityPostDetail() {
   const closeMenu = useCallback(() => setShowMenu(false), []);
   const menuRef = useClickOutside(() => setShowMenu(false));
 
-  // 섹션 추적
   const [currentSection, setCurrentSection] = useState<number>(0);
-  // 본문 컬럼과 첫 섹션 기준 측정
   const contentColRef = useRef<HTMLDivElement | null>(null);
   const [asideOffset, setAsideOffset] = useState(0);
-  // 섹션 refs는 HTMLDivElement로 구체화
   const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
-
-  // 유효 ID 계산
-  const effectiveId = useMemo(() => {
-    if (postId && Number.isFinite(Number(postId))) return Number(postId);
-    if (slug) return extractIdFromSlug(slug);
-    return NaN;
-  }, [postId, slug]);
 
   useEffect(() => {
     const updateAsideOffset = () => {
@@ -158,11 +174,6 @@ export default function CommunityPostDetail() {
       ro?.disconnect();
     };
   }, [post]); // post가 로드된 뒤에 계산
-
-  // 이어서 작성 안내 경고창
-  const resumePromptShownRef = useRef<Record<number, boolean>>({});
-
-  const detailCtx = useDetailContext();
 
   // 공유 토스트
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -217,293 +228,6 @@ export default function CommunityPostDetail() {
       showToast("복사에 실패했어요. 주소창에서 복사해주세요.");
     }
   };
-
-  // 댓글 로더
-  const loadComments = async (
-    id: number,
-    page1: number,
-    currentViewerId: number | null,
-  ) => {
-    setCLoading(true);
-    try {
-      const resp = await getCommunityComments(id, page1, 10);
-      const mapped = toPostComments(resp.content, currentViewerId);
-
-      setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
-
-      const nextPage1 = typeof resp.page === "number" ? resp.page + 1 : page1;
-      setCPage(nextPage1);
-      setCHasNext(!!resp.hasNext);
-
-      setPost((prev) =>
-        prev
-          ? { ...prev, commentCounts: resp.totalElements ?? prev.commentCounts }
-          : prev,
-      );
-    } finally {
-      setCLoading(false);
-    }
-  };
-
-  const [isCommunitySource, setIsCommunitySource] = useState(true); // 좋아요/댓글 표시 가드
-
-  useEffect(() => {
-    let cancelled = false;
-
-    setComments([]);
-    setCPage(1);
-    setCHasNext(false);
-    setLoading(true);
-    setLoadError(null);
-
-    if (!Number.isFinite(effectiveId)) {
-      setLoadError({ message: "잘못된 포스트 ID" });
-      setLoading(false);
-      return;
-    }
-
-    const loadCommunity = async () => {
-      const communityData = await getCommunityPostDetail(effectiveId);
-      if (!communityData) throw new Error("빈 응답입니다.");
-      const vm = toCommunityPostVM(communityData, detailCtx.viewerId);
-      setPost(vm);
-      setIsLiked(vm.isLiked);
-      setLikeCounts(vm.likeCounts);
-      setIsCommunitySource(true);
-      void loadComments(effectiveId, 1, detailCtx.viewerId ?? null);
-    };
-
-    const loadMineDraft = async (id: number) => {
-      const myDetail = await getPostDetail(id);
-
-      // 작성 중 여부
-      const completedAt = (myDetail as any)?.completedAt ?? null;
-      const isDraft = completedAt == null;
-
-      if (!isDraft) {
-        throw new Error("완료 문서입니다. 커뮤니티 상세로 이동해야 합니다.");
-      }
-
-      // 내 상세로 화면 세팅
-      const vmMine = toPostDetailVM(myDetail as any, detailCtx.viewerId);
-      setPost(vmMine);
-      setIsLiked(vmMine.isLiked);
-      setLikeCounts(vmMine.likeCounts);
-      setIsCommunitySource(false);
-
-      // 이어쓰기 안내(한 번만)
-      if (!resumePromptShownRef.current[id]) {
-        resumePromptShownRef.current[id] = true;
-
-        const ttRaw =
-          (myDetail as any)?.templateType ?? (vmMine as any)?.templateType;
-        const tt = String(ttRaw ?? "").toUpperCase(); // FREE_FORM | FREEFORM | GUIDELINE
-
-        const ok = window.confirm(
-          tt === "FREE_FORM" || tt === "FREEFORM"
-            ? "이 문서는 자유형식 글 작성 중이에요. 이어서 작성할까요?"
-            : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?",
-        );
-
-        if (ok) {
-          const baseState =
-            tt === "FREE_FORM" || tt === "FREEFORM"
-              ? buildFreeformPrefill(myDetail)
-              : buildTemplatePrefill(myDetail);
-
-          const editorPath =
-            tt === "FREE_FORM" || tt === "FREEFORM"
-              ? PATH.FREEFORM_WRITING
-              : PATH.TEMP_WRITING;
-
-          navigate(editorPath, {
-            replace: true,
-            state: {
-              ...baseState,
-              postId: id,
-              mode: "edit",
-              from: "community-detail",
-              projectId: (myDetail as any)?.projectId ?? undefined,
-              savePrefill: { ...(baseState as any).savePrefill },
-            },
-          });
-        }
-      }
-    };
-
-    (async () => {
-      try {
-        const {
-          viewerId,
-          ownerId,
-          statusFromList,
-          isVisibleFromList,
-          summaryIdFromList,
-          isMineFromList,
-          from,
-        } = detailCtx;
-
-        // 0. 목록 힌트 기준: 비공개로 내려온 글이면 무조건 내 상세 API 우선
-        if (isVisibleFromList === false) {
-          const myDetail = await getPostDetail(effectiveId);
-          const completedAt = (myDetail as any)?.completedAt ?? null;
-          const isDraft = completedAt == null;
-
-          if (isDraft) {
-            // 작성 중이면 기존 드래프트 로직 재사용
-            await loadMineDraft(effectiveId);
-          } else {
-            // 완료 문서 비공개 → 내 상세 화면으로만 세팅
-            const vmMine = toPostDetailVM(myDetail as any, viewerId);
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false); // 좋아요/댓글 비활성
-          }
-          return;
-        }
-
-        // ProjectDetail → 원본 탭에서 온 글은 항상 /troubles만
-        if (from === "project") {
-          const myDetail = await getPostDetail(effectiveId);
-          const completedAt = (myDetail as any)?.completedAt ?? null;
-          const isDraft = completedAt == null;
-
-          if (isDraft) {
-            // 작성 중이면 기존 드래프트 처리 로직 재사용
-            await loadMineDraft(effectiveId);
-          } else {
-            // 완료 문서면 내 상세 화면으로만 세팅
-            const vmMine = toPostDetailVM(myDetail as any, viewerId);
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false); // 좋아요/댓글 비활성
-          }
-          return;
-        }
-
-        // 내 글 여부 결정(힌트 우선)
-        const mineByIds =
-          viewerId != null &&
-          ownerId != null &&
-          String(ownerId) === String(viewerId);
-        const isMine = isMineFromList === true ? true : mineByIds;
-
-        // 1) 힌트가 있으면 즉시 분기 (중복 호출 차단)
-        if (isMine && statusFromList === "inProgress") {
-          // 작성 중 → 에디터(프리필 위해 1회 내 상세 호출)
-          await loadMineDraft(effectiveId);
-          return;
-        }
-
-        if (isMine && statusFromList === "created") {
-          if (summaryIdFromList != null) {
-            navigate(PATH.COMBINED_DETAIL(effectiveId, summaryIdFromList), {
-              replace: true,
-              state: {
-                from: "community-detail",
-                ownerId: viewerId ?? undefined,
-              },
-            });
-            return;
-          }
-          // 힌트에 summaryId가 없으면 한 번만 내 상세 조회로 보강
-          try {
-            const myDetail = await getPostDetail(effectiveId);
-            const sid =
-              (typeof (myDetail as any)?.postSummaryId === "number" &&
-                (myDetail as any).postSummaryId) ||
-              (typeof (myDetail as any)?.summaryId === "number" &&
-                (myDetail as any).summaryId) ||
-              null;
-            if (sid != null) {
-              navigate(PATH.COMBINED_DETAIL(effectiveId, sid), {
-                replace: true,
-                state: {
-                  from: "community-detail",
-                  ownerId: viewerId ?? undefined,
-                },
-              });
-              return;
-            }
-          } catch {
-            /* 무시하고 커뮤 상세로 폴백 */
-          }
-          await loadCommunity();
-          return;
-        }
-
-        if (
-          isMine &&
-          statusFromList === "complete" &&
-          typeof isVisibleFromList === "boolean"
-        ) {
-          if (isVisibleFromList) {
-            // 공개 완료 → 커뮤니티 상세만
-            await loadCommunity();
-          } else {
-            // 비공개 완료 → 내 상세만
-            const myDetail = await getPostDetail(effectiveId);
-            const vmMine = toPostDetailVM(myDetail as any, viewerId);
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false);
-          }
-          return;
-        }
-
-        // 2) 힌트가 부족하면 기존 로직(내 상세로 판정 → 필요 시 커뮤) 실행
-        if (isMine) {
-          try {
-            const myDetail = await getPostDetail(effectiveId);
-            const isDraft = (myDetail as any)?.completedAt == null;
-            if (isDraft) {
-              await loadMineDraft(effectiveId);
-              return;
-            }
-
-            // 완료 문서이지만 비공개라면 커뮤니티 UX를 비활성화
-            if ((myDetail as any)?.isVisible === false) {
-              const vmMine = toPostDetailVM(myDetail as any, viewerId);
-              setPost(vmMine);
-              setIsLiked(vmMine.isLiked);
-              setLikeCounts(vmMine.likeCounts);
-              setIsCommunitySource(false);
-              return;
-            }
-
-            await loadCommunity();
-          } catch {
-            await loadCommunity();
-          }
-        } else {
-          await loadCommunity();
-        }
-      } catch (err: any) {
-        if (!cancelled) {
-          setLoadError(parseApiError(err));
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    effectiveId,
-    detailCtx.viewerId,
-    detailCtx.ownerId,
-    detailCtx.statusFromList,
-    detailCtx.isVisibleFromList,
-    detailCtx.summaryIdFromList,
-    detailCtx.isMineFromList,
-    detailCtx.from,
-    navigate,
-  ]);
 
   useEffect(() => {
     if (!post) return;

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -23,6 +23,19 @@ export default function CommunityPostDetail() {
   const CONTENT_WIDTH_CLASS =
     "w-full sm:w-[520px] md:w-[680px] lg:w-[820px] xl:w-[960px]";
 
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showToast = useCallback((message: string) => {
+    setToast({ open: true, message });
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => {
+      setToast({ open: false, message: "" });
+    }, 2000);
+  }, []);
+
   const { postId, slug } = useParams<{ postId?: string; slug?: string }>();
   const navigate = useNavigate();
 
@@ -62,6 +75,7 @@ export default function CommunityPostDetail() {
     isCommunitySource,
     viewerId: detailCtx.viewerId ?? null,
     setPost,
+    onEditError: () => showToast("댓글 수정에 실패했어요."),
   });
 
   onLoadStartRef.current = () => commentsApi.resetForNewPost();
@@ -136,13 +150,6 @@ export default function CommunityPostDetail() {
     goMyPage,
   } = nav;
 
-  // 공유 토스트
-  const [toast, setToast] = useState<{ open: boolean; message: string }>({
-    open: false,
-    message: "",
-  });
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const copyToClipboard = async (text: string) => {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
@@ -160,14 +167,6 @@ export default function CommunityPostDetail() {
     } finally {
       document.body.removeChild(ta);
     }
-  };
-
-  const showToast = (message: string) => {
-    setToast({ open: true, message });
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = setTimeout(() => {
-      setToast({ open: false, message: "" });
-    }, 2000);
   };
 
   useEffect(() => {

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -8,8 +8,14 @@ import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import ReportModal from "@/shared/ui/Modal/ReportModal";
 import { PATH } from "@/shared/config/paths";
 import useClickOutside from "@/hooks/useClickOutside";
+import { useDetailContext } from "@/hooks/useDetailContext";
+import { parseApiError } from "@/shared/utils/apiErrorParser";
+import {
+  buildFreeformPrefill,
+  buildTemplatePrefill,
+} from "@/shared/utils/prefillBuilder";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import imageIcon from "@/assets/icons/image.svg";
 import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
@@ -30,7 +36,6 @@ import {
   toPostComment,
   toPostComments,
 } from "@/entities/trouble/mappers/communityComment.mapper";
-import { useViewerId } from "@/store/auth";
 import { getPostDetail, hardDeletePost } from "@/api/post.api";
 import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
 import { postFollow, postUnfollow } from "@/api/user.api";
@@ -71,8 +76,7 @@ export default function CommunityPostDetail() {
 
   const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
   const [loading, setLoading] = useState(true);
-  type LoadErr = { status?: number; message: string };
-  const [loadError, setLoadError] = useState<LoadErr | null>(null);
+  const [loadError, setLoadError] = useState<ReturnType<typeof parseApiError> | null>(null);
 
   // 좋아요/댓글 로컬 상태
   const [isLiked, setIsLiked] = useState(false);
@@ -111,17 +115,6 @@ export default function CommunityPostDetail() {
   const [asideOffset, setAsideOffset] = useState(0);
   // 섹션 refs는 HTMLDivElement로 구체화
   const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
-
-  // 서버 에러 응답 파싱
-  const parseApiError = (err: any): LoadErr => {
-    const status = err?.response?.status;
-    const message =
-      err?.response?.data?.error?.message ??
-      err?.response?.data?.message ??
-      err?.message ??
-      "요청 처리 중 오류가 발생했어요.";
-    return { status, message };
-  };
 
   // 유효 ID 계산
   const effectiveId = useMemo(() => {
@@ -169,174 +162,7 @@ export default function CommunityPostDetail() {
   // 이어서 작성 안내 경고창
   const resumePromptShownRef = useRef<Record<number, boolean>>({});
 
-  // 컨텍스트/판정 유틸
-  type FromSource =
-    | "home"
-    | "community"
-    | "search"
-    | "mypage"
-    | "project"
-    | undefined;
-  type SearchScope = "my" | "community" | undefined;
-
-  type DetailContentItem = {
-    id?: number;
-    subTitle?: string | null;
-    body?: string | null;
-    sequence?: number;
-  };
-
-  function useDetailContext() {
-    const location = useLocation();
-    const viewerIdInStore = useViewerId();
-
-    const stateFrom = (location.state as any)?.from as FromSource | undefined;
-    const stateOwnerId = (location.state as any)?.ownerId as number | undefined;
-
-    const qs = new URLSearchParams(location.search);
-    const qsFrom = (qs.get("from") as FromSource) || undefined;
-    const qsOwnerId = qs.get("ownerId");
-    const ownerId = stateOwnerId ?? (qsOwnerId ? Number(qsOwnerId) : undefined);
-    const from = stateFrom ?? qsFrom;
-
-    const stateScope = (location.state as any)?.searchScope as
-      | SearchScope
-      | undefined;
-    const qsScope = (qs.get("scope") as SearchScope) || undefined;
-    const searchScope = stateScope ?? qsScope;
-
-    // 목록에서 실어온 힌트
-    const statusFromList = (location.state as any)?.statusFromList as
-      | "inProgress"
-      | "complete"
-      | "created"
-      | undefined;
-    const isVisibleFromList = (location.state as any)?.isVisibleFromList as
-      | boolean
-      | undefined;
-    const summaryIdFromList = (location.state as any)?.summaryIdFromList as
-      | number
-      | undefined;
-    const isMineFromList = (location.state as any)?.isMineFromList as
-      | boolean
-      | undefined;
-
-    return {
-      from,
-      ownerId,
-      viewerId: viewerIdInStore,
-      searchScope,
-      statusFromList,
-      isVisibleFromList,
-      summaryIdFromList,
-      isMineFromList,
-    };
-  }
-
-  // 별점 enum/문자 → 숫자
-  const parseStar = (raw: unknown) => {
-    if (typeof raw === "number") return raw;
-    if (typeof raw !== "string") return 0;
-    const k = raw.toUpperCase();
-    const map: Record<string, number> = {
-      ONE_STAR: 1,
-      TWO_STARS: 2,
-      THREE_STARS: 3,
-      FOUR_STARS: 4,
-      FIVE_STARS: 5,
-      ONE: 1,
-      TWO: 2,
-      THREE: 3,
-      FOUR: 4,
-      FIVE: 5,
-      NONE: 0,
-    };
-    return map[k] ?? 0;
-  };
-
-  // 상세 응답 → FREEFORM 프리필 state
-  function buildFreeformPrefill(detail: any) {
-    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
-      ? detail.contents
-      : [];
-
-    const blocks = contents
-      .slice()
-      .sort(
-        (a: DetailContentItem, b: DetailContentItem) =>
-          (a.sequence ?? 0) - (b.sequence ?? 0),
-      )
-      .map((c: DetailContentItem, i: number) => ({
-        id: c.id ?? i,
-        title: c.subTitle ?? "",
-        content: c.body ?? "",
-        isSaved: false,
-      }));
-
-    return {
-      editorType: "FREEFORM" as const,
-      title: detail?.title ?? "",
-      tags: detail?.postTags ?? [],
-      errorType: detail?.errorTag ?? null,
-      blocks,
-      savePrefill: {
-        importance: parseStar(detail?.starRating),
-        description: detail?.introduction ?? "",
-        visibility: detail?.isVisible ? "public" : "private",
-        projectId: detail?.projectId ?? null,
-        projectName: undefined,
-        thumbnail: detail?.thumbnailUrl ?? null,
-      },
-      projectId: detail?.projectId ?? undefined,
-    };
-  }
-
-  // 상세 응답 → TEMPLATE 프리필 state
-  function buildTemplatePrefill(detail: any) {
-    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
-      ? detail.contents
-      : [];
-
-    const blocks = contents
-      .slice()
-      .sort(
-        (a: DetailContentItem, b: DetailContentItem) =>
-          (a.sequence ?? 0) - (b.sequence ?? 0),
-      )
-      .map((c: DetailContentItem, i: number) => ({
-        id: c.id ?? i,
-        content: c.body ?? "",
-        checklist: [],
-        checklistItems: [],
-        checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
-        question: c.subTitle ?? `질문 ${i + 1}`,
-        isSaved: false,
-      }));
-
-    return {
-      editorType: "TEMPLATE" as const,
-      title: detail?.title ?? "",
-      tags: detail?.postTags ?? [],
-      errorType: detail?.errorTag ?? null,
-      blocks,
-      savePrefill: {
-        importance: parseStar(detail?.starRating),
-        description: detail?.introduction ?? "",
-        visibility: detail?.isVisible ? "public" : "private",
-        projectId: detail?.projectId ?? null,
-        projectName: undefined,
-        thumbnail: detail?.thumbnailUrl ?? null,
-      },
-      projectId: detail?.projectId ?? undefined,
-      // TempWritePage에서 기대하는 키 이름으로 전달
-      checklistError: Array.isArray(detail?.checklistError)
-        ? detail.checklistError
-        : [],
-      checklistReason: Array.isArray(detail?.checklistReason)
-        ? detail.checklistReason
-        : [],
-    };
-  }
+  const detailCtx = useDetailContext();
 
   // 공유 토스트
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -419,8 +245,6 @@ export default function CommunityPostDetail() {
     }
   };
 
-  // 상세 로드
-  const detailCtx = useDetailContext();
   const [isCommunitySource, setIsCommunitySource] = useState(true); // 좋아요/댓글 표시 가드
 
   useEffect(() => {

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -1,7 +1,5 @@
 import TagList from "@/entities/trouble/ui/TagList";
-import PostComment, {
-  type PostCommentProps,
-} from "@/entities/trouble/ui/PostComment";
+import PostComment from "@/entities/trouble/ui/PostComment";
 import PostGuideMd from "@/entities/trouble/ui/PostGuideMd";
 import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
 import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
@@ -20,23 +18,12 @@ import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import likeEmptyIcon from "@/assets/icons/like_empty.svg";
 import shareIcon from "@/assets/icons/share.svg";
-import {
-  createCommunityComment,
-  getCommunityComments,
-  likeCommunityPost,
-  replyCommunityComment,
-  softDeleteCommunityComment,
-  updateCommunityComment,
-} from "@/api/community.api";
-import {
-  makeOptimisticComment,
-  toPostComment,
-  toPostComments,
-} from "@/entities/trouble/mappers/communityComment.mapper";
+import { likeCommunityPost } from "@/api/community.api";
 import { getPostDetail, hardDeletePost } from "@/api/post.api";
 import { postFollow, postUnfollow } from "@/api/user.api";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 import { usePostDetail } from "./hooks/usePostDetail";
+import { usePostComments } from "./hooks/usePostComments";
 
 export type { CommunityPostDetailProps } from "./types";
 
@@ -58,14 +45,6 @@ export default function CommunityPostDetail() {
 
   const detailCtx = useDetailContext();
   const resumePromptShownRef = useRef<Record<number, boolean>>({});
-
-  const [commentInput, setCommentInput] = useState("");
-  const [comments, setComments] = useState<PostCommentProps[]>([]);
-  const [isCommentPosting, setIsCommentPosting] = useState(false);
-  const [cPage, setCPage] = useState(1);
-  const [cHasNext, setCHasNext] = useState(false);
-  const [cLoading, setCLoading] = useState(false);
-
   const onLoadStartRef = useRef<() => void>(() => {});
   const onCommunityLoadedRef = useRef<(postId: number, viewerId: number | null) => void>(() => {});
 
@@ -89,36 +68,32 @@ export default function CommunityPostDetail() {
     resumePromptShownRef,
   });
 
-  onLoadStartRef.current = () => {
-    setComments([]);
-    setCPage(1);
-    setCHasNext(false);
+  const commentsApi = usePostComments({
+    effectiveId,
+    isCommunitySource,
+    viewerId: detailCtx.viewerId ?? null,
+    setPost,
+  });
+
+  onLoadStartRef.current = () => commentsApi.resetForNewPost();
+  onCommunityLoadedRef.current = (id: number, viewerId: number | null) => {
+    commentsApi.loadComments(id, 1, viewerId);
   };
 
-  const loadComments = useCallback(
-    async (id: number, page1: number, currentViewerId: number | null) => {
-      setCLoading(true);
-      try {
-        const resp = await getCommunityComments(id, page1, 10);
-        const mapped = toPostComments(resp.content, currentViewerId);
-        setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
-        const nextPage1 = typeof resp.page === "number" ? resp.page + 1 : page1;
-        setCPage(nextPage1);
-        setCHasNext(!!resp.hasNext);
-        setPost((prev) =>
-          prev
-            ? { ...prev, commentCounts: resp.totalElements ?? prev.commentCounts }
-            : prev
-        );
-      } finally {
-        setCLoading(false);
-      }
-    },
-    [setPost]
-  );
-  onCommunityLoadedRef.current = (id: number, viewerId: number | null) => {
-    loadComments(id, 1, viewerId);
-  };
+  const {
+    commentInput,
+    setCommentInput,
+    comments,
+    isCommentPosting,
+    cPage,
+    cHasNext,
+    cLoading,
+    loadComments,
+    handleSubmitComment,
+    handleReply,
+    handleEdit,
+    handleDelete,
+  } = commentsApi;
 
   const [isLiking, setIsLiking] = useState(false);
   const likeLockRef = useRef(false);
@@ -338,126 +313,6 @@ export default function CommunityPostDetail() {
         likeLockRef.current = false;
         setIsLiking(false);
       }
-    }
-  };
-
-  // 댓글 1페이지를 강제 새로고침(작성/삭제 직후 사용)
-  const reloadCommentsFirstPage = useCallback(async () => {
-    if (!Number.isFinite(effectiveId)) return;
-    await loadComments(effectiveId, 1, detailCtx.viewerId ?? null);
-  }, [postId, detailCtx.viewerId]);
-
-  // 댓글 제출(커뮤니티 글에서만)
-  const handleSubmitComment = async () => {
-    if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
-    const contents = commentInput.trim();
-    if (!contents || isCommentPosting) return;
-
-    setIsCommentPosting(true);
-
-    const optimistic = makeOptimisticComment({ contents });
-    setComments((prev) => [optimistic, ...prev]);
-    setPost((p) =>
-      p ? { ...p, commentCounts: (p.commentCounts ?? 0) + 1 } : p,
-    );
-    setCommentInput("");
-
-    try {
-      const created = await createCommunityComment(effectiveId, {
-        contents,
-      });
-      const mapped = toPostComment(created, detailCtx.viewerId, {
-        isReply: false,
-      });
-      setComments((prev) => {
-        const i = prev.findIndex((c) => c.id === optimistic.id);
-        if (i === -1) return [mapped, ...prev];
-        const next = [...prev];
-        next[i] = mapped;
-        return next;
-      });
-      await reloadCommentsFirstPage();
-    } catch {
-      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setPost((p) =>
-        p
-          ? { ...p, commentCounts: Math.max(0, (p.commentCounts ?? 1) - 1) }
-          : p,
-      );
-      setCommentInput(contents);
-    } finally {
-      setIsCommentPosting(false);
-    }
-  };
-
-  // 대댓글 제출
-  const handleReply = async (parentId: string, replyContent: string) => {
-    if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
-    const contents = replyContent.trim();
-    if (!contents) return;
-
-    const optimistic = makeOptimisticComment({ contents, parentId });
-    setComments((prev) => [...prev, optimistic]);
-
-    try {
-      const created = await replyCommunityComment(
-        effectiveId,
-        Number(parentId),
-        { contents },
-      );
-      const mapped = toPostComment(created, detailCtx.viewerId, {
-        isReply: true,
-        parentId,
-      });
-      setComments((prev) => {
-        const i = prev.findIndex((c) => c.id === optimistic.id);
-        if (i === -1) return [...prev, mapped];
-        const next = [...prev];
-        next[i] = mapped;
-        return next;
-      });
-      await reloadCommentsFirstPage();
-    } catch {
-      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      console.error("대댓글 작성 실패");
-    }
-  };
-
-  // 댓글 내용 수정
-  const handleEdit = async (id: string, newContent: string) => {
-    if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
-    const pid = effectiveId;
-    const cid = Number(id);
-    try {
-      const updated = await updateCommunityComment({
-        postId: pid,
-        commentId: cid,
-        contents: newContent,
-      });
-      const vm = toPostComment(updated, detailCtx.viewerId);
-      setComments((prev) =>
-        prev.map((c) =>
-          c.id === id ? { ...c, content: vm.content, date: vm.date } : c,
-        ),
-      );
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  // 댓글 삭제 (soft)
-  const handleDelete = async (id: string) => {
-    if (!isCommunitySource) return;
-    try {
-      await softDeleteCommunityComment(Number(id));
-      setComments((prev) => prev.filter((c) => c.id !== id));
-      setPost((prev) =>
-        prev
-          ? { ...prev, commentCounts: Math.max(0, prev.commentCounts - 1) }
-          : prev,
-      );
-    } catch (e) {
-      console.error(e);
     }
   };
 

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -5,12 +5,7 @@ import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
 import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import ReportModal from "@/shared/ui/Modal/ReportModal";
 import { PATH } from "@/shared/config/paths";
-import useClickOutside from "@/hooks/useClickOutside";
 import { useDetailContext } from "@/hooks/useDetailContext";
-import {
-  buildFreeformPrefill,
-  buildTemplatePrefill,
-} from "@/shared/utils/prefillBuilder";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import imageIcon from "@/assets/icons/image.svg";
@@ -18,12 +13,12 @@ import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import likeEmptyIcon from "@/assets/icons/like_empty.svg";
 import shareIcon from "@/assets/icons/share.svg";
-import { getPostDetail, hardDeletePost } from "@/api/post.api";
-import { postFollow, postUnfollow } from "@/api/user.api";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 import { usePostDetail } from "./hooks/usePostDetail";
 import { usePostComments } from "./hooks/usePostComments";
 import { usePostLike } from "./hooks/usePostLike";
+import { usePostMenu } from "./hooks/usePostMenu";
+import { usePostNavigation } from "./hooks/usePostNavigation";
 
 export type { CommunityPostDetailProps } from "./types";
 
@@ -104,57 +99,48 @@ export default function CommunityPostDetail() {
     setLikeCounts,
   });
 
-  const [showMenu, setShowMenu] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [reportModalOpen, setReportModalOpen] = useState(false);
-  const [reportTarget, setReportTarget] = useState<
-    | { type: "post"; postId: number }
-    | { type: "comment"; commentId: string }
-    | null
-  >(null);
-  const closeMenu = useCallback(() => setShowMenu(false), []);
-  const menuRef = useClickOutside(() => setShowMenu(false));
+  const {
+    showMenu,
+    setShowMenu,
+    deleting,
+    reportModalOpen,
+    setReportModalOpen,
+    reportTarget,
+    setReportTarget,
+    closeMenu,
+    menuRef,
+    handleDeletePost,
+  } = usePostMenu({
+    effectiveId,
+    from: detailCtx.from,
+    navigate,
+  });
 
-  const [currentSection, setCurrentSection] = useState<number>(0);
-  const contentColRef = useRef<HTMLDivElement | null>(null);
-  const [asideOffset, setAsideOffset] = useState(0);
-  const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const nav = usePostNavigation({
+    effectiveId,
+    post,
+    setPost,
+    navigate,
+    closeMenu,
+    viewerId: detailCtx.viewerId ?? null,
+    headerOffset: HEADER_OFFSET,
+  });
 
-  useEffect(() => {
-    const updateAsideOffset = () => {
-      const first = sectionRefs.current[0];
-      const col = contentColRef.current;
-      if (!first || !col) {
-        setAsideOffset(0);
-        return;
-      }
-      const firstTop = first.getBoundingClientRect().top + window.scrollY;
-      const colTop = col.getBoundingClientRect().top + window.scrollY;
-      const gap = Math.max(0, Math.round(firstTop - colTop));
-      setAsideOffset(gap);
-    };
-
-    // 초기에 한 번, 레이아웃 안정화 직후 한 번
-    requestAnimationFrame(updateAsideOffset);
-
-    // 리사이즈/폰트/이미지 로딩 등 레이아웃 변화에 대응
-    const onResize = () => updateAsideOffset();
-    window.addEventListener("resize", onResize);
-    window.addEventListener("load", onResize);
-
-    // 본문 컬럼 변화를 관찰(높이/폭 변동)
-    let ro: ResizeObserver | null = null;
-    if (typeof ResizeObserver !== "undefined" && contentColRef.current) {
-      ro = new ResizeObserver(updateAsideOffset);
-      ro.observe(contentColRef.current);
-    }
-
-    return () => {
-      window.removeEventListener("resize", onResize);
-      window.removeEventListener("load", onResize);
-      ro?.disconnect();
-    };
-  }, [post]); // post가 로드된 뒤에 계산
+  const {
+    contentColRef,
+    sectionRefs,
+    currentSection,
+    asideOffset,
+    scrollToSection,
+    goEditWithPrefill,
+    handleProfileClick,
+    handleFollow,
+    handleUnfollow,
+    goBack,
+    goCommunity,
+    goHome,
+    goMyPage,
+  } = nav;
 
   // 공유 토스트
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
@@ -212,182 +198,15 @@ export default function CommunityPostDetail() {
 
   useEffect(() => {
     if (!post) return;
-
-    // 비공개/내 글(/troubles 기반)일 때는 slug 정규화 X
     if (!isCommunitySource) return;
-
     const canonical =
       PATH.COMMUNITY_POST_SLUG(
-        makePostSlug(post.title, postId ?? effectiveId),
+        makePostSlug(post.title, postId ?? effectiveId)
       ) + window.location.search;
-
     if (!slug || slug !== makePostSlug(post.title, effectiveId)) {
       navigate(canonical, { replace: true });
     }
   }, [post, slug, effectiveId, navigate, postId, isCommunitySource]);
-
-  const navigatingRef = useRef(false);
-
-  const goEditWithPrefill = useCallback(async () => {
-    if (navigatingRef.current) return;
-    navigatingRef.current = true;
-
-    closeMenu();
-
-    try {
-      const pid = effectiveId;
-      if (!Number.isFinite(pid)) return;
-
-      const myDetail = await getPostDetail(pid);
-      const tt = String((myDetail as any)?.templateType ?? "").toUpperCase();
-      const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
-      const editorPath = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
-      const prefill = isFreeform
-        ? buildFreeformPrefill(myDetail)
-        : buildTemplatePrefill(myDetail);
-
-      // 같은 페인트 사이클에서의 상태 폭주 방지
-      queueMicrotask(() => {
-        navigate(editorPath, {
-          replace: true,
-          state: {
-            ...prefill,
-            postId: pid,
-            mode: "edit",
-            from: "community-detail",
-          },
-        });
-      });
-    } catch (err) {
-      console.error(err);
-      alert(
-        "수정 화면으로 이동하기 위한 데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요.",
-      );
-      navigatingRef.current = false; // 실패 시에만 잠금 해제
-    }
-  }, [postId, navigate, closeMenu]);
-
-  // 작성자 프로필 클릭
-  const handleProfileClick = () => {
-    if (!post || post.authorId == null) return;
-    navigate(PATH.MYPAGE_ID(String(post.authorId)));
-  };
-
-  // 포스트 삭제
-  const handleDeletePost = useCallback(async () => {
-    if (!Number.isFinite(effectiveId)) return;
-    if (
-      !window.confirm(
-        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다.",
-      )
-    )
-      return;
-
-    try {
-      setDeleting(true);
-      await hardDeletePost(effectiveId);
-      alert("문서가 영구 삭제되었습니다.");
-
-      if (detailCtx.from === "community") {
-        navigate(PATH.COMMUNITY, { replace: true });
-      } else {
-        navigate(-1);
-      }
-    } catch (err: any) {
-      console.error(err);
-      alert(
-        err?.response?.data?.message ??
-          "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
-      );
-    } finally {
-      setDeleting(false);
-      setShowMenu(false);
-    }
-  }, [postId, navigate, detailCtx.from]);
-
-  // 스크롤 감시
-  useEffect(() => {
-    const updateCurrentSection = () => {
-      // 화면의 현재 스크롤 위치에 오프셋을 더해 기준점을 맞춤
-      const y = window.scrollY + HEADER_OFFSET + 1;
-      let cur = 0;
-
-      sectionRefs.current.forEach((ref, idx) => {
-        if (!ref) return;
-        const top = ref.getBoundingClientRect().top + window.scrollY;
-        if (y >= top) cur = idx;
-      });
-
-      setCurrentSection(cur);
-    };
-
-    window.addEventListener("scroll", updateCurrentSection, { passive: true });
-    updateCurrentSection();
-
-    return () => window.removeEventListener("scroll", updateCurrentSection);
-  }, []);
-
-  const scrollToSection = (idx: number) => {
-    const target = sectionRefs.current[idx];
-    if (!target) return;
-    target.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
-  // 팔로우
-  const handleFollow = async () => {
-    setPost((prev) =>
-      prev
-        ? {
-            ...prev,
-            isFollowed: true,
-            authorFollowers: (prev.authorFollowers ?? 0) + 1,
-          }
-        : prev,
-    );
-
-    try {
-      await postFollow(Number(post?.authorId));
-    } catch (e) {
-      setPost((prev) =>
-        prev
-          ? {
-              ...prev,
-              isFollowed: false,
-              authorFollowers: Math.max(0, (prev.authorFollowers ?? 1) - 1),
-            }
-          : prev,
-      );
-      console.error("팔로우 실패", e);
-    }
-  };
-
-  // 언팔로우
-  const handleUnfollow = async () => {
-    setPost((prev) =>
-      prev
-        ? {
-            ...prev,
-            isFollowed: false,
-            authorFollowers: Math.max(0, (prev.authorFollowers ?? 1) - 1),
-          }
-        : prev,
-    );
-
-    try {
-      await postUnfollow(Number(post?.authorId));
-    } catch (e) {
-      setPost((prev) =>
-        prev
-          ? {
-              ...prev,
-              isFollowed: true,
-              authorFollowers: (prev.authorFollowers ?? 0) + 1,
-            }
-          : prev,
-      );
-      console.error("언팔로우 실패", e);
-    }
-  };
 
   // 로딩/에러 처리
   if (loading) {
@@ -405,24 +224,7 @@ export default function CommunityPostDetail() {
     );
   }
 
-  // CTA 핸들러들
   const viewerIdForCta = detailCtx.viewerId;
-  const goBack = () => {
-    if (window.history.length > 1) navigate(-1);
-    else navigate(PATH.COMMUNITY, { replace: true });
-  };
-  const goCommunity = () => navigate(PATH.COMMUNITY, { replace: true });
-  const goHome = () => navigate(PATH.HOME, { replace: true });
-  const goLogin = () => {
-    const sp = new URLSearchParams();
-    sp.set("next", window.location.pathname + window.location.search);
-    navigate(`${PATH.ROOT}?${sp.toString()}`, { replace: true });
-  };
-  const goMyPage = () => {
-    if (viewerIdForCta != null) navigate(PATH.MYPAGE_BASE);
-    else goLogin();
-  };
-
   const err = loadError;
 
   // 1) 400 BAD_REQUEST이면 카드 UI

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -18,12 +18,12 @@ import starIcon from "@/assets/icons/star.svg";
 import heartIcon from "@/assets/icons/heart.svg";
 import likeEmptyIcon from "@/assets/icons/like_empty.svg";
 import shareIcon from "@/assets/icons/share.svg";
-import { likeCommunityPost } from "@/api/community.api";
 import { getPostDetail, hardDeletePost } from "@/api/post.api";
 import { postFollow, postUnfollow } from "@/api/user.api";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 import { usePostDetail } from "./hooks/usePostDetail";
 import { usePostComments } from "./hooks/usePostComments";
+import { usePostLike } from "./hooks/usePostLike";
 
 export type { CommunityPostDetailProps } from "./types";
 
@@ -95,8 +95,14 @@ export default function CommunityPostDetail() {
     handleDelete,
   } = commentsApi;
 
-  const [isLiking, setIsLiking] = useState(false);
-  const likeLockRef = useRef(false);
+  const { isLiking, handleToggleLike } = usePostLike({
+    effectiveId,
+    isCommunitySource,
+    isLiked,
+    likeCounts,
+    setIsLiked,
+    setLikeCounts,
+  });
 
   const [showMenu, setShowMenu] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -265,55 +271,6 @@ export default function CommunityPostDetail() {
   const handleProfileClick = () => {
     if (!post || post.authorId == null) return;
     navigate(PATH.MYPAGE_ID(String(post.authorId)));
-  };
-
-  // 좋아요 토글(커뮤니티 글에서만)
-  const handleToggleLike = async () => {
-    if (!Number.isFinite(effectiveId)) return;
-    if (!isCommunitySource) {
-      alert("작성 중/비공개 문서는 좋아요를 사용할 수 없어요.");
-      return;
-    }
-    if (likeLockRef.current) return;
-    likeLockRef.current = true;
-    setIsLiking(true);
-
-    const pid = effectiveId;
-    const wasLiked = isLiked;
-    const prevCount = likeCounts;
-
-    if (wasLiked) {
-      setIsLiked(false);
-      setLikeCounts(Math.max(0, prevCount - 1));
-      try {
-        await likeCommunityPost(pid);
-      } catch {
-        setIsLiked(true);
-        setLikeCounts(prevCount);
-      } finally {
-        likeLockRef.current = false;
-        setIsLiking(false);
-      }
-    } else {
-      setIsLiked(true);
-      setLikeCounts(prevCount + 1);
-      try {
-        const res = await likeCommunityPost(pid);
-        setLikeCounts(res?.likeCount ?? prevCount + 1);
-      } catch (err: any) {
-        const status = err?.response?.status ?? err?.status;
-        if (status === 409) {
-          setIsLiked(true);
-          setLikeCounts(prevCount);
-        } else {
-          setIsLiked(false);
-          setLikeCounts(prevCount);
-        }
-      } finally {
-        likeLockRef.current = false;
-        setIsLiking(false);
-      }
-    }
   };
 
   // 포스트 삭제

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -1,3 +1,4 @@
+import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
 import ReportModal from "@/shared/ui/Modal/ReportModal";
 import { PostDetailContent } from "./components/PostDetailContent";
 import { PostDetailHeader } from "./components/PostDetailHeader";
@@ -9,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { extractIdFromSlug, makePostSlug } from "@/shared/lib/slug";
 import { usePostDetail } from "./hooks/usePostDetail";
+import { getResumeDraftMessage } from "@/shared/utils/prefillBuilder";
 import { usePostComments } from "./hooks/usePostComments";
 import { usePostLike } from "./hooks/usePostLike";
 import { usePostMenu } from "./hooks/usePostMenu";
@@ -60,6 +62,10 @@ export default function CommunityPostDetail() {
     likeCounts,
     setIsLiked,
     setLikeCounts,
+    resumePromptOpen,
+    resumePromptData,
+    confirmResumeEdit,
+    cancelResumePrompt,
   } = usePostDetail(effectiveId, detailCtx, navigate, {
     onLoadStart: useCallback(() => {
       onLoadStartRef.current();
@@ -372,6 +378,17 @@ export default function CommunityPostDetail() {
         >
           {toast.message}
         </div>
+      )}
+
+      {/* draft 이어쓰기 안내 모달 (window.confirm 대체) */}
+      {resumePromptOpen && resumePromptData && (
+        <ConfirmDeleteModal
+          title="이어쓰기"
+          description={getResumeDraftMessage(resumePromptData.myDetail.templateType)}
+          label="이어서 작성"
+          onClose={cancelResumePrompt}
+          onConfirm={confirmResumeEdit}
+        />
       )}
 
       {/* 신고 모달 */}

--- a/src/pages/Community/components/PostDetailComments.tsx
+++ b/src/pages/Community/components/PostDetailComments.tsx
@@ -1,0 +1,68 @@
+import PostComment from "@/entities/trouble/ui/PostComment";
+import type { PostCommentProps } from "@/entities/trouble/ui/PostComment";
+
+export interface PostDetailCommentsProps {
+  comments: PostCommentProps[];
+  onEdit: (id: string, newContent: string) => void;
+  onDelete: (id: string) => void;
+  onReply: (parentId: string, replyContent: string) => void | Promise<void>;
+  onReport: (commentId: string) => void;
+  onLoadMore: () => void;
+  hasNext: boolean;
+  loading: boolean;
+}
+
+/**
+ * 커뮤니티 포스트 상세 댓글 목록 + 더 보기
+ */
+export function PostDetailComments({
+  comments,
+  onEdit,
+  onDelete,
+  onReply,
+  onReport,
+  onLoadMore,
+  hasNext,
+  loading,
+}: PostDetailCommentsProps) {
+  return (
+    <div className="flex flex-col items-end self-stretch">
+      {comments
+        .filter((c) => !c.isReply)
+        .map((parent) => (
+          <div key={parent.id} className="w-full">
+            <PostComment
+              {...parent}
+              onEdit={(newContent) => onEdit(parent.id, newContent)}
+              onDelete={() => onDelete(parent.id)}
+              onReply={(replyContent) => onReply(parent.id, replyContent)}
+              onReport={onReport}
+            />
+            {comments
+              .filter((c) => c.parentId === parent.id)
+              .map((reply) => (
+                <PostComment
+                  key={reply.id}
+                  {...reply}
+                  onEdit={(newContent) => onEdit(reply.id, newContent)}
+                  onDelete={() => onDelete(reply.id)}
+                  onReport={onReport}
+                />
+              ))}
+          </div>
+        ))}
+
+      {hasNext && (
+        <button
+          disabled={loading}
+          onClick={onLoadMore}
+          className={`mt-4 px-6 py-2 rounded-full text-white ${
+            loading ? "bg-gray-300" : "bg-primary"
+          }`}
+        >
+          {loading ? "불러오는 중…" : "댓글 더 보기"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Community/components/PostDetailContent.tsx
+++ b/src/pages/Community/components/PostDetailContent.tsx
@@ -1,0 +1,195 @@
+import type { MutableRefObject } from "react";
+import PostGuideMd from "@/entities/trouble/ui/PostGuideMd";
+import imageIcon from "@/assets/icons/image.svg";
+import heartIcon from "@/assets/icons/heart.svg";
+import likeEmptyIcon from "@/assets/icons/like_empty.svg";
+import shareIcon from "@/assets/icons/share.svg";
+import type { CommunityPostDetailProps } from "@/pages/Community/types";
+
+export interface PostDetailContentProps {
+  post: CommunityPostDetailProps;
+  contentWidthClass: string;
+  headerOffset: number;
+  sectionRefs: MutableRefObject<(HTMLDivElement | null)[]>;
+  onProfileClick: () => void;
+  onFollow: () => void;
+  onUnfollow: () => void;
+  isCommunitySource: boolean;
+  isLiked: boolean;
+  isLiking: boolean;
+  likeCounts: number;
+  onToggleLike: () => void;
+  onCopyLink: () => void;
+  commentInput: string;
+  setCommentInput: (value: string) => void;
+  onSubmitComment: () => void;
+  isCommentPosting: boolean;
+}
+
+/**
+ * 커뮤니티 포스트 상세 하단: 본문, 작성자 카드, 좋아요/공유, 댓글 입력
+ */
+export function PostDetailContent({
+  post,
+  contentWidthClass,
+  headerOffset,
+  sectionRefs,
+  onProfileClick,
+  onFollow,
+  onUnfollow,
+  isCommunitySource,
+  isLiked,
+  isLiking,
+  likeCounts,
+  onToggleLike,
+  onCopyLink,
+  commentInput,
+  setCommentInput,
+  onSubmitComment,
+  isCommentPosting,
+}: PostDetailContentProps) {
+  return (
+    <div className="flex w-full flex-col items-start gap-[8px]">
+      <div className="flex flex-col items-start gap-[36px] self-stretch">
+        {/* 포스트 내용 */}
+        <div className="flex flex-col items-start gap-[48px] self-stretch">
+          {post.questions.map((q, idx) => (
+            <div
+              id={`section-${idx}`}
+              key={idx}
+              ref={(el) => {
+                sectionRefs.current[idx] = el;
+              }}
+              style={{ scrollMarginTop: headerOffset + 1 }}
+              className="scroll-mt-28 md:scroll-mt-[520px]"
+            >
+              <PostGuideMd
+                question={q}
+                content={post.contents[idx]}
+                widthClass={contentWidthClass}
+              />
+            </div>
+          ))}
+
+          {/* 작성자 정보 카드 */}
+          <div className="flex py-[24px] sm:py-[32px] px-5 sm:px-[40px] flex-col items-start gap-[10px] self-stretch rounded-[24px] sm:rounded-[36px] bg-[#F2F2F2]">
+            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center self-stretch gap-4">
+              <div
+                className="flex items-center gap-4 sm:gap-[28px] cursor-pointer"
+                onClick={onProfileClick}
+              >
+                <img
+                  src={post.authorProfile || imageIcon}
+                  onError={(e) => (e.currentTarget.src = imageIcon)}
+                  alt="profile"
+                  className="w-20 h-20 sm:w-[131px] sm:h-[131px] rounded-full object-cover"
+                />
+                <div className="flex flex-col items-start gap-[10px] sm:gap-[13px]">
+                  <div className="flex flex-col items-start gap-[2px]">
+                    <div className="text-head-24-bold">{post.authorName}</div>
+                    <div className="text-body-16-regular">
+                      {post.authorFollowers} 팔로워
+                    </div>
+                  </div>
+                  <div className="text-body-20-regular">{post.authorBio}</div>
+                </div>
+              </div>
+
+              {!post.isMine &&
+                (post.isFollowed ? (
+                  <button
+                    onClick={() => onUnfollow()}
+                    className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-subColor1 text-head-20-semibold text-white"
+                  >
+                    팔로잉
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => onFollow()}
+                    className="flex py-3 sm:py-[18px] px-6 sm:pl-[41px] sm:pr-[40px] justify-center items-center rounded-[100px] bg-primary text-head-20-semibold text-white"
+                  >
+                    팔로우
+                  </button>
+                ))}
+            </div>
+          </div>
+        </div>
+
+        {/* 좋아요/공유 */}
+        {isCommunitySource && (
+          <div className="flex pt-8 sm:pt-[52px] pb-5 sm:pb-[20px] items-center self-stretch border-b border-gray1">
+            <div className="flex items-center gap-4 sm:gap-[20px]">
+              <button
+                type="button"
+                aria-pressed={isLiked}
+                aria-busy={isLiking}
+                disabled={isLiking}
+                onClick={onToggleLike}
+                className={`flex items-center gap-2 sm:gap-[8px] ${
+                  isLiking
+                    ? "opacity-60 cursor-not-allowed"
+                    : "cursor-pointer"
+                }`}
+              >
+                <img
+                  src={isLiked ? heartIcon : likeEmptyIcon}
+                  alt="like"
+                  className="w-8 h-8 sm:w-10 sm:h-10"
+                />
+                <div className="text-body-20-regular text-gray3">
+                  {likeCounts}
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={onCopyLink}
+                className="cursor-pointer"
+                aria-label="현재 페이지 링크 복사"
+              >
+                <img
+                  src={shareIcon}
+                  alt="share"
+                  className="w-8 h-8 sm:w-10 sm:h-10"
+                />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 댓글 작성 */}
+        {isCommunitySource && (
+          <div className="flex flex-col items-end gap-[12px] self-stretch">
+            <div className="flex flex-col items-start gap-6 sm:gap-[36px] self-stretch">
+              <div className="text-head-32-semibold">
+                {post.commentCounts}개의 댓글
+              </div>
+              <textarea
+                value={commentInput}
+                onChange={(e) => setCommentInput(e.target.value)}
+                placeholder="댓글을 작성해주세요."
+                className="flex p-4 sm:pt-[28px] sm:pl-[32px] pb-24 sm:pb-[130px] w-full resize-none rounded-[24px] bg-white shadow-card text-body-20-regular text-[#757575] focus:outline-none"
+              />
+            </div>
+
+            <button
+              disabled={!commentInput.trim() || isCommentPosting}
+              onClick={onSubmitComment}
+              className={`inline-flex items-center justify-center rounded-[100px] px-6 sm:px-8
+              py-2 sm:py-3 text-white transition-colors
+              ${
+                commentInput.trim() && !isCommentPosting
+                  ? "bg-primary"
+                  : "bg-subColor1"
+              }`}
+            >
+              <span className="text-head-20-semibold leading-none">
+                {isCommentPosting ? "작성 중…" : "작성하기"}
+              </span>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Community/components/PostDetailContent.tsx
+++ b/src/pages/Community/components/PostDetailContent.tsx
@@ -61,7 +61,6 @@ export function PostDetailContent({
                 sectionRefs.current[idx] = el;
               }}
               style={{ scrollMarginTop: headerOffset + 1 }}
-              className="scroll-mt-28 md:scroll-mt-[520px]"
             >
               <PostGuideMd
                 question={q}

--- a/src/pages/Community/components/PostDetailHeader.tsx
+++ b/src/pages/Community/components/PostDetailHeader.tsx
@@ -1,0 +1,112 @@
+import type { RefObject } from "react";
+import TagList from "@/entities/trouble/ui/TagList";
+import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
+import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
+import imageIcon from "@/assets/icons/image.svg";
+import starIcon from "@/assets/icons/star.svg";
+import type { CommunityPostDetailProps } from "@/pages/Community/types";
+
+export interface PostDetailHeaderProps {
+  post: CommunityPostDetailProps;
+  menuRef: RefObject<HTMLDivElement | null>;
+  showMenu: boolean;
+  setShowMenu: (v: boolean) => void;
+  deleting: boolean;
+  onEdit: () => void | Promise<void>;
+  onDelete: () => void | Promise<void>;
+  onReport: () => void;
+  onAuthorClick: () => void;
+}
+
+/**
+ * 커뮤니티 포스트 상세 상단: 에러 타입, 케밥 메뉴, 제목, 태그·날짜, 작성자·중요도
+ */
+export function PostDetailHeader({
+  post,
+  menuRef,
+  showMenu,
+  setShowMenu,
+  deleting,
+  onEdit,
+  onDelete,
+  onReport,
+  onAuthorClick,
+}: PostDetailHeaderProps) {
+  return (
+    <div className="flex w-full pt-20 sm:pt-[180px] pb-[18px] items-center border-b border-gray1">
+      <div className="flex flex-col items-start gap-8 sm:gap-[44px] w-full">
+        <div className="flex flex-col items-start gap-8 sm:gap-[53px] w-full">
+          <div className="flex flex-col items-start gap-[10px] w-full">
+            <div className="flex w-full justify-between items-start gap-2">
+              <span className="text-head-20-semibold">{post.errorType}</span>
+              <div className="relative shrink-0" ref={menuRef}>
+                <KebabMenuButton onClick={() => setShowMenu(!showMenu)} />
+                {showMenu && (
+                  <KebabDropdown
+                    options={
+                      post.isMine
+                        ? [
+                            { label: "포스트 수정", onClick: () => void onEdit() },
+                            {
+                              label: deleting ? "삭제 중..." : "삭제",
+                              onClick: () => !deleting && void onDelete(),
+                            },
+                          ]
+                        : [
+                            {
+                              label: "신고하기",
+                              onClick: () => {
+                                setShowMenu(false);
+                                onReport();
+                              },
+                            },
+                          ]
+                    }
+                  />
+                )}
+              </div>
+            </div>
+            <div className="text-head-48 break-words">{post.title}</div>
+          </div>
+          <div className="flex flex-wrap items-center gap-[12px] sm:gap-[16px]">
+            <TagList tags={post.tags} variant="post" />
+            <div className="text-body-16-regular text-gray3">·</div>
+            <div className="text-body-20-regular text-gray3">{post.date}</div>
+          </div>
+        </div>
+        <div className="flex w-full flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div
+            className="flex items-center gap-[14px] sm:gap-[20px] cursor-pointer"
+            onClick={onAuthorClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onAuthorClick();
+              }
+            }}
+          >
+            <img
+              src={post.authorProfile || imageIcon}
+              onError={(e) => (e.currentTarget.src = imageIcon)}
+              alt="profile"
+              className="w-12 h-12 sm:w-[66px] sm:h-[66px] rounded-full object-cover"
+            />
+            <div className="text-head-24-bold">{post.authorName}</div>
+          </div>
+          {post.isMine && post.importance !== 0 && (
+            <div className="flex items-center gap-[8px]">
+              <img
+                src={starIcon}
+                alt="importance"
+                className="w-5 h-5 sm:w-[24px] sm:h-[24px]"
+              />
+              <div className="text-body-20-regular text-gray3">{post.importance}</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Community/components/PostDetailSidebar.tsx
+++ b/src/pages/Community/components/PostDetailSidebar.tsx
@@ -1,0 +1,39 @@
+export interface PostDetailSidebarProps {
+  questions: string[];
+  currentSection: number;
+  onSectionClick: (idx: number) => void;
+  headerOffset: number;
+  asideOffset: number;
+}
+
+/**
+ * 커뮤니티 포스트 상세 목차(TOC) 사이드바 — 큰 화면에서만 표시
+ */
+export function PostDetailSidebar({
+  questions,
+  currentSection,
+  onSectionClick,
+  headerOffset,
+  asideOffset,
+}: PostDetailSidebarProps) {
+  return (
+    <aside
+      className="hidden xl:block h-fit w-[220px] 2xl:w-[280px] sticky"
+      style={{ top: headerOffset, marginTop: asideOffset }}
+    >
+      <div className="flex flex-col items-start gap-[16px] border-l border-gray3 pl-[12px] pr-[8px] text-body-20-regular text-gray3 w-full">
+        {questions.map((q, idx) => (
+          <button
+            key={idx}
+            onClick={() => onSectionClick(idx)}
+            className={`text-left ${
+              currentSection === idx ? "text-black" : ""
+            }`}
+          >
+            {idx + 1}. {q}
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/pages/Community/hooks/usePostComments.ts
+++ b/src/pages/Community/hooks/usePostComments.ts
@@ -19,6 +19,8 @@ export interface UsePostCommentsOptions {
   isCommunitySource: boolean;
   viewerId: number | null;
   setPost: React.Dispatch<React.SetStateAction<CommunityPostDetailProps | null>>;
+  /** 댓글 수정 API 실패 시 호출 (에러 토스트 등) */
+  onEditError?: () => void;
 }
 
 export interface UsePostCommentsReturn {
@@ -46,7 +48,7 @@ export interface UsePostCommentsReturn {
 export function usePostComments(
   options: UsePostCommentsOptions
 ): UsePostCommentsReturn {
-  const { effectiveId, isCommunitySource, viewerId, setPost } = options;
+  const { effectiveId, isCommunitySource, viewerId, setPost, onEditError } = options;
 
   const [commentInput, setCommentInput] = useState("");
   const [comments, setComments] = useState<PostCommentProps[]>([]);
@@ -179,10 +181,10 @@ export function usePostComments(
           )
         );
       } catch {
-        // ignore
+        onEditError?.();
       }
     },
-    [effectiveId, isCommunitySource, viewerId]
+    [effectiveId, isCommunitySource, viewerId, onEditError]
   );
 
   const handleDelete = useCallback(

--- a/src/pages/Community/hooks/usePostComments.ts
+++ b/src/pages/Community/hooks/usePostComments.ts
@@ -62,7 +62,7 @@ export function usePostComments(
         const resp = await getCommunityComments(postId, page1, 10);
         const mapped = toPostComments(resp.content, currentViewerId);
         setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
-        setCPage(typeof resp.page === "number" ? resp.page + 1 : page1);
+        setCPage(typeof resp.page === "number" ? resp.page + 1 : page1 + 1);
         setCHasNext(!!resp.hasNext);
         setPost((prev) =>
           prev

--- a/src/pages/Community/hooks/usePostComments.ts
+++ b/src/pages/Community/hooks/usePostComments.ts
@@ -1,0 +1,223 @@
+import { useCallback, useState } from "react";
+import {
+  createCommunityComment,
+  getCommunityComments,
+  replyCommunityComment,
+  softDeleteCommunityComment,
+  updateCommunityComment,
+} from "@/api/community.api";
+import {
+  makeOptimisticComment,
+  toPostComment,
+  toPostComments,
+} from "@/entities/trouble/mappers/communityComment.mapper";
+import type { PostCommentProps } from "@/entities/trouble/ui/PostComment";
+import type { CommunityPostDetailProps } from "@/pages/Community/types";
+
+export interface UsePostCommentsOptions {
+  effectiveId: number;
+  isCommunitySource: boolean;
+  viewerId: number | null;
+  setPost: React.Dispatch<React.SetStateAction<CommunityPostDetailProps | null>>;
+}
+
+export interface UsePostCommentsReturn {
+  commentInput: string;
+  setCommentInput: React.Dispatch<React.SetStateAction<string>>;
+  comments: PostCommentProps[];
+  setComments: React.Dispatch<React.SetStateAction<PostCommentProps[]>>;
+  isCommentPosting: boolean;
+  cPage: number;
+  cHasNext: boolean;
+  cLoading: boolean;
+  loadComments: (postId: number, page1: number, viewerId: number | null) => Promise<void>;
+  reloadCommentsFirstPage: () => Promise<void>;
+  /** 상세 로드 시작 시 댓글 상태 초기화 (usePostDetail onLoadStart에서 호출) */
+  resetForNewPost: () => void;
+  handleSubmitComment: () => Promise<void>;
+  handleReply: (parentId: string, replyContent: string) => Promise<void>;
+  handleEdit: (id: string, newContent: string) => Promise<void>;
+  handleDelete: (id: string) => Promise<void>;
+}
+
+/**
+ * 커뮤니티 포스트 댓글 로드·작성·수정·삭제 로직
+ */
+export function usePostComments(
+  options: UsePostCommentsOptions
+): UsePostCommentsReturn {
+  const { effectiveId, isCommunitySource, viewerId, setPost } = options;
+
+  const [commentInput, setCommentInput] = useState("");
+  const [comments, setComments] = useState<PostCommentProps[]>([]);
+  const [isCommentPosting, setIsCommentPosting] = useState(false);
+  const [cPage, setCPage] = useState(1);
+  const [cHasNext, setCHasNext] = useState(false);
+  const [cLoading, setCLoading] = useState(false);
+
+  const loadComments = useCallback(
+    async (postId: number, page1: number, currentViewerId: number | null) => {
+      setCLoading(true);
+      try {
+        const resp = await getCommunityComments(postId, page1, 10);
+        const mapped = toPostComments(resp.content, currentViewerId);
+        setComments((prev) => (page1 === 1 ? mapped : [...prev, ...mapped]));
+        setCPage(typeof resp.page === "number" ? resp.page + 1 : page1);
+        setCHasNext(!!resp.hasNext);
+        setPost((prev) =>
+          prev
+            ? { ...prev, commentCounts: resp.totalElements ?? prev.commentCounts }
+            : prev
+        );
+      } finally {
+        setCLoading(false);
+      }
+    },
+    [setPost]
+  );
+
+  const reloadCommentsFirstPage = useCallback(async () => {
+    if (!Number.isFinite(effectiveId)) return;
+    await loadComments(effectiveId, 1, viewerId);
+  }, [effectiveId, viewerId, loadComments]);
+
+  const resetForNewPost = useCallback(() => {
+    setComments([]);
+    setCPage(1);
+    setCHasNext(false);
+  }, []);
+
+  const handleSubmitComment = useCallback(async () => {
+    if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
+    const contents = commentInput.trim();
+    if (!contents || isCommentPosting) return;
+
+    setIsCommentPosting(true);
+    const optimistic = makeOptimisticComment({ contents });
+    setComments((prev) => [optimistic, ...prev]);
+    setPost((p) => (p ? { ...p, commentCounts: (p.commentCounts ?? 0) + 1 } : p));
+    setCommentInput("");
+
+    try {
+      const created = await createCommunityComment(effectiveId, { contents });
+      const mapped = toPostComment(created, viewerId, { isReply: false });
+      setComments((prev) => {
+        const i = prev.findIndex((c) => c.id === optimistic.id);
+        if (i === -1) return [mapped, ...prev];
+        const next = [...prev];
+        next[i] = mapped;
+        return next;
+      });
+      await reloadCommentsFirstPage();
+    } catch {
+      setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+      setPost((p) =>
+        p ? { ...p, commentCounts: Math.max(0, (p.commentCounts ?? 1) - 1) } : p
+      );
+      setCommentInput(contents);
+    } finally {
+      setIsCommentPosting(false);
+    }
+  }, [
+    effectiveId,
+    isCommunitySource,
+    commentInput,
+    isCommentPosting,
+    viewerId,
+    setPost,
+    reloadCommentsFirstPage,
+  ]);
+
+  const handleReply = useCallback(
+    async (parentId: string, replyContent: string) => {
+      if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
+      const contents = replyContent.trim();
+      if (!contents) return;
+
+      const optimistic = makeOptimisticComment({ contents, parentId });
+      setComments((prev) => [...prev, optimistic]);
+
+      try {
+        const created = await replyCommunityComment(
+          effectiveId,
+          Number(parentId),
+          { contents }
+        );
+        const mapped = toPostComment(created, viewerId, {
+          isReply: true,
+          parentId,
+        });
+        setComments((prev) => {
+          const i = prev.findIndex((c) => c.id === optimistic.id);
+          if (i === -1) return [...prev, mapped];
+          const next = [...prev];
+          next[i] = mapped;
+          return next;
+        });
+        await reloadCommentsFirstPage();
+      } catch {
+        setComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+      }
+    },
+    [effectiveId, isCommunitySource, viewerId, reloadCommentsFirstPage]
+  );
+
+  const handleEdit = useCallback(
+    async (id: string, newContent: string) => {
+      if (!Number.isFinite(effectiveId) || !isCommunitySource) return;
+      const cid = Number(id);
+      try {
+        const updated = await updateCommunityComment({
+          postId: effectiveId,
+          commentId: cid,
+          contents: newContent,
+        });
+        const vm = toPostComment(updated, viewerId);
+        setComments((prev) =>
+          prev.map((c) =>
+            c.id === id ? { ...c, content: vm.content, date: vm.date } : c
+          )
+        );
+      } catch {
+        // ignore
+      }
+    },
+    [effectiveId, isCommunitySource, viewerId]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!isCommunitySource) return;
+      try {
+        await softDeleteCommunityComment(Number(id));
+        setComments((prev) => prev.filter((c) => c.id !== id));
+        setPost((prev) =>
+          prev
+            ? { ...prev, commentCounts: Math.max(0, prev.commentCounts - 1) }
+            : prev
+        );
+      } catch {
+        // ignore
+      }
+    },
+    [isCommunitySource, setPost]
+  );
+
+  return {
+    commentInput,
+    setCommentInput,
+    comments,
+    setComments,
+    isCommentPosting,
+    cPage,
+    cHasNext,
+    cLoading,
+    loadComments,
+    reloadCommentsFirstPage,
+    resetForNewPost,
+    handleSubmitComment,
+    handleReply,
+    handleEdit,
+    handleDelete,
+  };
+}

--- a/src/pages/Community/hooks/usePostDetail.ts
+++ b/src/pages/Community/hooks/usePostDetail.ts
@@ -71,8 +71,10 @@ export function usePostDetail(
 
     const loadCommunity = async () => {
       const communityData = await getCommunityPostDetail(effectiveId);
+      if (cancelled) return;
       if (!communityData) throw new Error("빈 응답입니다.");
       const vm = toCommunityPostVM(communityData, detailCtx.viewerId);
+      if (cancelled) return;
       setPost(vm);
       setIsLiked(vm.isLiked);
       setLikeCounts(vm.likeCounts);
@@ -82,6 +84,7 @@ export function usePostDetail(
 
     const loadMineDraft = async (id: number) => {
       const myDetail = await getPostDetail(id);
+      if (cancelled) return;
       const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
       const isDraft = completedAt == null;
 
@@ -90,6 +93,7 @@ export function usePostDetail(
       }
 
       const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], detailCtx.viewerId);
+      if (cancelled) return;
       setPost(vmMine);
       setIsLiked(vmMine.isLiked);
       setLikeCounts(vmMine.likeCounts);
@@ -108,6 +112,7 @@ export function usePostDetail(
             : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?"
         );
 
+        if (cancelled) return;
         if (ok) {
           const baseState =
             tt === "FREE_FORM" || tt === "FREEFORM"
@@ -117,6 +122,7 @@ export function usePostDetail(
             tt === "FREE_FORM" || tt === "FREEFORM"
               ? PATH.FREEFORM_WRITING
               : PATH.TEMP_WRITING;
+          if (cancelled) return;
           navigate(editorPath, {
             replace: true,
             state: {
@@ -149,12 +155,14 @@ export function usePostDetail(
 
         if (isVisibleFromList === false) {
           const myDetail = await getPostDetail(effectiveId);
+          if (cancelled) return;
           const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
           const isDraft = completedAt == null;
           if (isDraft) {
             await loadMineDraft(effectiveId);
           } else {
             const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
             setLikeCounts(vmMine.likeCounts);
@@ -165,12 +173,14 @@ export function usePostDetail(
 
         if (from === "project") {
           const myDetail = await getPostDetail(effectiveId);
+          if (cancelled) return;
           const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
           const isDraft = completedAt == null;
           if (isDraft) {
             await loadMineDraft(effectiveId);
           } else {
             const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
             setLikeCounts(vmMine.likeCounts);
@@ -192,6 +202,7 @@ export function usePostDetail(
 
         if (isMine && statusFromList === "created") {
           if (summaryIdFromList != null) {
+            if (cancelled) return;
             navigate(PATH.COMBINED_DETAIL(effectiveId, summaryIdFromList), {
               replace: true,
               state: { from: "community-detail", ownerId: viewerId ?? undefined },
@@ -200,12 +211,14 @@ export function usePostDetail(
           }
           try {
             const myDetail = await getPostDetail(effectiveId);
+            if (cancelled) return;
             const md = myDetail as { postSummaryId?: number; summaryId?: number };
             const sid =
               (typeof md?.postSummaryId === "number" && md.postSummaryId) ||
               (typeof md?.summaryId === "number" && md.summaryId) ||
               null;
             if (sid != null) {
+              if (cancelled) return;
               navigate(PATH.COMBINED_DETAIL(effectiveId, sid), {
                 replace: true,
                 state: { from: "community-detail", ownerId: viewerId ?? undefined },
@@ -228,7 +241,9 @@ export function usePostDetail(
             await loadCommunity();
           } else {
             const myDetail = await getPostDetail(effectiveId);
+            if (cancelled) return;
             const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
             setLikeCounts(vmMine.likeCounts);
@@ -240,6 +255,7 @@ export function usePostDetail(
         if (isMine) {
           try {
             const myDetail = await getPostDetail(effectiveId);
+            if (cancelled) return;
             const isDraft = (myDetail as { completedAt?: string | null })?.completedAt == null;
             if (isDraft) {
               await loadMineDraft(effectiveId);
@@ -247,6 +263,7 @@ export function usePostDetail(
             }
             if ((myDetail as { isVisible?: boolean })?.isVisible === false) {
               const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+              if (cancelled) return;
               setPost(vmMine);
               setIsLiked(vmMine.isLiked);
               setLikeCounts(vmMine.likeCounts);
@@ -255,6 +272,7 @@ export function usePostDetail(
             }
             await loadCommunity();
           } catch {
+            if (cancelled) return;
             await loadCommunity();
           }
         } else {

--- a/src/pages/Community/hooks/usePostDetail.ts
+++ b/src/pages/Community/hooks/usePostDetail.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { getCommunityPostDetail } from "@/api/community.api";
 import { getPostDetail } from "@/api/post.api";
+import type { ViewPostResponse } from "@/models/post.model";
 import { toCommunityPostVM } from "@/entities/trouble/mappers/communityPostDetail.mapper";
 import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
 import { PATH } from "@/shared/config/paths";
@@ -83,16 +84,16 @@ export function usePostDetail(
     };
 
     const loadMineDraft = async (id: number) => {
-      const myDetail = await getPostDetail(id);
+      const myDetail: ViewPostResponse = await getPostDetail(id);
       if (cancelled) return;
-      const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+      const completedAt = myDetail.completedAt ?? null;
       const isDraft = completedAt == null;
 
       if (!isDraft) {
         throw new Error("완료 문서입니다. 커뮤니티 상세로 이동해야 합니다.");
       }
 
-      const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], detailCtx.viewerId);
+      const vmMine = toPostDetailVM(myDetail, detailCtx.viewerId);
       if (cancelled) return;
       setPost(vmMine);
       setIsLiked(vmMine.isLiked);
@@ -101,9 +102,7 @@ export function usePostDetail(
 
       if (!resumePromptShownRef.current[id]) {
         resumePromptShownRef.current[id] = true;
-        const ttRaw =
-          (myDetail as { templateType?: string })?.templateType ??
-          (vmMine as { templateType?: string })?.templateType;
+        const ttRaw = myDetail.templateType;
         const tt = String(ttRaw ?? "").toUpperCase();
 
         const ok = window.confirm(
@@ -130,10 +129,10 @@ export function usePostDetail(
               postId: id,
               mode: "edit",
               from: "community-detail",
-              projectId: (myDetail as { projectId?: number })?.projectId ?? undefined,
+              projectId: myDetail.projectId ?? undefined,
               savePrefill:
-                (baseState as { savePrefill?: object }).savePrefill != null
-                  ? { ...(baseState as { savePrefill: object }).savePrefill }
+                baseState.savePrefill != null
+                  ? { ...baseState.savePrefill }
                   : undefined,
             },
           });
@@ -154,14 +153,14 @@ export function usePostDetail(
         } = detailCtx;
 
         if (isVisibleFromList === false) {
-          const myDetail = await getPostDetail(effectiveId);
+          const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
           if (cancelled) return;
-          const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+          const completedAt = myDetail.completedAt ?? null;
           const isDraft = completedAt == null;
           if (isDraft) {
             await loadMineDraft(effectiveId);
           } else {
-            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            const vmMine = toPostDetailVM(myDetail, viewerId);
             if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
@@ -172,14 +171,14 @@ export function usePostDetail(
         }
 
         if (from === "project") {
-          const myDetail = await getPostDetail(effectiveId);
+          const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
           if (cancelled) return;
-          const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+          const completedAt = myDetail.completedAt ?? null;
           const isDraft = completedAt == null;
           if (isDraft) {
             await loadMineDraft(effectiveId);
           } else {
-            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            const vmMine = toPostDetailVM(myDetail, viewerId);
             if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
@@ -210,12 +209,11 @@ export function usePostDetail(
             return;
           }
           try {
-            const myDetail = await getPostDetail(effectiveId);
+            const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
             if (cancelled) return;
-            const md = myDetail as { postSummaryId?: number; summaryId?: number };
             const sid =
-              (typeof md?.postSummaryId === "number" && md.postSummaryId) ||
-              (typeof md?.summaryId === "number" && md.summaryId) ||
+              (typeof myDetail.postSummaryId === "number" && myDetail.postSummaryId) ||
+              (typeof myDetail.summaryId === "number" && myDetail.summaryId) ||
               null;
             if (sid != null) {
               if (cancelled) return;
@@ -240,9 +238,9 @@ export function usePostDetail(
           if (isVisibleFromList) {
             await loadCommunity();
           } else {
-            const myDetail = await getPostDetail(effectiveId);
+            const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
             if (cancelled) return;
-            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            const vmMine = toPostDetailVM(myDetail, viewerId);
             if (cancelled) return;
             setPost(vmMine);
             setIsLiked(vmMine.isLiked);
@@ -254,15 +252,15 @@ export function usePostDetail(
 
         if (isMine) {
           try {
-            const myDetail = await getPostDetail(effectiveId);
+            const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
             if (cancelled) return;
-            const isDraft = (myDetail as { completedAt?: string | null })?.completedAt == null;
+            const isDraft = myDetail.completedAt == null;
             if (isDraft) {
               await loadMineDraft(effectiveId);
               return;
             }
-            if ((myDetail as { isVisible?: boolean })?.isVisible === false) {
-              const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            if (myDetail.isVisible === false) {
+              const vmMine = toPostDetailVM(myDetail, viewerId);
               if (cancelled) return;
               setPost(vmMine);
               setIsLiked(vmMine.isLiked);

--- a/src/pages/Community/hooks/usePostDetail.ts
+++ b/src/pages/Community/hooks/usePostDetail.ts
@@ -1,0 +1,299 @@
+import { useEffect, useState } from "react";
+import type { NavigateFunction } from "react-router-dom";
+import { getCommunityPostDetail } from "@/api/community.api";
+import { getPostDetail } from "@/api/post.api";
+import { toCommunityPostVM } from "@/entities/trouble/mappers/communityPostDetail.mapper";
+import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
+import { PATH } from "@/shared/config/paths";
+import { parseApiError } from "@/shared/utils/apiErrorParser";
+import {
+  buildFreeformPrefill,
+  buildTemplatePrefill,
+} from "@/shared/utils/prefillBuilder";
+import type { UseDetailContextReturn } from "@/hooks/useDetailContext";
+import type { CommunityPostDetailProps } from "@/pages/Community/types";
+
+export interface UsePostDetailOptions {
+  /** 상세 로드 시작 시 호출 (댓글 상태 초기화 등) */
+  onLoadStart?: () => void;
+  /** 커뮤니티 상세 로드 완료 후 호출 (댓글 1페이지 로드 등) */
+  onCommunityLoaded?: (postId: number, viewerId: number | null) => void;
+  /** 이어쓰기 안내 한 번만 띄우기 위한 ref */
+  resumePromptShownRef: React.MutableRefObject<Record<number, boolean>>;
+}
+
+export interface UsePostDetailReturn {
+  post: CommunityPostDetailProps | null;
+  setPost: React.Dispatch<React.SetStateAction<CommunityPostDetailProps | null>>;
+  loading: boolean;
+  loadError: ReturnType<typeof parseApiError> | null;
+  isCommunitySource: boolean;
+  isLiked: boolean;
+  likeCounts: number;
+  setIsLiked: React.Dispatch<React.SetStateAction<boolean>>;
+  setLikeCounts: React.Dispatch<React.SetStateAction<number>>;
+}
+
+/**
+ * 커뮤니티 포스트 상세 데이터 로딩 로직 (커뮤/내상세 분기, 이어쓰기 안내 포함)
+ */
+export function usePostDetail(
+  effectiveId: number,
+  detailCtx: UseDetailContextReturn,
+  navigate: NavigateFunction,
+  options: UsePostDetailOptions
+): UsePostDetailReturn {
+  const {
+    onLoadStart,
+    onCommunityLoaded,
+    resumePromptShownRef,
+  } = options;
+
+  const [post, setPost] = useState<CommunityPostDetailProps | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<ReturnType<typeof parseApiError> | null>(null);
+  const [isCommunitySource, setIsCommunitySource] = useState(true);
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeCounts, setLikeCounts] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    onLoadStart?.();
+    setLoading(true);
+    setLoadError(null);
+
+    if (!Number.isFinite(effectiveId)) {
+      setLoadError({ message: "잘못된 포스트 ID" });
+      setLoading(false);
+      return;
+    }
+
+    const loadCommunity = async () => {
+      const communityData = await getCommunityPostDetail(effectiveId);
+      if (!communityData) throw new Error("빈 응답입니다.");
+      const vm = toCommunityPostVM(communityData, detailCtx.viewerId);
+      setPost(vm);
+      setIsLiked(vm.isLiked);
+      setLikeCounts(vm.likeCounts);
+      setIsCommunitySource(true);
+      onCommunityLoaded?.(effectiveId, detailCtx.viewerId ?? null);
+    };
+
+    const loadMineDraft = async (id: number) => {
+      const myDetail = await getPostDetail(id);
+      const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+      const isDraft = completedAt == null;
+
+      if (!isDraft) {
+        throw new Error("완료 문서입니다. 커뮤니티 상세로 이동해야 합니다.");
+      }
+
+      const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], detailCtx.viewerId);
+      setPost(vmMine);
+      setIsLiked(vmMine.isLiked);
+      setLikeCounts(vmMine.likeCounts);
+      setIsCommunitySource(false);
+
+      if (!resumePromptShownRef.current[id]) {
+        resumePromptShownRef.current[id] = true;
+        const ttRaw =
+          (myDetail as { templateType?: string })?.templateType ??
+          (vmMine as { templateType?: string })?.templateType;
+        const tt = String(ttRaw ?? "").toUpperCase();
+
+        const ok = window.confirm(
+          tt === "FREE_FORM" || tt === "FREEFORM"
+            ? "이 문서는 자유형식 글 작성 중이에요. 이어서 작성할까요?"
+            : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?"
+        );
+
+        if (ok) {
+          const baseState =
+            tt === "FREE_FORM" || tt === "FREEFORM"
+              ? buildFreeformPrefill(myDetail)
+              : buildTemplatePrefill(myDetail);
+          const editorPath =
+            tt === "FREE_FORM" || tt === "FREEFORM"
+              ? PATH.FREEFORM_WRITING
+              : PATH.TEMP_WRITING;
+          navigate(editorPath, {
+            replace: true,
+            state: {
+              ...baseState,
+              postId: id,
+              mode: "edit",
+              from: "community-detail",
+              projectId: (myDetail as { projectId?: number })?.projectId ?? undefined,
+              savePrefill:
+                (baseState as { savePrefill?: object }).savePrefill != null
+                  ? { ...(baseState as { savePrefill: object }).savePrefill }
+                  : undefined,
+            },
+          });
+        }
+      }
+    };
+
+    (async () => {
+      try {
+        const {
+          viewerId,
+          ownerId,
+          statusFromList,
+          isVisibleFromList,
+          summaryIdFromList,
+          isMineFromList,
+          from,
+        } = detailCtx;
+
+        if (isVisibleFromList === false) {
+          const myDetail = await getPostDetail(effectiveId);
+          const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+          const isDraft = completedAt == null;
+          if (isDraft) {
+            await loadMineDraft(effectiveId);
+          } else {
+            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            setPost(vmMine);
+            setIsLiked(vmMine.isLiked);
+            setLikeCounts(vmMine.likeCounts);
+            setIsCommunitySource(false);
+          }
+          return;
+        }
+
+        if (from === "project") {
+          const myDetail = await getPostDetail(effectiveId);
+          const completedAt = (myDetail as { completedAt?: string | null })?.completedAt ?? null;
+          const isDraft = completedAt == null;
+          if (isDraft) {
+            await loadMineDraft(effectiveId);
+          } else {
+            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            setPost(vmMine);
+            setIsLiked(vmMine.isLiked);
+            setLikeCounts(vmMine.likeCounts);
+            setIsCommunitySource(false);
+          }
+          return;
+        }
+
+        const mineByIds =
+          viewerId != null &&
+          ownerId != null &&
+          String(ownerId) === String(viewerId);
+        const isMine = isMineFromList === true ? true : mineByIds;
+
+        if (isMine && statusFromList === "inProgress") {
+          await loadMineDraft(effectiveId);
+          return;
+        }
+
+        if (isMine && statusFromList === "created") {
+          if (summaryIdFromList != null) {
+            navigate(PATH.COMBINED_DETAIL(effectiveId, summaryIdFromList), {
+              replace: true,
+              state: { from: "community-detail", ownerId: viewerId ?? undefined },
+            });
+            return;
+          }
+          try {
+            const myDetail = await getPostDetail(effectiveId);
+            const md = myDetail as { postSummaryId?: number; summaryId?: number };
+            const sid =
+              (typeof md?.postSummaryId === "number" && md.postSummaryId) ||
+              (typeof md?.summaryId === "number" && md.summaryId) ||
+              null;
+            if (sid != null) {
+              navigate(PATH.COMBINED_DETAIL(effectiveId, sid), {
+                replace: true,
+                state: { from: "community-detail", ownerId: viewerId ?? undefined },
+              });
+              return;
+            }
+          } catch {
+            /* fallback to community */
+          }
+          await loadCommunity();
+          return;
+        }
+
+        if (
+          isMine &&
+          statusFromList === "complete" &&
+          typeof isVisibleFromList === "boolean"
+        ) {
+          if (isVisibleFromList) {
+            await loadCommunity();
+          } else {
+            const myDetail = await getPostDetail(effectiveId);
+            const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+            setPost(vmMine);
+            setIsLiked(vmMine.isLiked);
+            setLikeCounts(vmMine.likeCounts);
+            setIsCommunitySource(false);
+          }
+          return;
+        }
+
+        if (isMine) {
+          try {
+            const myDetail = await getPostDetail(effectiveId);
+            const isDraft = (myDetail as { completedAt?: string | null })?.completedAt == null;
+            if (isDraft) {
+              await loadMineDraft(effectiveId);
+              return;
+            }
+            if ((myDetail as { isVisible?: boolean })?.isVisible === false) {
+              const vmMine = toPostDetailVM(myDetail as Parameters<typeof toPostDetailVM>[0], viewerId);
+              setPost(vmMine);
+              setIsLiked(vmMine.isLiked);
+              setLikeCounts(vmMine.likeCounts);
+              setIsCommunitySource(false);
+              return;
+            }
+            await loadCommunity();
+          } catch {
+            await loadCommunity();
+          }
+        } else {
+          await loadCommunity();
+        }
+      } catch (err: unknown) {
+        if (!cancelled) setLoadError(parseApiError(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    effectiveId,
+    detailCtx.viewerId,
+    detailCtx.ownerId,
+    detailCtx.statusFromList,
+    detailCtx.isVisibleFromList,
+    detailCtx.summaryIdFromList,
+    detailCtx.isMineFromList,
+    detailCtx.from,
+    navigate,
+    onLoadStart,
+    onCommunityLoaded,
+    resumePromptShownRef,
+  ]);
+
+  return {
+    post,
+    setPost,
+    loading,
+    loadError,
+    isCommunitySource,
+    isLiked,
+    likeCounts,
+    setIsLiked,
+    setLikeCounts,
+  };
+}

--- a/src/pages/Community/hooks/usePostDetail.ts
+++ b/src/pages/Community/hooks/usePostDetail.ts
@@ -105,6 +105,26 @@ export function usePostDetail(
       onCommunityLoaded?.(effectiveId, detailCtx.viewerId ?? null);
     };
 
+    const applyMineView = (vm: CommunityPostDetailProps) => {
+      setPost(vm);
+      setIsLiked(vm.isLiked);
+      setLikeCounts(vm.likeCounts);
+      setIsCommunitySource(false);
+    };
+
+    const loadMyDetailOrDraft = async (id: number) => {
+      const myDetail: ViewPostResponse = await getPostDetail(id);
+      if (cancelled) return;
+      const isDraft = myDetail.completedAt == null;
+      if (isDraft) {
+        await loadMineDraft(id);
+      } else {
+        const vmMine = toPostDetailVM(myDetail, detailCtx.viewerId ?? null);
+        if (cancelled) return;
+        applyMineView(vmMine);
+      }
+    };
+
     const loadMineDraft = async (id: number) => {
       const myDetail: ViewPostResponse = await getPostDetail(id);
       if (cancelled) return;
@@ -117,10 +137,7 @@ export function usePostDetail(
 
       const vmMine = toPostDetailVM(myDetail, detailCtx.viewerId);
       if (cancelled) return;
-      setPost(vmMine);
-      setIsLiked(vmMine.isLiked);
-      setLikeCounts(vmMine.likeCounts);
-      setIsCommunitySource(false);
+      applyMineView(vmMine);
 
       if (!resumePromptShownRef.current[id]) {
         resumePromptShownRef.current[id] = true;
@@ -142,38 +159,12 @@ export function usePostDetail(
         } = detailCtx;
 
         if (isVisibleFromList === false) {
-          const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
-          if (cancelled) return;
-          const completedAt = myDetail.completedAt ?? null;
-          const isDraft = completedAt == null;
-          if (isDraft) {
-            await loadMineDraft(effectiveId);
-          } else {
-            const vmMine = toPostDetailVM(myDetail, viewerId);
-            if (cancelled) return;
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false);
-          }
+          await loadMyDetailOrDraft(effectiveId);
           return;
         }
 
         if (from === "project") {
-          const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
-          if (cancelled) return;
-          const completedAt = myDetail.completedAt ?? null;
-          const isDraft = completedAt == null;
-          if (isDraft) {
-            await loadMineDraft(effectiveId);
-          } else {
-            const vmMine = toPostDetailVM(myDetail, viewerId);
-            if (cancelled) return;
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false);
-          }
+          await loadMyDetailOrDraft(effectiveId);
           return;
         }
 
@@ -229,12 +220,7 @@ export function usePostDetail(
           } else {
             const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
             if (cancelled) return;
-            const vmMine = toPostDetailVM(myDetail, viewerId);
-            if (cancelled) return;
-            setPost(vmMine);
-            setIsLiked(vmMine.isLiked);
-            setLikeCounts(vmMine.likeCounts);
-            setIsCommunitySource(false);
+            applyMineView(toPostDetailVM(myDetail, viewerId));
           }
           return;
         }
@@ -249,12 +235,8 @@ export function usePostDetail(
               return;
             }
             if (myDetail.isVisible === false) {
-              const vmMine = toPostDetailVM(myDetail, viewerId);
               if (cancelled) return;
-              setPost(vmMine);
-              setIsLiked(vmMine.isLiked);
-              setLikeCounts(vmMine.likeCounts);
-              setIsCommunitySource(false);
+              applyMineView(toPostDetailVM(myDetail, viewerId));
               return;
             }
             await loadCommunity();

--- a/src/pages/Community/hooks/usePostDetail.ts
+++ b/src/pages/Community/hooks/usePostDetail.ts
@@ -1,16 +1,13 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { getCommunityPostDetail } from "@/api/community.api";
 import { getPostDetail } from "@/api/post.api";
 import type { ViewPostResponse } from "@/models/post.model";
 import { toCommunityPostVM } from "@/entities/trouble/mappers/communityPostDetail.mapper";
 import { toPostDetailVM } from "@/entities/trouble/mappers/myPostDetail.mapper";
-import { PATH } from "@/shared/config/paths";
 import { parseApiError } from "@/shared/utils/apiErrorParser";
-import {
-  buildFreeformPrefill,
-  buildTemplatePrefill,
-} from "@/shared/utils/prefillBuilder";
+import { PATH } from "@/shared/config/paths";
+import { buildEditorNavigationState } from "@/shared/utils/prefillBuilder";
 import type { UseDetailContextReturn } from "@/hooks/useDetailContext";
 import type { CommunityPostDetailProps } from "@/pages/Community/types";
 
@@ -23,6 +20,11 @@ export interface UsePostDetailOptions {
   resumePromptShownRef: React.MutableRefObject<Record<number, boolean>>;
 }
 
+export interface ResumePromptData {
+  myDetail: ViewPostResponse;
+  postId: number;
+}
+
 export interface UsePostDetailReturn {
   post: CommunityPostDetailProps | null;
   setPost: React.Dispatch<React.SetStateAction<CommunityPostDetailProps | null>>;
@@ -33,6 +35,11 @@ export interface UsePostDetailReturn {
   likeCounts: number;
   setIsLiked: React.Dispatch<React.SetStateAction<boolean>>;
   setLikeCounts: React.Dispatch<React.SetStateAction<number>>;
+  /** draft 이어쓰기 안내 모달 (window.confirm 대체) */
+  resumePromptOpen: boolean;
+  resumePromptData: ResumePromptData | null;
+  confirmResumeEdit: () => void;
+  cancelResumePrompt: () => void;
 }
 
 /**
@@ -56,6 +63,21 @@ export function usePostDetail(
   const [isCommunitySource, setIsCommunitySource] = useState(true);
   const [isLiked, setIsLiked] = useState(false);
   const [likeCounts, setLikeCounts] = useState(0);
+  const [resumePromptData, setResumePromptData] = useState<ResumePromptData | null>(null);
+
+  const confirmResumeEdit = useCallback(() => {
+    if (!resumePromptData) return;
+    const { path, state } = buildEditorNavigationState(
+      resumePromptData.myDetail,
+      resumePromptData.postId
+    );
+    setResumePromptData(null);
+    navigate(path, { replace: true, state });
+  }, [resumePromptData, navigate]);
+
+  const cancelResumePrompt = useCallback(() => {
+    setResumePromptData(null);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,41 +124,8 @@ export function usePostDetail(
 
       if (!resumePromptShownRef.current[id]) {
         resumePromptShownRef.current[id] = true;
-        const ttRaw = myDetail.templateType;
-        const tt = String(ttRaw ?? "").toUpperCase();
-
-        const ok = window.confirm(
-          tt === "FREE_FORM" || tt === "FREEFORM"
-            ? "이 문서는 자유형식 글 작성 중이에요. 이어서 작성할까요?"
-            : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?"
-        );
-
         if (cancelled) return;
-        if (ok) {
-          const baseState =
-            tt === "FREE_FORM" || tt === "FREEFORM"
-              ? buildFreeformPrefill(myDetail)
-              : buildTemplatePrefill(myDetail);
-          const editorPath =
-            tt === "FREE_FORM" || tt === "FREEFORM"
-              ? PATH.FREEFORM_WRITING
-              : PATH.TEMP_WRITING;
-          if (cancelled) return;
-          navigate(editorPath, {
-            replace: true,
-            state: {
-              ...baseState,
-              postId: id,
-              mode: "edit",
-              from: "community-detail",
-              projectId: myDetail.projectId ?? undefined,
-              savePrefill:
-                baseState.savePrefill != null
-                  ? { ...baseState.savePrefill }
-                  : undefined,
-            },
-          });
-        }
+        setResumePromptData({ myDetail, postId: id });
       }
     };
 
@@ -311,5 +300,9 @@ export function usePostDetail(
     likeCounts,
     setIsLiked,
     setLikeCounts,
+    resumePromptOpen: resumePromptData != null,
+    resumePromptData,
+    confirmResumeEdit,
+    cancelResumePrompt,
   };
 }

--- a/src/pages/Community/hooks/usePostLike.ts
+++ b/src/pages/Community/hooks/usePostLike.ts
@@ -1,0 +1,83 @@
+import { useRef, useState } from "react";
+import { likeCommunityPost } from "@/api/community.api";
+
+export interface UsePostLikeOptions {
+  effectiveId: number;
+  isCommunitySource: boolean;
+  isLiked: boolean;
+  likeCounts: number;
+  setIsLiked: React.Dispatch<React.SetStateAction<boolean>>;
+  setLikeCounts: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export interface UsePostLikeReturn {
+  isLiking: boolean;
+  handleToggleLike: () => Promise<void>;
+}
+
+/**
+ * 커뮤니티 포스트 좋아요 토글 로직
+ */
+export function usePostLike(options: UsePostLikeOptions): UsePostLikeReturn {
+  const {
+    effectiveId,
+    isCommunitySource,
+    isLiked,
+    likeCounts,
+    setIsLiked,
+    setLikeCounts,
+  } = options;
+
+  const [isLiking, setIsLiking] = useState(false);
+  const likeLockRef = useRef(false);
+
+  const handleToggleLike = async () => {
+    if (!Number.isFinite(effectiveId)) return;
+    if (!isCommunitySource) {
+      alert("작성 중/비공개 문서는 좋아요를 사용할 수 없어요.");
+      return;
+    }
+    if (likeLockRef.current) return;
+    likeLockRef.current = true;
+    setIsLiking(true);
+
+    const pid = effectiveId;
+    const wasLiked = isLiked;
+    const prevCount = likeCounts;
+
+    if (wasLiked) {
+      setIsLiked(false);
+      setLikeCounts(Math.max(0, prevCount - 1));
+      try {
+        await likeCommunityPost(pid);
+      } catch {
+        setIsLiked(true);
+        setLikeCounts(prevCount);
+      } finally {
+        likeLockRef.current = false;
+        setIsLiking(false);
+      }
+    } else {
+      setIsLiked(true);
+      setLikeCounts(prevCount + 1);
+      try {
+        const res = await likeCommunityPost(pid);
+        setLikeCounts(res?.likeCount ?? prevCount + 1);
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number }; status?: number })?.response?.status ?? (err as { status?: number })?.status;
+        if (status === 409) {
+          setIsLiked(true);
+          setLikeCounts(prevCount);
+        } else {
+          setIsLiked(false);
+          setLikeCounts(prevCount);
+        }
+      } finally {
+        likeLockRef.current = false;
+        setIsLiking(false);
+      }
+    }
+  };
+
+  return { isLiking, handleToggleLike };
+}

--- a/src/pages/Community/hooks/usePostLike.ts
+++ b/src/pages/Community/hooks/usePostLike.ts
@@ -64,10 +64,21 @@ export function usePostLike(options: UsePostLikeOptions): UsePostLikeReturn {
         const res = await likeCommunityPost(pid);
         setLikeCounts(res?.likeCount ?? prevCount + 1);
       } catch (err: unknown) {
-        const status = (err as { response?: { status?: number }; status?: number })?.response?.status ?? (err as { status?: number })?.status;
+        const axiosErr = err as {
+          response?: { status?: number; data?: { likeCount?: number } };
+          status?: number;
+        };
+        const status =
+          axiosErr?.response?.status ?? axiosErr?.status;
+        const likeCountFromBody = axiosErr?.response?.data?.likeCount;
+
         if (status === 409) {
           setIsLiked(true);
-          setLikeCounts(prevCount);
+          const count =
+            typeof likeCountFromBody === "number" && Number.isFinite(likeCountFromBody)
+              ? likeCountFromBody
+              : prevCount + 1;
+          setLikeCounts(count);
         } else {
           setIsLiked(false);
           setLikeCounts(prevCount);

--- a/src/pages/Community/hooks/usePostMenu.ts
+++ b/src/pages/Community/hooks/usePostMenu.ts
@@ -41,7 +41,7 @@ export function usePostMenu(options: UsePostMenuOptions): UsePostMenuReturn {
   const [reportTarget, setReportTarget] = useState<ReportTarget>(null);
 
   const closeMenu = useCallback(() => setShowMenu(false), []);
-  const menuRef = useClickOutside<HTMLDivElement>(() => setShowMenu(false));
+  const menuRef = useClickOutside<HTMLDivElement>(closeMenu);
 
   const handleDeletePost = useCallback(async () => {
     if (!Number.isFinite(effectiveId)) return;

--- a/src/pages/Community/hooks/usePostMenu.ts
+++ b/src/pages/Community/hooks/usePostMenu.ts
@@ -1,0 +1,88 @@
+import { useCallback, useState } from "react";
+import type { NavigateFunction } from "react-router-dom";
+import useClickOutside from "@/hooks/useClickOutside";
+import { hardDeletePost } from "@/api/post.api";
+import { PATH } from "@/shared/config/paths";
+import type { DetailFromSource } from "@/hooks/useDetailContext";
+
+export type ReportTarget =
+  | { type: "post"; postId: number }
+  | { type: "comment"; commentId: string }
+  | null;
+
+export interface UsePostMenuOptions {
+  effectiveId: number;
+  from: DetailFromSource;
+  navigate: NavigateFunction;
+}
+
+export interface UsePostMenuReturn {
+  showMenu: boolean;
+  setShowMenu: React.Dispatch<React.SetStateAction<boolean>>;
+  deleting: boolean;
+  reportModalOpen: boolean;
+  setReportModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  reportTarget: ReportTarget;
+  setReportTarget: React.Dispatch<React.SetStateAction<ReportTarget>>;
+  closeMenu: () => void;
+  menuRef: React.RefObject<HTMLDivElement | null>;
+  handleDeletePost: () => Promise<void>;
+}
+
+/**
+ * 케밥 메뉴·삭제·신고 모달 상태 및 포스트 삭제 핸들러
+ */
+export function usePostMenu(options: UsePostMenuOptions): UsePostMenuReturn {
+  const { effectiveId, from, navigate } = options;
+
+  const [showMenu, setShowMenu] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [reportModalOpen, setReportModalOpen] = useState(false);
+  const [reportTarget, setReportTarget] = useState<ReportTarget>(null);
+
+  const closeMenu = useCallback(() => setShowMenu(false), []);
+  const menuRef = useClickOutside<HTMLDivElement>(() => setShowMenu(false));
+
+  const handleDeletePost = useCallback(async () => {
+    if (!Number.isFinite(effectiveId)) return;
+    if (
+      !window.confirm(
+        "이 문서를 영구적으로 삭제할까요? 삭제 후에는 복구할 수 없습니다."
+      )
+    )
+      return;
+
+    try {
+      setDeleting(true);
+      await hardDeletePost(effectiveId);
+      alert("문서가 영구 삭제되었습니다.");
+      if (from === "community") {
+        navigate(PATH.COMMUNITY, { replace: true });
+      } else {
+        navigate(-1);
+      }
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response
+          ?.data?.message ??
+        "삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+      alert(msg);
+    } finally {
+      setDeleting(false);
+      setShowMenu(false);
+    }
+  }, [effectiveId, from, navigate]);
+
+  return {
+    showMenu,
+    setShowMenu,
+    deleting,
+    reportModalOpen,
+    setReportModalOpen,
+    reportTarget,
+    setReportTarget,
+    closeMenu,
+    menuRef,
+    handleDeletePost,
+  };
+}

--- a/src/pages/Community/hooks/usePostNavigation.ts
+++ b/src/pages/Community/hooks/usePostNavigation.ts
@@ -136,6 +136,7 @@ export function usePostNavigation(
   }, [post, navigate]);
 
   const handleFollow = useCallback(async () => {
+    if (!post || post.authorId == null) return;
     setPost((prev) =>
       prev
         ? { ...prev, isFollowed: true, authorFollowers: (prev.authorFollowers ?? 0) + 1 }
@@ -157,6 +158,7 @@ export function usePostNavigation(
   }, [post?.authorId, setPost]);
 
   const handleUnfollow = useCallback(async () => {
+    if (!post || post.authorId == null) return;
     setPost((prev) =>
       prev
         ? { ...prev, isFollowed: false, authorFollowers: Math.max(0, (prev.authorFollowers ?? 1) - 1) }

--- a/src/pages/Community/hooks/usePostNavigation.ts
+++ b/src/pages/Community/hooks/usePostNavigation.ts
@@ -113,7 +113,10 @@ export function usePostNavigation(
     navigatingRef.current = true;
     closeMenu();
     try {
-      if (!Number.isFinite(effectiveId)) return;
+      if (!Number.isFinite(effectiveId)) {
+        navigatingRef.current = false;
+        return;
+      }
       const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
       const { path, state } = buildEditorNavigationState(myDetail, effectiveId);
       queueMicrotask(() => {

--- a/src/pages/Community/hooks/usePostNavigation.ts
+++ b/src/pages/Community/hooks/usePostNavigation.ts
@@ -2,11 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { getPostDetail } from "@/api/post.api";
 import { postFollow, postUnfollow } from "@/api/user.api";
+import type { ViewPostResponse } from "@/models/post.model";
 import { PATH } from "@/shared/config/paths";
-import {
-  buildFreeformPrefill,
-  buildTemplatePrefill,
-} from "@/shared/utils/prefillBuilder";
+import { buildEditorNavigationState } from "@/shared/utils/prefillBuilder";
 import type { CommunityPostDetailProps } from "@/pages/Community/types";
 
 const DEFAULT_HEADER_OFFSET = 100;
@@ -116,18 +114,10 @@ export function usePostNavigation(
     closeMenu();
     try {
       if (!Number.isFinite(effectiveId)) return;
-      const myDetail = await getPostDetail(effectiveId);
-      const tt = String((myDetail as { templateType?: string })?.templateType ?? "").toUpperCase();
-      const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
-      const editorPath = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
-      const prefill = isFreeform
-        ? buildFreeformPrefill(myDetail)
-        : buildTemplatePrefill(myDetail);
+      const myDetail: ViewPostResponse = await getPostDetail(effectiveId);
+      const { path, state } = buildEditorNavigationState(myDetail, effectiveId);
       queueMicrotask(() => {
-        navigate(editorPath, {
-          replace: true,
-          state: { ...prefill, postId: effectiveId, mode: "edit", from: "community-detail" },
-        });
+        navigate(path, { replace: true, state });
       });
     } catch {
       navigatingRef.current = false;

--- a/src/pages/Community/hooks/usePostNavigation.ts
+++ b/src/pages/Community/hooks/usePostNavigation.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { NavigateFunction } from "react-router-dom";
+import { getPostDetail } from "@/api/post.api";
+import { postFollow, postUnfollow } from "@/api/user.api";
+import { PATH } from "@/shared/config/paths";
+import {
+  buildFreeformPrefill,
+  buildTemplatePrefill,
+} from "@/shared/utils/prefillBuilder";
+import type { CommunityPostDetailProps } from "@/pages/Community/types";
+
+const DEFAULT_HEADER_OFFSET = 100;
+
+export interface UsePostNavigationOptions {
+  effectiveId: number;
+  post: CommunityPostDetailProps | null;
+  setPost: React.Dispatch<React.SetStateAction<CommunityPostDetailProps | null>>;
+  navigate: NavigateFunction;
+  closeMenu: () => void;
+  viewerId: number | null;
+  headerOffset?: number;
+}
+
+export interface UsePostNavigationReturn {
+  contentColRef: React.RefObject<HTMLDivElement | null>;
+  sectionRefs: React.MutableRefObject<Array<HTMLDivElement | null>>;
+  currentSection: number;
+  asideOffset: number;
+  scrollToSection: (idx: number) => void;
+  goEditWithPrefill: () => Promise<void>;
+  handleProfileClick: () => void;
+  handleFollow: () => Promise<void>;
+  handleUnfollow: () => Promise<void>;
+  goBack: () => void;
+  goCommunity: () => void;
+  goHome: () => void;
+  goLogin: () => void;
+  goMyPage: () => void;
+}
+
+/**
+ * 목차 스크롤, 수정 이동, 프로필/팔로우, CTA(이전/홈/마이페이지 등) 네비게이션 로직
+ */
+export function usePostNavigation(
+  options: UsePostNavigationOptions
+): UsePostNavigationReturn {
+  const {
+    effectiveId,
+    post,
+    setPost,
+    navigate,
+    closeMenu,
+    viewerId,
+    headerOffset = DEFAULT_HEADER_OFFSET,
+  } = options;
+
+  const contentColRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const [currentSection, setCurrentSection] = useState(0);
+  const [asideOffset, setAsideOffset] = useState(0);
+  const navigatingRef = useRef(false);
+
+  useEffect(() => {
+    const updateAsideOffset = () => {
+      const first = sectionRefs.current[0];
+      const col = contentColRef.current;
+      if (!first || !col) {
+        setAsideOffset(0);
+        return;
+      }
+      const firstTop = first.getBoundingClientRect().top + window.scrollY;
+      const colTop = col.getBoundingClientRect().top + window.scrollY;
+      setAsideOffset(Math.max(0, Math.round(firstTop - colTop)));
+    };
+    requestAnimationFrame(updateAsideOffset);
+    const onResize = () => updateAsideOffset();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("load", onResize);
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined" && contentColRef.current) {
+      ro = new ResizeObserver(updateAsideOffset);
+      ro.observe(contentColRef.current);
+    }
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("load", onResize);
+      ro?.disconnect();
+    };
+  }, [post]);
+
+  useEffect(() => {
+    const updateCurrentSection = () => {
+      const y = window.scrollY + headerOffset + 1;
+      let cur = 0;
+      sectionRefs.current.forEach((ref, idx) => {
+        if (!ref) return;
+        const top = ref.getBoundingClientRect().top + window.scrollY;
+        if (y >= top) cur = idx;
+      });
+      setCurrentSection(cur);
+    };
+    window.addEventListener("scroll", updateCurrentSection, { passive: true });
+    updateCurrentSection();
+    return () => window.removeEventListener("scroll", updateCurrentSection);
+  }, [headerOffset]);
+
+  const scrollToSection = useCallback((idx: number) => {
+    const target = sectionRefs.current[idx];
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  const goEditWithPrefill = useCallback(async () => {
+    if (navigatingRef.current) return;
+    navigatingRef.current = true;
+    closeMenu();
+    try {
+      if (!Number.isFinite(effectiveId)) return;
+      const myDetail = await getPostDetail(effectiveId);
+      const tt = String((myDetail as { templateType?: string })?.templateType ?? "").toUpperCase();
+      const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
+      const editorPath = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
+      const prefill = isFreeform
+        ? buildFreeformPrefill(myDetail)
+        : buildTemplatePrefill(myDetail);
+      queueMicrotask(() => {
+        navigate(editorPath, {
+          replace: true,
+          state: { ...prefill, postId: effectiveId, mode: "edit", from: "community-detail" },
+        });
+      });
+    } catch {
+      navigatingRef.current = false;
+      alert(
+        "수정 화면으로 이동하기 위한 데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요."
+      );
+    }
+  }, [effectiveId, navigate, closeMenu]);
+
+  const handleProfileClick = useCallback(() => {
+    if (!post || post.authorId == null) return;
+    navigate(PATH.MYPAGE_ID(String(post.authorId)));
+  }, [post, navigate]);
+
+  const handleFollow = useCallback(async () => {
+    setPost((prev) =>
+      prev
+        ? { ...prev, isFollowed: true, authorFollowers: (prev.authorFollowers ?? 0) + 1 }
+        : prev
+    );
+    try {
+      await postFollow(Number(post?.authorId));
+    } catch {
+      setPost((prev) =>
+        prev
+          ? {
+              ...prev,
+              isFollowed: false,
+              authorFollowers: Math.max(0, (prev.authorFollowers ?? 1) - 1),
+            }
+          : prev
+      );
+    }
+  }, [post?.authorId, setPost]);
+
+  const handleUnfollow = useCallback(async () => {
+    setPost((prev) =>
+      prev
+        ? { ...prev, isFollowed: false, authorFollowers: Math.max(0, (prev.authorFollowers ?? 1) - 1) }
+        : prev
+    );
+    try {
+      await postUnfollow(Number(post?.authorId));
+    } catch {
+      setPost((prev) =>
+        prev
+          ? {
+              ...prev,
+              isFollowed: true,
+              authorFollowers: (prev.authorFollowers ?? 0) + 1,
+            }
+          : prev
+      );
+    }
+  }, [post?.authorId, setPost]);
+
+  const goBack = useCallback(() => {
+    if (window.history.length > 1) navigate(-1);
+    else navigate(PATH.COMMUNITY, { replace: true });
+  }, [navigate]);
+
+  const goCommunity = useCallback(() => navigate(PATH.COMMUNITY, { replace: true }), [navigate]);
+  const goHome = useCallback(() => navigate(PATH.HOME, { replace: true }), [navigate]);
+  const goLogin = useCallback(() => {
+    const sp = new URLSearchParams();
+    sp.set("next", window.location.pathname + window.location.search);
+    navigate(`${PATH.ROOT}?${sp.toString()}`, { replace: true });
+  }, [navigate]);
+  const goMyPage = useCallback(() => {
+    if (viewerId != null) navigate(PATH.MYPAGE_BASE);
+    else goLogin();
+  }, [viewerId, navigate, goLogin]);
+
+  return {
+    contentColRef,
+    sectionRefs,
+    currentSection,
+    asideOffset,
+    scrollToSection,
+    goEditWithPrefill,
+    handleProfileClick,
+    handleFollow,
+    handleUnfollow,
+    goBack,
+    goCommunity,
+    goHome,
+    goLogin,
+    goMyPage,
+  };
+}

--- a/src/pages/Community/types.ts
+++ b/src/pages/Community/types.ts
@@ -1,0 +1,24 @@
+import type { PostCommentProps } from "@/entities/trouble/ui/PostComment";
+
+export interface CommunityPostDetailProps {
+  errorType: string;
+  title: string;
+  tags: string[];
+  date: string;
+  isMine: boolean;
+  authorId?: number;
+  authorProfile?: string;
+  authorName: string;
+  authorFollowers: number;
+  authorBio: string;
+  isFollowed: boolean;
+  importance: number;
+  questions: string[];
+  contents: (string | { type: "image"; src: string; alt?: string })[][];
+  isLiked: boolean;
+  likeCounts: number;
+  commentCounts: number;
+  comments: PostCommentProps[];
+  checklistError?: number[];
+  checklistReason?: number[];
+}

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -37,6 +37,11 @@ import {
   toPostComment,
   toPostComments,
 } from "@/entities/trouble/mappers/communityComment.mapper";
+import { parseStar } from "@/shared/utils/starParser";
+import {
+  buildFreeformPrefill,
+  buildTemplatePrefill,
+} from "@/shared/utils/prefillBuilder";
 
 export default function CombinedDetailPage() {
   const { postId, summaryId } = useParams<{
@@ -136,109 +141,6 @@ export default function CombinedDetailPage() {
         : "복사에 실패했어요. 주소창에서 복사해주세요."
     );
   };
-
-  const parseStar = (raw: unknown) => {
-    if (typeof raw === "number") return raw;
-    if (typeof raw !== "string") return 0;
-    const k = raw.toUpperCase();
-    const map: Record<string, number> = {
-      ONE_STAR: 1,
-      TWO_STARS: 2,
-      THREE_STARS: 3,
-      FOUR_STARS: 4,
-      FIVE_STARS: 5,
-      ONE: 1,
-      TWO: 2,
-      THREE: 3,
-      FOUR: 4,
-      FIVE: 5,
-      NONE: 0,
-    };
-    return map[k] ?? 0;
-  };
-
-  type DetailContentItem = {
-    id?: number;
-    subTitle?: string | null;
-    body?: string | null;
-    sequence?: number;
-  };
-
-  function buildFreeformPrefill(detail: any) {
-    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
-      ? detail.contents
-      : [];
-
-    const blocks = contents
-      .slice()
-      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
-      .map((c, i) => ({
-        id: c.id ?? i,
-        title: c.subTitle ?? "",
-        content: c.body ?? "",
-        isSaved: false,
-      }));
-
-    return {
-      editorType: "FREEFORM" as const,
-      title: detail?.title ?? "",
-      tags: detail?.postTags ?? [],
-      errorType: detail?.errorTag ?? null,
-      blocks,
-      savePrefill: {
-        importance: parseStar(detail?.starRating),
-        description: detail?.introduction ?? "",
-        visibility: detail?.isVisible ? "public" : "private",
-        projectId: detail?.projectId ?? null,
-        projectName: undefined,
-        thumbnail: detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null,
-      },
-      projectId: detail?.projectId ?? undefined,
-    };
-  }
-
-  function buildTemplatePrefill(detail: any) {
-    const contents: DetailContentItem[] = Array.isArray(detail?.contents)
-      ? detail.contents
-      : [];
-
-    const blocks = contents
-      .slice()
-      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
-      .map((c, i) => ({
-        id: c.id ?? i,
-        content: c.body ?? "",
-        checklist: [],
-        checklistItems: [],
-        checklistTitle: c.subTitle ? `${c.subTitle} ` : "",
-        question: c.subTitle ?? `질문 ${i + 1}`,
-        isSaved: false,
-      }));
-
-    return {
-      editorType: "TEMPLATE" as const,
-      title: detail?.title ?? "",
-      tags: detail?.postTags ?? [],
-      errorType: detail?.errorTag ?? null,
-      blocks,
-      savePrefill: {
-        importance: parseStar(detail?.starRating),
-        description: detail?.introduction ?? "",
-        visibility: detail?.isVisible ? "public" : "private",
-        projectId: detail?.projectId ?? null,
-        projectName: undefined,
-        thumbnail: detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null,
-      },
-      projectId: detail?.projectId ?? undefined,
-      // TempWritePage가 그대로 받아 쓰는 키
-      checklistError: Array.isArray(detail?.checklistError)
-        ? detail.checklistError
-        : [],
-      checklistReason: Array.isArray(detail?.checklistReason)
-        ? detail.checklistReason
-        : [],
-    };
-  }
 
   const SUMMARY_TYPE_LABELS: Record<string, string> = {
     RESUME: "자기소개서",

--- a/src/shared/ui/EmptyState/EmptyState.tsx
+++ b/src/shared/ui/EmptyState/EmptyState.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+export interface EmptyStateProps {
+  /** 제목 또는 메인 문구 */
+  title?: ReactNode;
+  /** 부가 설명 */
+  description?: ReactNode;
+  /** 액션 버튼 등 (선택) */
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * 목록/검색 결과가 없을 때 등 빈 상태를 표시하는 공통 컴포넌트
+ */
+export function EmptyState({
+  title = "내용이 없어요",
+  description,
+  action,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-4 py-12 px-4 text-center ${className}`}
+    >
+      {title != null && (
+        <p className="text-body-16-regular text-gray-600">{title}</p>
+      )}
+      {description != null && (
+        <p className="text-body-14-regular text-gray-500">{description}</p>
+      )}
+      {action != null && <div className="mt-2">{action}</div>}
+    </div>
+  );
+}

--- a/src/shared/ui/EmptyState/index.ts
+++ b/src/shared/ui/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export { EmptyState, type EmptyStateProps } from "./EmptyState";

--- a/src/shared/ui/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** 에러 시 대체 UI (미제공 시 기본 fallback) */
+  fallback?: ReactNode;
+  /** 에러 발생 시 콜백 (로깅 등) */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * 하위 트리에서 발생한 에러를 잡아 fallback을 렌더링하는 에러 바운더리
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback) return this.props.fallback;
+      return (
+        <div
+          className="flex flex-col items-center justify-center gap-4 p-8 text-center"
+          role="alert"
+        >
+          <p className="text-body-16-regular text-red-600">
+            일시적인 오류가 발생했어요.
+          </p>
+          <p className="text-body-14-regular text-gray-500">
+            {this.state.error.message}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/shared/ui/ErrorBoundary/index.ts
+++ b/src/shared/ui/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary, type ErrorBoundaryProps } from "./ErrorBoundary";

--- a/src/shared/ui/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/shared/ui/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+export interface LoadingSpinnerProps {
+  /** 스피너 크기: sm | default | lg */
+  size?: "sm" | "default" | "lg";
+  /** 스피너 아래 텍스트 */
+  message?: ReactNode;
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "w-8 h-8 border-2",
+  default: "w-12 h-12 border-4",
+  lg: "w-16 h-16 border-4",
+};
+
+/**
+ * 공통 로딩 스피너
+ */
+export function LoadingSpinner({
+  size = "default",
+  message,
+  className = "",
+}: LoadingSpinnerProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-4 ${className}`}
+      role="status"
+      aria-label={message ? undefined : "로딩 중"}
+    >
+      <div
+        className={`${sizeClasses[size]} border-primary border-t-transparent rounded-full animate-spin`}
+      />
+      {message != null && (
+        <p className="text-body-16-regular text-gray-600">{message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/LoadingSpinner/index.ts
+++ b/src/shared/ui/LoadingSpinner/index.ts
@@ -1,0 +1,1 @@
+export { LoadingSpinner, type LoadingSpinnerProps } from "./LoadingSpinner";

--- a/src/shared/utils/apiErrorParser.ts
+++ b/src/shared/utils/apiErrorParser.ts
@@ -1,0 +1,22 @@
+export interface ParsedApiError {
+  status?: number;
+  message: string;
+}
+
+/**
+ * API 에러 응답을 { status, message } 형태로 파싱
+ */
+export function parseApiError(err: unknown): ParsedApiError {
+  const anyErr = err as {
+    response?: { status?: number; data?: { error?: { message?: string }; message?: string } };
+    message?: string;
+    status?: number;
+  };
+  const status = anyErr?.response?.status;
+  const message =
+    anyErr?.response?.data?.error?.message ??
+    anyErr?.response?.data?.message ??
+    anyErr?.message ??
+    "요청 처리 중 오류가 발생했어요.";
+  return { status, message };
+}

--- a/src/shared/utils/prefillBuilder.ts
+++ b/src/shared/utils/prefillBuilder.ts
@@ -1,0 +1,152 @@
+import { parseStar } from "./starParser";
+
+export interface DetailContentItem {
+  id?: number;
+  subTitle?: string | null;
+  body?: string | null;
+  sequence?: number;
+}
+
+/** 상세 API 응답과 호환되는 객체 (필드 선택적) */
+export interface PostDetailLike {
+  title?: string;
+  postTags?: string[];
+  errorTag?: string | null;
+  contents?: DetailContentItem[];
+  starRating?: unknown;
+  introduction?: string;
+  isVisible?: boolean;
+  projectId?: number | null;
+  thumbnailUrl?: string | null;
+  thumbnailImageUrl?: string | null;
+  checklistError?: number[];
+  checklistReason?: number[];
+}
+
+export interface FreeformPrefillState {
+  editorType: "FREEFORM";
+  title: string;
+  tags: string[];
+  errorType: string | null;
+  blocks: Array<{
+    id: number;
+    title: string;
+    content: string;
+    isSaved: boolean;
+  }>;
+  savePrefill: {
+    importance: number;
+    description: string;
+    visibility: "public" | "private";
+    projectId: number | null;
+    projectName: undefined;
+    thumbnail: string | null;
+  };
+  projectId?: number;
+}
+
+export interface TemplatePrefillState {
+  editorType: "TEMPLATE";
+  title: string;
+  tags: string[];
+  errorType: string | null;
+  blocks: Array<{
+    id: number;
+    content: string;
+    checklist: string[];
+    checklistItems: unknown[];
+    checklistTitle: string;
+    question: string;
+    isSaved: boolean;
+  }>;
+  savePrefill: {
+    importance: number;
+    description: string;
+    visibility: "public" | "private";
+    projectId: number | null;
+    projectName: undefined;
+    thumbnail: string | null;
+  };
+  projectId?: number;
+  checklistError: number[];
+  checklistReason: number[];
+}
+
+/**
+ * 상세 응답 → 자유형식(FREEFORM) 에디터 프리필 state
+ */
+export function buildFreeformPrefill(detail: PostDetailLike | null | undefined): FreeformPrefillState {
+  const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+    ? detail.contents
+    : [];
+
+  const blocks = contents
+    .slice()
+    .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+    .map((c, i) => ({
+      id: c.id ?? i,
+      title: c.subTitle ?? "",
+      content: c.body ?? "",
+      isSaved: false,
+    }));
+
+  const thumb = detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null;
+  return {
+    editorType: "FREEFORM",
+    title: detail?.title ?? "",
+    tags: detail?.postTags ?? [],
+    errorType: detail?.errorTag ?? null,
+    blocks,
+    savePrefill: {
+      importance: parseStar(detail?.starRating),
+      description: detail?.introduction ?? "",
+      visibility: detail?.isVisible ? "public" : "private",
+      projectId: detail?.projectId ?? null,
+      projectName: undefined,
+      thumbnail: thumb,
+    },
+    projectId: detail?.projectId ?? undefined,
+  };
+}
+
+/**
+ * 상세 응답 → 템플릿(TEMPLATE) 에디터 프리필 state
+ */
+export function buildTemplatePrefill(detail: PostDetailLike | null | undefined): TemplatePrefillState {
+  const contents: DetailContentItem[] = Array.isArray(detail?.contents)
+    ? detail.contents
+    : [];
+
+  const blocks = contents
+    .slice()
+    .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+    .map((c, i) => ({
+      id: c.id ?? i,
+      content: c.body ?? "",
+      checklist: [],
+      checklistItems: [],
+      checklistTitle: c.subTitle ? `${c.subTitle} 체크리스트` : "",
+      question: c.subTitle ?? `질문 ${i + 1}`,
+      isSaved: false,
+    }));
+
+  const thumb = detail?.thumbnailUrl ?? detail?.thumbnailImageUrl ?? null;
+  return {
+    editorType: "TEMPLATE",
+    title: detail?.title ?? "",
+    tags: detail?.postTags ?? [],
+    errorType: detail?.errorTag ?? null,
+    blocks,
+    savePrefill: {
+      importance: parseStar(detail?.starRating),
+      description: detail?.introduction ?? "",
+      visibility: detail?.isVisible ? "public" : "private",
+      projectId: detail?.projectId ?? null,
+      projectName: undefined,
+      thumbnail: thumb,
+    },
+    projectId: detail?.projectId ?? undefined,
+    checklistError: Array.isArray(detail?.checklistError) ? detail.checklistError : [],
+    checklistReason: Array.isArray(detail?.checklistReason) ? detail.checklistReason : [],
+  };
+}

--- a/src/shared/utils/prefillBuilder.ts
+++ b/src/shared/utils/prefillBuilder.ts
@@ -1,3 +1,5 @@
+import type { ViewPostResponse } from "@/models/post.model";
+import { PATH } from "@/shared/config/paths";
 import { parseStar } from "./starParser";
 
 export interface DetailContentItem {
@@ -159,4 +161,35 @@ export function buildTemplatePrefill(detail: PostDetailLike | null | undefined):
         ? detail.checkListReason
         : [],
   };
+}
+
+/** 상세 응답 → 에디터 경로 및 navigate state (goEditWithPrefill, loadMineDraft 공통) */
+export function buildEditorNavigationState(
+  myDetail: ViewPostResponse,
+  postId: number
+): { path: string; state: object } {
+  const tt = String(myDetail.templateType ?? "").toUpperCase();
+  const isFreeform = tt === "FREE_FORM" || tt === "FREEFORM";
+  const path = isFreeform ? PATH.FREEFORM_WRITING : PATH.TEMP_WRITING;
+  const prefill = isFreeform
+    ? buildFreeformPrefill(myDetail)
+    : buildTemplatePrefill(myDetail);
+  const state = {
+    ...prefill,
+    postId,
+    mode: "edit",
+    from: "community-detail",
+    projectId: myDetail.projectId ?? undefined,
+    savePrefill:
+      prefill.savePrefill != null ? { ...prefill.savePrefill } : undefined,
+  };
+  return { path, state };
+}
+
+/** draft 이어쓰기 안내 메시지 (모달용) */
+export function getResumeDraftMessage(templateType?: string): string {
+  const tt = String(templateType ?? "").toUpperCase();
+  return tt === "FREE_FORM" || tt === "FREEFORM"
+    ? "이 문서는 자유형식 글 작성 중이에요. 이어서 작성할까요?"
+    : "이 문서는 가이드 템플릿 글 작성 중이에요. 이어서 작성할까요?";
 }

--- a/src/shared/utils/prefillBuilder.ts
+++ b/src/shared/utils/prefillBuilder.ts
@@ -7,7 +7,7 @@ export interface DetailContentItem {
   sequence?: number;
 }
 
-/** 상세 API 응답과 호환되는 객체 (필드 선택적) */
+/** 상세 API 응답과 호환되는 객체 (필드 선택적, checkListError/Reason은 ViewPostResponse 별칭) */
 export interface PostDetailLike {
   title?: string;
   postTags?: string[];
@@ -21,6 +21,8 @@ export interface PostDetailLike {
   thumbnailImageUrl?: string | null;
   checklistError?: number[];
   checklistReason?: number[];
+  checkListError?: number[];
+  checkListReason?: number[];
 }
 
 export interface FreeformPrefillState {
@@ -146,7 +148,15 @@ export function buildTemplatePrefill(detail: PostDetailLike | null | undefined):
       thumbnail: thumb,
     },
     projectId: detail?.projectId ?? undefined,
-    checklistError: Array.isArray(detail?.checklistError) ? detail.checklistError : [],
-    checklistReason: Array.isArray(detail?.checklistReason) ? detail.checklistReason : [],
+    checklistError: Array.isArray(detail?.checklistError)
+      ? detail.checklistError
+      : Array.isArray(detail?.checkListError)
+        ? detail.checkListError
+        : [],
+    checklistReason: Array.isArray(detail?.checklistReason)
+      ? detail.checklistReason
+      : Array.isArray(detail?.checkListReason)
+        ? detail.checkListReason
+        : [],
   };
 }

--- a/src/shared/utils/starParser.ts
+++ b/src/shared/utils/starParser.ts
@@ -1,0 +1,23 @@
+/**
+ * 별점 enum/문자 → 숫자 변환
+ * API 응답(ONE_STAR, TWO_STARS 등) 및 단축 문자열(ONE, TWO 등) 지원
+ */
+export function parseStar(raw: unknown): number {
+  if (typeof raw === "number") return raw;
+  if (typeof raw !== "string") return 0;
+  const k = raw.toUpperCase();
+  const map: Record<string, number> = {
+    ONE_STAR: 1,
+    TWO_STARS: 2,
+    THREE_STARS: 3,
+    FOUR_STARS: 4,
+    FIVE_STARS: 5,
+    ONE: 1,
+    TWO: 2,
+    THREE: 3,
+    FOUR: 4,
+    FIVE: 5,
+    NONE: 0,
+  };
+  return map[k] ?? 0;
+}


### PR DESCRIPTION
## 🔥 Issues

- #188 

## ✅ What to do

- [x] 공통 유틸/훅 추출 및 공통 UI 추가
- [x] CommunityPostDetail 내부 훅, 컴포넌트 분리

## 📄 Description

### 공통 유틸·훅 

- **`shared/utils/starParser.ts`**: `parseStar(raw)` — 별점 enum/문자 → 숫자
- **`shared/utils/prefillBuilder.ts`**: `buildFreeformPrefill`, `buildTemplatePrefill` — 상세 응답 → 에디터 프리필 state
- **`shared/utils/apiErrorParser.ts`**: `parseApiError(err)` — API 에러 → `{ status?, message }`
- **`hooks/useDetailContext.ts`**: 상세 페이지용 location/쿼리 출처·소유자·목록 힌트

### 공통 유틸·훅 반영한 페이지

- **CommunityPostDetail**: 위 유틸·훅 import로 인라인 정의 제거, `useViewerId` 제거(useDetailContext로 대체)
- **CombinedDetailPage**: `parseStar`, `buildFreeformPrefill`, `buildTemplatePrefill` 제거 후 공통 유틸 import

### 공통 UI 추가

- **`shared/ui/LoadingSpinner`**: 로딩 스피너 (size, message)
- **`shared/ui/ErrorBoundary`**: 에러 바운더리 (fallback, onError)
- **`shared/ui/EmptyState`**: 빈 상태 (title, description, action)

### CommunityPostDetail 내부 훅/UI 컴포넌트 분리

- `pages/Community/types.ts`, `hooks/usePostDetail.ts` 추출
- `hooks/usePostComments.ts` 추출 (댓글 로드·작성·수정·삭제)
- `hooks/usePostLike.ts` 추출 (좋아요 토글)
- `hooks/usePostMenu.ts` 추출 (케밥 메뉴·삭제·신고)
- `hooks/usePostNavigation.ts` 추출 (목차/수정/팔로우/CTA)
- `components/PostDetailHeader.tsx` 분리 (상단: 케밥/제목/태그/작성자)
- `components/PostDetailContent.tsx` 분리 (본문/작성자 카드/좋아요·공유/댓글 입력)
- `components/PostDetailSidebar.tsx` 분리 (목차 TOC)
- `components/PostDetailComments.tsx` 분리 (댓글 목록/더 보기)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 커뮤니티 게시물 상세 페이지 기능 확대: 댓글 관리, 좋아요 토글, 메뉴 작업 개선
  * 공유 UI 컴포넌트 추가: 로딩 스피너, 빈 상태 화면, 에러 바운더리
  * API 에러 처리 및 별점 파싱 유틸리티 추가

* **리팩토링**
  * 게시물 상세 페이지를 모듈식 컴포넌트와 훅으로 재구성하여 유지보수성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->