### PR TITLE
[REFACTOR] TempWrite / FreeForm 작성 페이지 리팩토링

### DIFF
--- a/src/entities/trouble/ui/CardHeaderRight.tsx
+++ b/src/entities/trouble/ui/CardHeaderRight.tsx
@@ -74,7 +74,11 @@ export default function CardHeaderRight({
   }
 
   options.push({
-    label: deleting ? "삭제 중..." : "삭제",
+    label: deleting
+      ? "삭제 중..."
+      : hasSummary
+        ? "삭제"
+        : "삭제(원본 삭제)",
     onClick: () => {
       if (!deleting) onDelete?.();
     },

--- a/src/entities/trouble/ui/TroubleShootingCard.tsx
+++ b/src/entities/trouble/ui/TroubleShootingCard.tsx
@@ -294,16 +294,20 @@ const TroubleShootingCard = ({
             <KebabDropdown
               options={
                 [
-                  // 요약본이 있고, 내가 쓴 글이면서 요약 상태일 때만 요약 삭제 노출
+                  // 원본+요약본: 요약본 삭제 옵션 노출
                   summaryId &&
-                    shouldShowSummaryType && {
+                    isMine && {
                       label: summaryDeleting
                         ? "요약본 삭제 중..."
                         : "요약본 삭제",
                       onClick: summaryDeleting ? () => {} : handleDeleteSummary,
                     },
                   {
-                    label: deleting ? "삭제 중..." : "문서 삭제",
+                    label: deleting
+                      ? "삭제 중..."
+                      : summaryId
+                        ? "삭제"
+                        : "삭제(원본 삭제)",
                     onClick: deleting ? () => {} : handleDelete,
                   },
                 ].filter(Boolean) as { label: string; onClick: () => void }[]

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -13,7 +13,7 @@ import TemplateSelectModal from "@/shared/ui/Modal/TemplateSelectModal";
 import PostSuccessModal from "@/shared/ui/Modal/PostSuccessModal";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { PATH } from "@/shared/config/paths";
-import { useProjectList } from "@/hooks/useProjectList";
+import { useProjectSelection } from "@/shared/hooks/useProjectSelection";
 import type {
   PostContentDto,
   SummaryTypeParam,
@@ -91,35 +91,21 @@ export default function FreeFormWritePage() {
 
   const [createdPostId, setCreatedPostId] = useState<number | null>(null);
 
-  // 프로젝트 목록
-  const { data: projectList = [], loading: projectsLoading } = useProjectList();
-  const projectNames = useMemo(
-    () => projectList.map((p) => p.name),
-    [projectList]
-  );
-  const nameToId = useMemo(
-    () => new Map(projectList.map((p) => [p.name, p.id])),
-    [projectList]
-  );
-  const projectNameById = (id?: number | null) =>
-    projectList.find((p) => p.id === id)?.name ?? "";
-
-  // 최초 진입 시 선택된 프로젝트 추론
-  const initialProjectId = useMemo(() => {
-    return (
+  const {
+    selectedProjectId: selectedProjectIdPage,
+    setSelectedProjectId: setSelectedProjectIdPage,
+    initialProjectId,
+    projectList,
+    projectNames,
+    nameToId,
+    projectNameById,
+    loading: projectsLoading,
+  } = useProjectSelection({
+    initialProjectId:
       location.state?.projectId ??
       location.state?.savePrefill?.projectId ??
-      null
-    );
-  }, [location.state]);
-
-  const [selectedProjectIdPage, setSelectedProjectIdPage] = useState<
-    number | null
-  >(null);
-  useEffect(() => {
-    if (initialProjectId != null)
-      setSelectedProjectIdPage(Number(initialProjectId));
-  }, [initialProjectId]);
+      null,
+  });
 
   // 이어쓰기(수정) 여부 + 대상 포스트
   const resumePostId = useMemo(() => {

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import HeaderWoSearch from "@/layouts/Header/HeaderWoSearch";
-import DropDownButton from "@/shared/ui/Button/DropDownButton";
-import CategoryTag from "@/shared/ui/Editor/CategoryTag";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { Editor } from "@toast-ui/react-editor";
 import type EditorInstance from "@toast-ui/editor";
@@ -29,6 +27,7 @@ import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
 import { useWriteSummaryFlow } from "@/shared/hooks/useWriteSummaryFlow";
 import { WriteToast } from "@/shared/ui/WriteToast";
+import { WritePageMetaSection } from "@/shared/components/WritePageMetaSection";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 import { FiChevronUp } from "react-icons/fi";
@@ -896,79 +895,31 @@ export default function FreeFormWritePage() {
             <WriteToast show={showCancelAlert} message="요약 작업이 중단되었어요." />
             <WriteToast show={showSubtitleAlert} message="소제목을 입력해주세요." />
 
-            {/* 제목/태그 + 상단 액션바 */}
-            <div className="flex flex-col items-start gap-[40px]">
-              <input
-                ref={titleInputRef}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="제목을 입력하세요."
-                className="
-    w-[1100px] md:w-[1030px]
-    text-2xl sm:text-3xl md:text-4xl lg:text-5xl
-    font-bold text-black outline-none leading-tight
-    whitespace-pre-wrap break-words
-    relative
-    border-none bg-transparent
-  "
-              />
-              <div className="flex w-full max-w-[1200px] justify-between gap-3 flex-wrap">
-                <div className="flex flex-col gap-4 w-full">
-                  <div className="flex items-end justify-between">
-                    <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
-                      <div className="flex gap-3 items-center flex-wrap">
-                        {/* 프로젝트 선택 */}
-                        <DropDownButton
-                          options={projectNames}
-                          placeholder={
-                            projectsLoading
-                              ? "프로젝트 불러오는 중..."
-                              : projectNameById(selectedProjectIdPage) ||
-                                "프로젝트를 선택하세요"
-                          }
-                          width="w-full sm:w-[170px] md:w-[190px]"
-                          onSelect={(name: string) =>
-                            setSelectedProjectIdPage(nameToId.get(name) ?? null)
-                          }
-                        />
-
-                        {/* 에러 종류 */}
-                        <DropDownButton
-                          options={ERROR_OPTIONS}
-                          placeholder={
-                            selectedErrorType ?? "에러 종류를 선택하세요"
-                          }
-                          width="w-full sm:w-[180px] lg:w-[220px]"
-                          onSelect={(selectedError) =>
-                            setSelectedErrorType(selectedError)
-                          }
-                        />
-                      </div>
-
-                      {/* 태그 */}
-                      <div className="w-full sm:w-auto min-w-[200px]">
-                        <CategoryTag
-                          value={selectedTags}
-                          onChange={setSelectedTags}
-                        />
-                      </div>
-                    </div>
-
-                    <div className="flex gap-2 w-full lg:w-auto">
-                      <div className="flex flex-col sm:flex-row gap-2 w-full lg:w-auto">
-                        <button
-                          onClick={handleEnd}
-                          disabled={isResume && !detailLoaded}
-                          className="pt-2 pr-6 pb-2 pl-6 bg-primary text-white rounded-full text-head-16-semibold hover:bg-purple-600 w-full sm:w-auto"
-                        >
-                          작성 완료
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <WritePageMetaSection
+              title={title}
+              onTitleChange={setTitle}
+              titleRef={titleInputRef}
+              projectNames={projectNames}
+              projectsLoading={projectsLoading}
+              selectedProjectId={selectedProjectIdPage}
+              onProjectSelect={setSelectedProjectIdPage}
+              projectNameById={projectNameById}
+              nameToId={nameToId}
+              errorOptions={ERROR_OPTIONS}
+              selectedErrorType={selectedErrorType}
+              onErrorTypeSelect={setSelectedErrorType}
+              selectedTags={selectedTags}
+              onTagsChange={setSelectedTags}
+              actions={
+                <button
+                  onClick={handleEnd}
+                  disabled={isResume && !detailLoaded}
+                  className="pt-2 pr-6 pb-2 pl-6 bg-primary text-white rounded-full text-head-16-semibold hover:bg-purple-600 w-full sm:w-auto"
+                >
+                  작성 완료
+                </button>
+              }
+            />
 
             {/* 블록 리스트 */}
             {blocks.map((block) => (

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -36,6 +36,7 @@ import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
 import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import { ERROR_OPTIONS, toErrorLabel } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
+import { useWriteModals } from "@/shared/hooks/useWriteModals";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 import { FiChevronUp } from "react-icons/fi";
@@ -141,16 +142,23 @@ export default function FreeFormWritePage() {
   // }, [isResume, resumePostId]);
 
   // ------------ 모달/알림 ------------
-  const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
-  const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
-    useState(false);
-  const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-
-  const [showAlert, setShowAlert] = useState(false);
+  const {
+    isPostSaveModalOpen,
+    setIsPostSaveModalOpen,
+    isTemplateSelectModalOpen,
+    setIsTemplateSelectModalOpen,
+    isLoadingModalOpen,
+    setIsLoadingModalOpen,
+    isSuccessModalOpen,
+    setIsSuccessModalOpen,
+    showAlert,
+    setShowAlert,
+    showSaveAlert,
+    setShowSaveAlert,
+    showCancelAlert,
+    setShowCancelAlert,
+  } = useWriteModals();
   const [showBlockAlert, setShowBlockAlert] = useState(false);
-  const [showSaveAlert, setShowSaveAlert] = useState(false);
-  const [showCancelAlert, setShowCancelAlert] = useState(false);
   const [showSubtitleAlert, setShowSubtitleAlert] = useState(false);
 
   // ------------ 요약/상태 ------------

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -14,29 +14,20 @@ import PostSuccessModal from "@/shared/ui/Modal/PostSuccessModal";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { PATH } from "@/shared/config/paths";
 import { useProjectSelection } from "@/shared/hooks/useProjectSelection";
-import type {
-  PostContentDto,
-  SummaryTypeParam,
-  StartLoadingResponse,
-} from "@/models/post.model";
+import type { PostContentDto, SummaryTypeParam } from "@/models/post.model";
 import {
   toCreatePostRequest,
   toEditPostRequest,
   type PostForm,
 } from "@/entities/trouble/mappers/postMapper";
-import {
-  createPost,
-  startSummary,
-  cancelSummary,
-  editPost,
-  getPostDetail,
-} from "@/api/post.api";
+import { createPost, editPost, getPostDetail } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
 import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
 import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import { ERROR_OPTIONS, toErrorLabel } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
+import { useWriteSummaryFlow } from "@/shared/hooks/useWriteSummaryFlow";
 import { WriteToast } from "@/shared/ui/WriteToast";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
@@ -565,7 +556,22 @@ export default function FreeFormWritePage() {
   //   }
   // };
 
-  // 템플릿 확정 → 요약 시작
+  const { runConfirmTemplate, closeLoadingModal } = useWriteSummaryFlow({
+    postId: createdPostId ?? resumePostId,
+    summaryTaskId,
+    summaryProgress,
+    setSummaryTaskId,
+    setSummaryProgress,
+    setSummaryStatus,
+    setStatusMessage,
+    setTemplateLabel,
+    setIsTemplateSelectModalOpen,
+    setIsLoadingModalOpen,
+    setCreatedPostId,
+    setShowCancelAlert,
+    cancelAlertDuration: 1000,
+  });
+
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -576,7 +582,6 @@ export default function FreeFormWritePage() {
       const postId = createdPostId ?? resumePostId;
       if (!postId) throw new Error("Post가 아직 생성되지 않았어요.");
 
-      // 1) 요약 시작 전, 최신 내용으로 반드시 수정 API 호출
       const effectiveMeta: PostSavePayload = {
         importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
         description:
@@ -604,27 +609,12 @@ export default function FreeFormWritePage() {
         throw new Error("프로젝트를 선택해주세요.");
       }
 
-      const editForm = await buildEditFormFromMeta(effectiveMeta, {
-        mode: "summary",
+      await runConfirmTemplate(type, label, async () => {
+        const form = await buildEditFormFromMeta(effectiveMeta, {
+          mode: "summary",
+        });
+        return toEditPostRequest(form) as any;
       });
-      await editPost(postId, toEditPostRequest(editForm) as any);
-
-      // 2) 수정 성공 후에만 요약 로딩 UI 오픈 및 요약 시작
-      setIsTemplateSelectModalOpen(false);
-      setIsLoadingModalOpen(true);
-      setSummaryProgress(0);
-      setSummaryStatus(null);
-      setStatusMessage("");
-      setTemplateLabel(label);
-
-      const res: StartLoadingResponse = await startSummary(postId, type);
-      const taskId =
-        (res as any).taskId ??
-        (res as any).data?.taskId ??
-        (res as any).content?.taskId;
-      if (!taskId) throw new Error("요약 작업 ID(taskId)를 찾을 수 없어요.");
-
-      setSummaryTaskId(taskId);
     } catch (e) {
       console.error(e);
       setIsLoadingModalOpen(false);
@@ -687,28 +677,7 @@ export default function FreeFormWritePage() {
     setStatusMessage("프로젝트를 먼저 선택해주세요.");
   };
 
-  // 로딩 모달 닫기(요약 취소)
-  const handleCloseLoading = async () => {
-    if (closingRef.current) return;
-    closingRef.current = true;
-    try {
-      const targetId = createdPostId ?? resumePostId;
-      if (summaryProgress < 100 && targetId && summaryTaskId) {
-        try {
-          await cancelSummary(targetId, summaryTaskId);
-        } catch (e) {
-          console.error("요약 작업 취소 실패:", e);
-        }
-      }
-      setIsLoadingModalOpen(false);
-      setSummaryTaskId(null);
-      setSummaryProgress(0);
-      setShowCancelAlert(true);
-      setTimeout(() => setShowCancelAlert(false), 1000);
-    } finally {
-      closingRef.current = false;
-    }
-  };
+  const handleCloseLoading = () => closeLoadingModal(closingRef);
 
   // 저장 가능 여부(버튼 비활성화용)
   const canSave = useMemo(() => {

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -27,17 +27,16 @@ import {
 import {
   createPost,
   startSummary,
-  getSummaryStatus,
   cancelSummary,
   editPost,
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
-import { isAxiosError } from "axios";
-import { startRefresh } from "@/api/axios";
 import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
 import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import { ERROR_OPTIONS, toErrorLabel } from "@/shared/utils/errorCodeLabel";
+import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
+import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 import { FiChevronUp } from "react-icons/fi";
 
@@ -68,17 +67,6 @@ type IncomingFreeformState = {
   postId?: number;
   mode?: "edit" | "create";
 };
-
-// 서버가 내려줄 수 있는 요약 상태들
-export type SummaryStatus =
-  | "PENDING"
-  | "STARTED"
-  | "PREPROCESSING"
-  | "ANALYZING"
-  | "POSTPROCESSING"
-  | "COMPLETED"
-  | "FAILED"
-  | "CANCELLED";
 
 export default function FreeFormWritePage() {
   // ------------ 기본 상태 ------------
@@ -657,110 +645,28 @@ export default function FreeFormWritePage() {
   };
 
   // 폴링
-  useEffect(() => {
-    if (
-      !isLoadingModalOpen ||
-      !(createdPostId ?? resumePostId) ||
-      !summaryTaskId
-    )
-      return;
-
-    let stopped = false;
-    let timer: number | null = null;
-
-    const tick = async () => {
-      // 리프레시 진행 중이면 먼저 대기
-      const awaitRefreshIfAny = async () => {
-        const p = (window as any).__authRefreshPromise as Promise<
-          string | null
-        > | null;
-        if (p) {
-          try {
-            await p;
-          } catch {
-            /* ignore */
-          }
-        }
-      };
-
-      try {
-        const targetId = (createdPostId ?? resumePostId) as number;
-
-        await awaitRefreshIfAny();
-
-        const fetchOnce = () =>
-          getSummaryStatus(targetId, summaryTaskId, {
-            __skipGlobalAuthGuard: true, // 전역 가드 스킵(자체 처리)
-          });
-
-        let data: any;
-        try {
-          data = await fetchOnce();
-        } catch (e) {
-          // 401이면 리프레시 후 1회 재시도
-          if (isAxiosError(e) && e.response?.status === 401) {
-            const inflight = (window as any).__authRefreshPromise as Promise<
-              string | null
-            > | null;
-            const token = inflight ? await inflight : await startRefresh();
-            if (!token) throw e; // 실패 → 상위에서 처리(모달 닫기 등)
-
-            data = await getSummaryStatus(targetId, summaryTaskId, {
-              __skipGlobalAuthGuard: true,
-              headers: { Authorization: `Bearer ${token}` },
-            });
-          } else {
-            throw e;
-          }
-        }
-
-        if (stopped) return;
-
-        const p = Math.max(0, Math.min(100, data?.progress ?? 0));
-        setSummaryProgress(p);
-        if (data?.status) setSummaryStatus(data.status as SummaryStatus);
-
-        if (data?.currentStep) setStatusMessage(data.currentStep);
-        else if (data?.message) setStatusMessage(data.message);
-        else if (
-          data?.result &&
-          typeof data.result === "object" &&
-          "message" in (data.result as any)
-        ) {
-          setStatusMessage((data.result as any).message ?? "");
-        }
-
-        if (data?.status === "COMPLETED" || p >= 100) {
-          setSummaryProgress(100);
-
-          if (typeof data?.postSummaryId === "number") {
-            setCompletedSummaryId(data.postSummaryId);
-            setIsLoadingModalOpen(false);
-            setIsSuccessModalOpen(true);
-          } else {
-            setIsLoadingModalOpen(false);
-          }
-          if (timer !== null) {
-            clearInterval(timer);
-            timer = null;
-          }
-        }
-      } catch (err) {
-        console.error("poll tick error:", err);
+  const handlePollComplete = useCallback(
+    (postSummaryId?: number) => {
+      if (typeof postSummaryId === "number") {
+        setCompletedSummaryId(postSummaryId);
+        setIsLoadingModalOpen(false);
+        setIsSuccessModalOpen(true);
+      } else {
+        setIsLoadingModalOpen(false);
       }
-    };
+    },
+    []
+  );
 
-    tick();
-    timer = window.setInterval(tick, 1200);
-
-    return () => {
-      stopped = true;
-      if (timer !== null) {
-        clearInterval(timer);
-        timer = null;
-      }
-    };
-  }, [isLoadingModalOpen, createdPostId, resumePostId, summaryTaskId]);
+  useSummaryPolling({
+    postId: createdPostId ?? resumePostId,
+    summaryTaskId,
+    isActive: !!isLoadingModalOpen,
+    onProgress: setSummaryProgress,
+    onStatus: setSummaryStatus,
+    onMessage: setStatusMessage,
+    onComplete: handlePollComplete,
+  });
 
   // 나중에 하기(요약 건너뛰고 미리보기/프로젝트로 이동)
   const handleLater = async () => {

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -37,6 +37,7 @@ import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import { ERROR_OPTIONS, toErrorLabel } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
+import { WriteToast } from "@/shared/ui/WriteToast";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 import { FiChevronUp } from "react-icons/fi";
@@ -914,31 +915,17 @@ export default function FreeFormWritePage() {
         <div className="container mx-auto px-8 sm:px-12 lg:px-16">
           <div className="flex-1 flex w-full max-w-[1200px] mx-auto flex-col gap-3">
             {/* Alerts */}
-            {showAlert && (
-              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-                제목, 프로젝트, 에러 종류, 첫 블록 내용을 모두 입력해주세요.
-              </div>
-            )}
-            {showBlockAlert && (
-              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-                첫 번째 블록의 내용이 비어있습니다.
-              </div>
-            )}
-            {showSaveAlert && (
-              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-                저장되었습니다.
-              </div>
-            )}
-            {showCancelAlert && (
-              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-                요약 작업이 중단되었어요.
-              </div>
-            )}
-            {showSubtitleAlert && (
-              <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-                소제목을 입력해주세요.
-              </div>
-            )}
+            <WriteToast
+              show={showAlert}
+              message="제목, 프로젝트, 에러 종류, 첫 블록 내용을 모두 입력해주세요."
+            />
+            <WriteToast
+              show={showBlockAlert}
+              message="첫 번째 블록의 내용이 비어있습니다."
+            />
+            <WriteToast show={showSaveAlert} message="저장되었습니다." variant="success" />
+            <WriteToast show={showCancelAlert} message="요약 작업이 중단되었어요." />
+            <WriteToast show={showSubtitleAlert} message="소제목을 입력해주세요." />
 
             {/* 제목/태그 + 상단 액션바 */}
             <div className="flex flex-col items-start gap-[40px]">

--- a/src/pages/FreeFormWrite/FreeFormWritePage.tsx
+++ b/src/pages/FreeFormWrite/FreeFormWritePage.tsx
@@ -30,13 +30,14 @@ import {
   getSummaryStatus,
   cancelSummary,
   editPost,
-  getTagsByKeyword,
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
 import { isAxiosError } from "axios";
 import { startRefresh } from "@/api/axios";
 import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
+import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
+import { ERROR_OPTIONS, toErrorLabel } from "@/shared/utils/errorCodeLabel";
 
 import { FiChevronUp } from "react-icons/fi";
 
@@ -67,34 +68,6 @@ type IncomingFreeformState = {
   postId?: number;
   mode?: "edit" | "create";
 };
-
-const errorOptions = [
-  "Build/Compile Error",
-  "Runtime Error",
-  "Dependency/Version Error",
-  "Network/API Error",
-  "Authentication/Authorization Error",
-  "Database Error",
-  "UI/Rendering Error",
-  "Configuration Error",
-  "Timeout/Error Handling",
-  "Third-Party Library Error",
-];
-
-const ERROR_CODE_TO_LABEL: Record<string, string> = {
-  BUILD_COMPILE_ERROR: "Build/Compile Error",
-  RUNTIME_ERROR: "Runtime Error",
-  DEPENDENCY_VERSION_ERROR: "Dependency/Version Error",
-  NETWORK_API_ERROR: "Network/API Error",
-  AUTHENTICATION_AUTHORIZATION_ERROR: "Authentication/Authorization Error",
-  DATABASE_ERROR: "Database Error",
-  UI_RENDERING_ERROR: "UI/Rendering Error",
-  CONFIGURATION_ERROR: "Configuration Error",
-  TIMEOUT_ERROR_HANDLING: "Timeout/Error Handling",
-  THIRD_PARTY_LIBRARY_ERROR: "Third-Party Library Error",
-};
-const toErrorLabel = (code?: string | null) =>
-  code ? ERROR_CODE_TO_LABEL[code] ?? code : null;
 
 // 서버가 내려줄 수 있는 요약 상태들
 export type SummaryStatus =
@@ -360,35 +333,6 @@ export default function FreeFormWritePage() {
             summaryType: "NONE",
           } as any)
       );
-
-  // ------------ 태그 정규화 ------------
-  const canonicalizeTags = async (rawTags: string[]) => {
-    const out: string[] = [];
-    const seen = new Set<string>();
-    for (const raw of rawTags) {
-      const q = String(raw).replace(/^#\s*/, "").trim();
-      if (!q) continue;
-
-      const res: any = await getTagsByKeyword({ tagName: q });
-      const list: any[] = Array.isArray(res)
-        ? res
-        : res?.data ?? res?.content ?? res?.results ?? [];
-
-      const names = list
-        .map((t) => (typeof t === "string" ? t : t?.name ?? t))
-        .filter(Boolean) as string[];
-
-      const exact = names.find((n) => n.toLowerCase() === q.toLowerCase());
-      const pick = (exact ?? names[0]) as string | undefined;
-
-      const normalized = String(pick ?? q).trim();
-      if (!seen.has(normalized.toLowerCase())) {
-        seen.add(normalized.toLowerCase());
-        out.push(normalized);
-      }
-    }
-    return out;
-  };
 
   // ------------ 서버 폼 빌드 ------------
   const buildForm = (
@@ -1134,7 +1078,7 @@ export default function FreeFormWritePage() {
 
                         {/* 에러 종류 */}
                         <DropDownButton
-                          options={errorOptions}
+                          options={ERROR_OPTIONS}
                           placeholder={
                             selectedErrorType ?? "에러 종류를 선택하세요"
                           }

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -143,24 +143,26 @@ export default function HomePage() {
       }
 
       // 2) 요약본이 하나도 없는 원본
-      //    → "원본(요약 전)" 1개만
+      //    → "원본(요약 전)" 1개만 — 케밥은 '삭제(원본 삭제)'만 노출
       if (!hasSummaries) {
         result.push({
           ...card,
           status: originalStatus, // SUMMARIZED 이면서 요약본이 없는 경우도 완료로 처리
           _kind: "original", // 원본(요약 전)
+          summaryId: undefined,
         });
         continue;
       }
 
       // 3) 요약본이 있는 포스트(status: created)
-      //    - 원본(요약 후) 1개 (작성 완료 표시, 요약 타입 표시는 제거)
-      //    - 원본+요약본 N개 (요약 타입 표시, 상태는 created)
+      //    - 원본(요약 후) 1개 (작성 완료 표시) — 케밥은 '삭제(원본 삭제)'만 노출
+      //    - 원본+요약본 N개 (요약 타입 표시) — 케밥은 '요약본 삭제' + '삭제'
       result.push({
         ...card,
         status: originalStatus,
         summaryType: undefined,
         _kind: "original", // 원본(요약 후)
+        summaryId: undefined,
       });
 
       for (const summary of summaries) {
@@ -473,6 +475,7 @@ export default function HomePage() {
                     {...card}
                     compact
                     onDeleted={handleRecentDeleted}
+                    onSummaryDeleted={recentsReload}
                     onClick={() => {
                       const ownerId = card.authorId ?? undefined;
 

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -21,16 +21,9 @@ import {
 import type {
   PostContentDto,
   SummaryTypeParam,
-  StartLoadingResponse,
 } from "@/models/post.model";
 import { useProjectSelection } from "@/shared/hooks/useProjectSelection";
-import {
-  createPost,
-  startSummary,
-  cancelSummary,
-  editPost,
-  getPostDetail,
-} from "@/api/post.api";
+import { createPost, editPost, getPostDetail } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
 import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import {
@@ -39,6 +32,7 @@ import {
 } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
+import { useWriteSummaryFlow } from "@/shared/hooks/useWriteSummaryFlow";
 import { WriteToast } from "@/shared/ui/WriteToast";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
@@ -505,6 +499,22 @@ const TempWritePage = () => {
   //   }
   // };
 
+  const { runConfirmTemplate, closeLoadingModal } = useWriteSummaryFlow({
+    postId: createdPostId ?? resumePostId,
+    summaryTaskId,
+    summaryProgress,
+    setSummaryTaskId,
+    setSummaryProgress,
+    setSummaryStatus,
+    setStatusMessage,
+    setTemplateLabel,
+    setIsTemplateSelectModalOpen,
+    setIsLoadingModalOpen,
+    setCreatedPostId,
+    setShowCancelAlert,
+    cancelAlertDuration: 3000,
+  });
+
   const handleConfirmTemplate = async (
     type: SummaryTypeParam,
     label: string
@@ -515,7 +525,6 @@ const TempWritePage = () => {
       const postId = createdPostId ?? resumePostId;
       if (!postId) throw new Error("Post가 아직 생성되지 않았어요.");
 
-      // 1) 요약 시작 전, 항상 최신 내용으로 수정 API 호출
       const effectiveMeta: PostSavePayload = {
         importance: previewMeta?.importance ?? detailPrefill?.importance ?? 0,
         description:
@@ -539,29 +548,12 @@ const TempWritePage = () => {
         throw new Error("프로젝트를 선택해주세요.");
       }
 
-      const editForm = await buildEditFormFromMeta(effectiveMeta, {
-        mode: "summary",
+      await runConfirmTemplate(type, label, async () => {
+        const form = await buildEditFormFromMeta(effectiveMeta, {
+          mode: "summary",
+        });
+        return toEditPostRequest(form) as any;
       });
-      await editPost(postId, toEditPostRequest(editForm) as any);
-
-      // 2) 수정 성공 후에만 요약 로딩 UI 오픈 및 요약 시작
-      setIsTemplateSelectModalOpen(false);
-      setIsLoadingModalOpen(true);
-      setSummaryProgress(0);
-      setSummaryStatus(null);
-      setStatusMessage("");
-      setTemplateLabel(label);
-
-      const res: StartLoadingResponse = await startSummary(postId, type);
-
-      const taskId =
-        (res as any).taskId ??
-        (res as any).data?.taskId ??
-        (res as any).content?.taskId;
-
-      if (!taskId) throw new Error("요약 작업 ID(taskId)를 찾을 수 없어요.");
-
-      setSummaryTaskId(taskId);
     } catch (e) {
       console.error(e);
       setIsLoadingModalOpen(false);
@@ -632,27 +624,7 @@ const TempWritePage = () => {
     setTimeout(() => setShowAlert(false), 1000);
   };
 
-  const handleCloseLoading = async () => {
-    if (closingRef.current) return;
-    closingRef.current = true;
-    try {
-      const targetId = createdPostId ?? resumePostId;
-      if (summaryProgress < 100 && targetId && summaryTaskId) {
-        try {
-          await cancelSummary(targetId, summaryTaskId);
-        } catch (e) {
-          console.error("요약 작업 취소 실패:", e);
-        }
-      }
-      setIsLoadingModalOpen(false);
-      setSummaryTaskId(null);
-      setSummaryProgress(0);
-      setShowCancelAlert(true);
-      setTimeout(() => setShowCancelAlert(false), 3000);
-    } finally {
-      closingRef.current = false;
-    }
-  };
+  const handleCloseLoading = () => closeLoadingModal(closingRef);
 
   // ---------- 임시 저장 ----------
   const handleClickSave = async (): Promise<boolean> => {

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -23,7 +23,7 @@ import type {
   SummaryTypeParam,
   StartLoadingResponse,
 } from "@/models/post.model";
-import { useProjectList } from "@/hooks/useProjectList";
+import { useProjectSelection } from "@/shared/hooks/useProjectSelection";
 import {
   createPost,
   startSummary,
@@ -160,11 +160,19 @@ const TempWritePage = () => {
   // 네비게이션 & 라우트 상태
   const navigate = useNavigate();
   const location = useLocation() as { state?: IncomingTemplateState };
-  const initialProjectId =
-    location.state?.projectId ?? location.state?.savePrefill?.projectId ?? null;
-
-  // 프로젝트 목록
-  const { data: projectList = [], loading: projectsLoading } = useProjectList();
+  const {
+    selectedProjectId: selectedProjectIdPage,
+    setSelectedProjectId: setSelectedProjectIdPage,
+    initialProjectId,
+    projectList,
+    projectNames,
+    nameToId,
+    projectNameById,
+    loading: projectsLoading,
+  } = useProjectSelection({
+    initialProjectId:
+      location.state?.projectId ?? location.state?.savePrefill?.projectId ?? null,
+  });
 
   // 기본 상태
   const [title, setTitle] = useState("");
@@ -173,28 +181,6 @@ const TempWritePage = () => {
   const [activeIndex, setActiveIndex] = useState(0);
   const [selectedErrorType, setSelectedErrorType] = useState<string | null>(
     null
-  );
-
-  // 페이지 내 프로젝트 선택값
-  const [selectedProjectIdPage, setSelectedProjectIdPage] = useState<
-    number | null
-  >(null);
-  useEffect(() => {
-    if (initialProjectId != null)
-      setSelectedProjectIdPage(Number(initialProjectId));
-  }, [initialProjectId]);
-
-  const projectNames = useMemo(
-    () => projectList.map((p) => p.name),
-    [projectList]
-  );
-  const nameToId = useMemo(
-    () => new Map(projectList.map((p) => [p.name, p.id])),
-    [projectList]
-  );
-  const projectNameById = useCallback(
-    (id?: number | null) => projectList.find((p) => p.id === id)?.name ?? "",
-    [projectList]
   );
 
   const [draftPostId, setDraftPostId] = useState<number | null>(null);

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -249,34 +249,75 @@ const TempWritePage = () => {
     null
   );
 
-  // 수정 모드 초기 진입 시 상세 조회에서 가져오기
+  // 수정 모드 초기 진입 시 상세 조회에서 가져오기 (템플릿 타입에 따라 자유형이면 자유형 페이지로 리다이렉트)
   useEffect(() => {
     (async () => {
       if (!isResume || !resumePostId) return;
       try {
         const d: any = await getPostDetail(resumePostId);
+        const templateType =
+          d?.templateType ?? d?.template ?? "";
+
+        if (String(templateType).toUpperCase() === "FREE_FORM") {
+          navigate(PATH.FREEFORM_WRITING, {
+            state: { postId: resumePostId, projectId: d?.projectId },
+            replace: true,
+          });
+          return;
+        }
+
         setCurrentThumbnail(d?.thumbnailImageUrl ?? null);
-        // 서버 필드명 상이할 수 있어 둘 다 고려
+        setTitle(d?.title ?? "");
+        setSelectedTags(Array.isArray(d?.postTags) ? d.postTags : []);
+        setSelectedErrorType(
+          toErrorLabel(d?.errorTag) ?? d?.errorTag ?? null
+        );
+
+        const contents = Array.isArray(d?.contents) ? d.contents : [];
+        const rawBlocks = contents.map((c: any, idx: number) => ({
+          id: c.id ?? idx,
+          question: c.subTitle ?? "",
+          content: c.body ?? "",
+          isSaved: true,
+        }));
+        const errNums = Array.isArray(d?.checkListError)
+          ? d.checkListError
+          : Array.isArray(d?.checklistError)
+            ? d.checklistError
+            : [];
+        const reasonNums = Array.isArray(d?.checkListReason)
+          ? d.checkListReason
+          : Array.isArray(d?.checklistReason)
+            ? d.checklistReason
+            : [];
+        setBlocks(
+          rawBlocks.length > 0
+            ? enrichBlocksWithChecklist(rawBlocks, {
+                error: errNums,
+                reason: reasonNums,
+              })
+            : []
+        );
+
         const s = (d?.postStatus ?? d?.status) as
           | "WRITING"
           | "COMPLETED"
           | "SUMMARIZED"
           | undefined;
         setInitialPostStatus(s ?? null);
-        // ← 기존 introduction / starRating / visibility / projectId 등을 프리필에 저장
         setDetailPrefill({
           importance: Number(d?.starRating ?? 0),
           description: String(d?.introduction ?? ""),
           visibility: d?.isVisible ? "public" : "private",
           projectId: Number.isFinite(d?.projectId) ? Number(d.projectId) : null,
-          projectName: "", // 필요시 후속 조회로 채워도 무방
+          projectName: "",
           thumbnail: d?.thumbnailImageUrl ?? null,
         });
       } catch {
         /* ignore */
       }
     })();
-  }, [isResume, resumePostId]);
+  }, [isResume, resumePostId, navigate]);
 
   // ---------- 프리필 ----------
   useEffect(() => {

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -30,12 +30,16 @@ import {
   getSummaryStatus,
   cancelSummary,
   editPost,
-  getTagsByKeyword,
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
 import { isAxiosError } from "axios";
 import { startRefresh } from "@/api/axios";
+import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
+import {
+  ERROR_OPTIONS,
+  toErrorLabel,
+} from "@/shared/utils/errorCodeLabel";
 
 // ---- 숫자 인덱스 변환 유틸 ----
 const QI = { ERROR: 0, REASON: 1 } as const;
@@ -107,22 +111,6 @@ type IncomingTemplateState = {
   postId?: number; // 수정 식별용
   mode?: "edit" | "create";
 };
-
-// ---------- 에러 라벨/코드  ----------
-const ERROR_CODE_TO_LABEL: Record<string, string> = {
-  BUILD_COMPILE_ERROR: "Build/Compile Error",
-  RUNTIME_ERROR: "Runtime Error",
-  DEPENDENCY_VERSION_ERROR: "Dependency/Version Error",
-  NETWORK_API_ERROR: "Network/API Error",
-  AUTHENTICATION_AUTHORIZATION_ERROR: "Authentication/Authorization Error",
-  DATABASE_ERROR: "Database Error",
-  UI_RENDERING_ERROR: "UI/Rendering Error",
-  CONFIGURATION_ERROR: "Configuration Error",
-  TIMEOUT_ERROR_HANDLING: "Timeout/Error Handling",
-  THIRD_PARTY_LIBRARY_ERROR: "Third-Party Library Error",
-};
-const toErrorLabel = (code?: string | null) =>
-  code ? ERROR_CODE_TO_LABEL[code] ?? code : null;
 
 // ---------- 체크리스트 ----------
 const enrichBlocksWithChecklist = (
@@ -378,35 +366,6 @@ const TempWritePage = () => {
             summaryType: "NONE",
           } as any)
       );
-
-  // ---------- 태그 정규화 ----------
-  const canonicalizeTags = async (rawTags: string[]) => {
-    const out: string[] = [];
-    const seen = new Set<string>();
-    for (const raw of rawTags) {
-      const q = String(raw).replace(/^#\s*/, "").trim();
-      if (!q) continue;
-
-      const res: any = await getTagsByKeyword({ tagName: q });
-      const list: any[] = Array.isArray(res)
-        ? res
-        : res?.data ?? res?.content ?? res?.results ?? [];
-      const names = list
-        .map((t) => (typeof t === "string" ? t : t?.name ?? t))
-        .filter(Boolean);
-      const exact = names.find(
-        (n: string) => n.toLowerCase() === q.toLowerCase()
-      );
-      const pick = (exact ?? names[0]) as string | undefined;
-
-      const normalized = String(pick ?? q).trim();
-      if (!seen.has(normalized.toLowerCase())) {
-        seen.add(normalized.toLowerCase());
-        out.push(normalized);
-      }
-    }
-    return out;
-  };
 
   // 현재 화면 상태 + PostSaveModal에서 받은 meta로 수정 페이로드 만들기
   const buildEditFormFromMeta = async (
@@ -1068,18 +1027,7 @@ const TempWritePage = () => {
                 />
 
                 <DropDownButton
-                  options={[
-                    "Build/Compile Error",
-                    "Runtime Error",
-                    "Dependency/Version Error",
-                    "Network/API Error",
-                    "Authentication/Authorization Error",
-                    "Database Error",
-                    "UI/Rendering Error",
-                    "Configuration Error",
-                    "Timeout/Error Handling",
-                    "Third-Party Library Error",
-                  ]}
+                  options={ERROR_OPTIONS}
                   placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
                   width="w-full sm:w-[180px] lg:w-[220px]"
                   onSelect={(v: string) => setSelectedErrorType(v)}

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import HeaderWoSearch from "@/layouts/Header/HeaderWoSearch";
-import DropDownButton from "@/shared/ui/Button/DropDownButton";
-import CategoryTag from "@/shared/ui/Editor/CategoryTag";
 import EditorBlock, { type BlockData } from "@/shared/ui/Editor/EditorBlock";
 import { questionData } from "@/features/template-write/lib/questionTemplate";
 import PostSaveModal, {
@@ -34,6 +32,7 @@ import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
 import { useWriteSummaryFlow } from "@/shared/hooks/useWriteSummaryFlow";
 import { WriteToast } from "@/shared/ui/WriteToast";
+import { WritePageMetaSection } from "@/shared/components/WritePageMetaSection";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 // ---- 숫자 인덱스 변환 유틸 ----
@@ -863,50 +862,21 @@ const TempWritePage = () => {
           <WriteToast show={showSaveAlert} message="저장되었습니다." variant="success" />
           <WriteToast show={showCancelAlert} message="요약 작업이 중단되었어요." />
 
-          <div className="flex flex-col gap-6 sm:gap-10">
-            <input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="제목을 입력하세요."
-              className="
-    w-[1100px] md:w-[870px]
-    text-2xl sm:text-3xl md:text-4xl lg:text-5xl
-    font-bold text-black outline-none leading-tight
-    whitespace-pre-wrap break-words
-    relative
-    border-none bg-transparent
-  "
-            />
-
-            <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
-              <div className="flex gap-3 items-center flex-wrap">
-                <DropDownButton
-                  options={projectNames}
-                  placeholder={
-                    projectsLoading
-                      ? "프로젝트 불러오는 중..."
-                      : projectNameById(selectedProjectIdPage) ||
-                        "프로젝트를 선택하세요"
-                  }
-                  width="w-full sm:w-[170px] md:w-[190px]"
-                  onSelect={(name: string) =>
-                    setSelectedProjectIdPage(nameToId.get(name) ?? null)
-                  }
-                />
-
-                <DropDownButton
-                  options={ERROR_OPTIONS}
-                  placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
-                  width="w-full sm:w-[180px] lg:w-[220px]"
-                  onSelect={(v: string) => setSelectedErrorType(v)}
-                />
-              </div>
-
-              <div className="w-full sm:w-auto min-w-[180px]">
-                <CategoryTag value={selectedTags} onChange={setSelectedTags} />
-              </div>
-            </div>
-          </div>
+          <WritePageMetaSection
+            title={title}
+            onTitleChange={setTitle}
+            projectNames={projectNames}
+            projectsLoading={projectsLoading}
+            selectedProjectId={selectedProjectIdPage}
+            onProjectSelect={setSelectedProjectIdPage}
+            projectNameById={projectNameById}
+            nameToId={nameToId}
+            errorOptions={ERROR_OPTIONS}
+            selectedErrorType={selectedErrorType}
+            onErrorTypeSelect={setSelectedErrorType}
+            selectedTags={selectedTags}
+            onTagsChange={setSelectedTags}
+          />
 
           <div className="flex flex-col pb-2">
             {reversedBlocks.map(({ block, originalIndex }) => (

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -38,6 +38,7 @@ import {
   toErrorLabel,
 } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
+import { useWriteModals } from "@/shared/hooks/useWriteModals";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 // ---- 숫자 인덱스 변환 유틸 ----
@@ -186,16 +187,22 @@ const TempWritePage = () => {
   const [draftPostId, setDraftPostId] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
-  // 모달/알림
-  const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
-  const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
-    useState(false);
-  const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-
-  const [showAlert, setShowAlert] = useState(false);
-  const [showSaveAlert, setShowSaveAlert] = useState(false);
-  const [showCancelAlert, setShowCancelAlert] = useState(false);
+  const {
+    isPostSaveModalOpen,
+    setIsPostSaveModalOpen,
+    isTemplateSelectModalOpen,
+    setIsTemplateSelectModalOpen,
+    isLoadingModalOpen,
+    setIsLoadingModalOpen,
+    isSuccessModalOpen,
+    setIsSuccessModalOpen,
+    showAlert,
+    setShowAlert,
+    showSaveAlert,
+    setShowSaveAlert,
+    showCancelAlert,
+    setShowCancelAlert,
+  } = useWriteModals();
 
   // 요약 상태
   const [previewMeta, setPreviewMeta] = useState<PostSavePayload | null>(null);

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/shared/utils/errorCodeLabel";
 import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
 import { useWriteModals } from "@/shared/hooks/useWriteModals";
+import { WriteToast } from "@/shared/ui/WriteToast";
 import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 // ---- 숫자 인덱스 변환 유틸 ----
@@ -883,21 +884,12 @@ const TempWritePage = () => {
       <HeaderWoSearch />
       <div className="w-full max-w-[1680px] sm:pl-64 lg:pl-64 pt-8 sm:pt-12">
         <div className="mx-auto w-full max-w-[1680px] flex flex-col gap-8 sm:gap-9">
-          {showAlert && (
-            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-              제목, 프로젝트, 에러 종류, 첫 번째 블록 내용을 모두 입력해주세요.
-            </div>
-          )}
-          {showSaveAlert && (
-            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-white border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-              저장되었습니다.
-            </div>
-          )}
-          {showCancelAlert && (
-            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] bg-purple-100 border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out">
-              요약 작업이 중단되었어요.
-            </div>
-          )}
+          <WriteToast
+            show={showAlert}
+            message="제목, 프로젝트, 에러 종류, 첫 번째 블록 내용을 모두 입력해주세요."
+          />
+          <WriteToast show={showSaveAlert} message="저장되었습니다." variant="success" />
+          <WriteToast show={showCancelAlert} message="요약 작업이 중단되었어요." />
 
           <div className="flex flex-col gap-6 sm:gap-10">
             <input

--- a/src/pages/TempWrite/TempWritePage.tsx
+++ b/src/pages/TempWrite/TempWritePage.tsx
@@ -27,19 +27,18 @@ import { useProjectList } from "@/hooks/useProjectList";
 import {
   createPost,
   startSummary,
-  getSummaryStatus,
   cancelSummary,
   editPost,
   getPostDetail,
 } from "@/api/post.api";
 import { uploadImage } from "@/api/image.api";
-import { isAxiosError } from "axios";
-import { startRefresh } from "@/api/axios";
 import { canonicalizeTags } from "@/shared/utils/canonicalizeTags";
 import {
   ERROR_OPTIONS,
   toErrorLabel,
 } from "@/shared/utils/errorCodeLabel";
+import { useSummaryPolling } from "@/shared/hooks/useSummaryPolling";
+import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
 
 // ---- 숫자 인덱스 변환 유틸 ----
 const QI = { ERROR: 0, REASON: 1 } as const;
@@ -222,15 +221,6 @@ const TempWritePage = () => {
     null
   );
 
-  type SummaryStatus =
-    | "PENDING"
-    | "STARTED"
-    | "PREPROCESSING"
-    | "ANALYZING"
-    | "POSTPROCESSING"
-    | "COMPLETED"
-    | "FAILED"
-    | "CANCELLED";
   const [summaryStatus, setSummaryStatus] = useState<SummaryStatus | null>(
     null
   );
@@ -593,107 +583,28 @@ const TempWritePage = () => {
   };
 
   // ---------- 폴링 ----------
-  useEffect(() => {
-    if (
-      !isLoadingModalOpen ||
-      !(createdPostId ?? resumePostId) ||
-      !summaryTaskId
-    )
-      return;
-
-    let stopped = false;
-    let timer: number | null = null;
-
-    const tick = async () => {
-      const awaitRefreshIfAny = async () => {
-        const p = (window as any).__authRefreshPromise as Promise<
-          string | null
-        > | null;
-        if (p) {
-          try {
-            await p;
-          } catch {
-            /* ignore */
-          }
-        }
-      };
-
-      try {
-        const targetId = (createdPostId ?? resumePostId) as number;
-
-        await awaitRefreshIfAny();
-
-        const fetchOnce = () =>
-          getSummaryStatus(targetId, summaryTaskId, {
-            __skipGlobalAuthGuard: true,
-          });
-
-        let data: any;
-        try {
-          data = await fetchOnce();
-        } catch (e) {
-          if (isAxiosError(e) && e.response?.status === 401) {
-            const inflight = (window as any).__authRefreshPromise as Promise<
-              string | null
-            > | null;
-            const token = inflight ? await inflight : await startRefresh();
-            if (!token) throw e;
-
-            data = await getSummaryStatus(targetId, summaryTaskId, {
-              __skipGlobalAuthGuard: true,
-              headers: { Authorization: `Bearer ${token}` },
-            });
-          } else {
-            throw e;
-          }
-        }
-
-        const p = Math.max(0, Math.min(100, data?.progress ?? 0));
-        if (stopped) return;
-
-        setSummaryProgress(p);
-        if (data?.status) setSummaryStatus(data.status as SummaryStatus);
-
-        if (data?.currentStep) setStatusMessage(data.currentStep);
-        else if (data?.message) setStatusMessage(data.message);
-        else if (
-          data?.result &&
-          typeof data.result === "object" &&
-          "message" in (data.result as any)
-        ) {
-          setStatusMessage((data.result as any).message ?? "");
-        }
-
-        if (data?.status === "COMPLETED" || p >= 100) {
-          setSummaryProgress(100);
-          if (typeof data?.postSummaryId === "number") {
-            setCompletedSummaryId(data.postSummaryId);
-            setIsLoadingModalOpen(false);
-            setIsSuccessModalOpen(true);
-          } else {
-            setIsLoadingModalOpen(false);
-          }
-          if (timer !== null) {
-            clearInterval(timer);
-            timer = null;
-          }
-        }
-      } catch (err) {
-        console.error("poll tick error:", err);
+  const handlePollComplete = useCallback(
+    (postSummaryId?: number) => {
+      if (typeof postSummaryId === "number") {
+        setCompletedSummaryId(postSummaryId);
+        setIsLoadingModalOpen(false);
+        setIsSuccessModalOpen(true);
+      } else {
+        setIsLoadingModalOpen(false);
       }
-    };
+    },
+    []
+  );
 
-    tick();
-    timer = window.setInterval(tick, 1200);
-
-    return () => {
-      stopped = true;
-      if (timer !== null) {
-        clearInterval(timer);
-        timer = null;
-      }
-    };
-  }, [isLoadingModalOpen, createdPostId, resumePostId, summaryTaskId]);
+  useSummaryPolling({
+    postId: createdPostId ?? resumePostId,
+    summaryTaskId,
+    isActive: !!isLoadingModalOpen,
+    onProgress: setSummaryProgress,
+    onStatus: setSummaryStatus,
+    onMessage: setStatusMessage,
+    onComplete: handlePollComplete,
+  });
 
   const buildPreviewState = () => ({
     editorType: "TEMPLATE" as const,

--- a/src/shared/components/WritePageMetaSection.tsx
+++ b/src/shared/components/WritePageMetaSection.tsx
@@ -14,7 +14,7 @@ export interface WritePageMetaSectionProps {
   nameToId: Map<string, number>;
   errorOptions: string[];
   selectedErrorType: string | null;
-  onErrorTypeSelect: (v: string) => void;
+  onErrorTypeSelect: (v: string | null) => void;
   selectedTags: string[];
   onTagsChange: React.Dispatch<React.SetStateAction<string[]>>;
   /** 우측 액션(예: 작성 완료 버튼). FreeForm 등에서 사용 */

--- a/src/shared/components/WritePageMetaSection.tsx
+++ b/src/shared/components/WritePageMetaSection.tsx
@@ -1,0 +1,97 @@
+import type { RefObject } from "react";
+import DropDownButton from "@/shared/ui/Button/DropDownButton";
+import CategoryTag from "@/shared/ui/Editor/CategoryTag";
+
+export interface WritePageMetaSectionProps {
+  title: string;
+  onTitleChange: (v: string) => void;
+  titleRef?: RefObject<HTMLInputElement | null>;
+  projectNames: string[];
+  projectsLoading: boolean;
+  selectedProjectId: number | null;
+  onProjectSelect: (id: number | null) => void;
+  projectNameById: (id?: number | null) => string;
+  nameToId: Map<string, number>;
+  errorOptions: string[];
+  selectedErrorType: string | null;
+  onErrorTypeSelect: (v: string) => void;
+  selectedTags: string[];
+  onTagsChange: React.Dispatch<React.SetStateAction<string[]>>;
+  /** 우측 액션(예: 작성 완료 버튼). FreeForm 등에서 사용 */
+  actions?: React.ReactNode;
+}
+
+const TITLE_CLASS =
+  "text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-black outline-none leading-tight whitespace-pre-wrap break-words relative border-none bg-transparent";
+
+export function WritePageMetaSection({
+  title,
+  onTitleChange,
+  titleRef,
+  projectNames,
+  projectsLoading,
+  selectedProjectId,
+  onProjectSelect,
+  projectNameById,
+  nameToId,
+  errorOptions,
+  selectedErrorType,
+  onErrorTypeSelect,
+  selectedTags,
+  onTagsChange,
+  actions,
+}: WritePageMetaSectionProps) {
+  const metaContent = (
+    <>
+      <div className="flex gap-3 items-center flex-wrap">
+        <DropDownButton
+          options={projectNames}
+          placeholder={
+            projectsLoading
+              ? "프로젝트 불러오는 중..."
+              : projectNameById(selectedProjectId) || "프로젝트를 선택하세요"
+          }
+          width="w-full sm:w-[170px] md:w-[190px]"
+          onSelect={(name: string) =>
+            onProjectSelect(nameToId.get(name) ?? null)
+          }
+        />
+        <DropDownButton
+          options={errorOptions}
+          placeholder={selectedErrorType ?? "에러 종류를 선택하세요"}
+          width="w-full sm:w-[180px] lg:w-[220px]"
+          onSelect={onErrorTypeSelect}
+        />
+      </div>
+      <div className="w-full sm:w-auto min-w-[180px]">
+        <CategoryTag value={selectedTags} onChange={onTagsChange} />
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex flex-col items-start gap-6 sm:gap-10">
+      <input
+        ref={titleRef}
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        placeholder="제목을 입력하세요."
+        className={`w-[1100px] md:w-[870px] ${TITLE_CLASS}`}
+      />
+      <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
+        {actions ? (
+          <div className="flex items-end justify-between gap-3 flex-wrap">
+            <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
+              {metaContent}
+            </div>
+            <div className="flex gap-2 w-full lg:w-auto">
+              {actions}
+            </div>
+          </div>
+        ) : (
+          metaContent
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/WritePageMetaSection.tsx
+++ b/src/shared/components/WritePageMetaSection.tsx
@@ -76,12 +76,12 @@ export function WritePageMetaSection({
         value={title}
         onChange={(e) => onTitleChange(e.target.value)}
         placeholder="제목을 입력하세요."
-        className={`w-[1100px] md:w-[870px] ${TITLE_CLASS}`}
+        className={`w-full max-w-full md:max-w-[870px] ${TITLE_CLASS}`}
       />
-      <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
+      <div className="flex flex-col gap-3 max-w-[900px] md:max-w-[1100px] lg:w-auto">
         {actions ? (
           <div className="flex items-end justify-between gap-3 flex-wrap">
-            <div className="flex flex-col gap-3 max-w-[1100px] md:max-w-[900px] lg:w-auto">
+            <div className="flex flex-col gap-3 max-w-[900px] md:max-w-[1100px] lg:w-auto">
               {metaContent}
             </div>
             <div className="flex gap-2 w-full lg:w-auto">

--- a/src/shared/hooks/useProjectSelection.ts
+++ b/src/shared/hooks/useProjectSelection.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useProjectList } from "@/hooks/useProjectList";
+import type { ProjectListItem } from "@/types/project.model";
+
+export interface UseProjectSelectionOptions {
+  initialProjectId: number | null;
+}
+
+export interface UseProjectSelectionResult {
+  selectedProjectId: number | null;
+  setSelectedProjectId: (id: number | null) => void;
+  initialProjectId: number | null;
+  projectList: ProjectListItem[];
+  projectNames: string[];
+  nameToId: Map<string, number>;
+  projectNameById: (id?: number | null) => string;
+  loading: boolean;
+}
+
+export function useProjectSelection({
+  initialProjectId,
+}: UseProjectSelectionOptions): UseProjectSelectionResult {
+  const { data: projectList = [], loading } = useProjectList();
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (initialProjectId != null) setSelectedProjectId(Number(initialProjectId));
+  }, [initialProjectId]);
+
+  const projectNames = useMemo(
+    () => projectList.map((p) => p.name),
+    [projectList]
+  );
+  const nameToId = useMemo(
+    () => new Map(projectList.map((p) => [p.name, p.id])),
+    [projectList]
+  );
+  const projectNameById = useCallback(
+    (id?: number | null) => projectList.find((p) => p.id === id)?.name ?? "",
+    [projectList]
+  );
+
+  return {
+    selectedProjectId,
+    setSelectedProjectId,
+    initialProjectId,
+    projectList,
+    projectNames,
+    nameToId,
+    projectNameById,
+    loading,
+  };
+}

--- a/src/shared/hooks/useSummaryPolling.ts
+++ b/src/shared/hooks/useSummaryPolling.ts
@@ -1,0 +1,114 @@
+import { useEffect } from "react";
+import { isAxiosError } from "axios";
+import { getSummaryStatus } from "@/api/post.api";
+import { startRefresh } from "@/api/axios";
+import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
+
+export interface UseSummaryPollingOptions {
+  postId: number | null;
+  summaryTaskId: string | null;
+  isActive: boolean;
+  onProgress: (progress: number) => void;
+  onStatus: (status: SummaryStatus | null) => void;
+  onMessage: (message: string) => void;
+  onComplete: (postSummaryId?: number) => void;
+}
+
+export function useSummaryPolling({
+  postId,
+  summaryTaskId,
+  isActive,
+  onProgress,
+  onStatus,
+  onMessage,
+  onComplete,
+}: UseSummaryPollingOptions) {
+  useEffect(() => {
+    if (!isActive || !postId || !summaryTaskId) return;
+
+    let stopped = false;
+    let timer: number | null = null;
+
+    const tick = async () => {
+      const awaitRefreshIfAny = async () => {
+        const p = (window as any).__authRefreshPromise as Promise<
+          string | null
+        > | null;
+        if (p) {
+          try {
+            await p;
+          } catch {
+            /* ignore */
+          }
+        }
+      };
+
+      try {
+        await awaitRefreshIfAny();
+
+        const fetchOnce = () =>
+          getSummaryStatus(postId, summaryTaskId, {
+            __skipGlobalAuthGuard: true,
+          });
+
+        let data: any;
+        try {
+          data = await fetchOnce();
+        } catch (e) {
+          if (isAxiosError(e) && e.response?.status === 401) {
+            const inflight = (window as any).__authRefreshPromise as Promise<
+              string | null
+            > | null;
+            const token = inflight ? await inflight : await startRefresh();
+            if (!token) throw e;
+
+            data = await getSummaryStatus(postId, summaryTaskId, {
+              __skipGlobalAuthGuard: true,
+              headers: { Authorization: `Bearer ${token}` },
+            });
+          } else {
+            throw e;
+          }
+        }
+
+        if (stopped) return;
+
+        const p = Math.max(0, Math.min(100, data?.progress ?? 0));
+        onProgress(p);
+        if (data?.status) onStatus(data.status as SummaryStatus);
+
+        if (data?.currentStep) onMessage(data.currentStep);
+        else if (data?.message) onMessage(data.message);
+        else if (
+          data?.result &&
+          typeof data.result === "object" &&
+          "message" in (data.result as any)
+        ) {
+          onMessage((data.result as any).message ?? "");
+        }
+
+        if (data?.status === "COMPLETED" || p >= 100) {
+          onProgress(100);
+          onComplete(typeof data?.postSummaryId === "number" ? data.postSummaryId : undefined);
+          if (timer !== null) {
+            clearInterval(timer);
+            timer = null;
+          }
+        }
+      } catch (err) {
+        console.error("poll tick error:", err);
+      }
+    };
+
+    tick();
+    timer = window.setInterval(tick, 1200);
+
+    return () => {
+      stopped = true;
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+  }, [isActive, postId, summaryTaskId, onProgress, onStatus, onMessage, onComplete]);
+}

--- a/src/shared/hooks/useSummaryPolling.ts
+++ b/src/shared/hooks/useSummaryPolling.ts
@@ -87,9 +87,21 @@ export function useSummaryPolling({
           onMessage((data.result as any).message ?? "");
         }
 
-        if (data?.status === "COMPLETED" || p >= 100) {
-          onProgress(100);
-          onComplete(typeof data?.postSummaryId === "number" ? data.postSummaryId : undefined);
+        const isTerminal =
+          data?.status === "COMPLETED" ||
+          data?.status === "FAILED" ||
+          data?.status === "CANCELLED" ||
+          p >= 100;
+
+        if (isTerminal) {
+          if (data?.status === "COMPLETED" || p >= 100) {
+            onProgress(100);
+            onComplete(
+              typeof data?.postSummaryId === "number" ? data.postSummaryId : undefined
+            );
+          } else {
+            onComplete(undefined);
+          }
           if (timer !== null) {
             clearInterval(timer);
             timer = null;

--- a/src/shared/hooks/useWriteModals.ts
+++ b/src/shared/hooks/useWriteModals.ts
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+export interface UseWriteModalsResult {
+  // 저장/요약 모달
+  isPostSaveModalOpen: boolean;
+  setIsPostSaveModalOpen: (v: boolean) => void;
+  isTemplateSelectModalOpen: boolean;
+  setIsTemplateSelectModalOpen: (v: boolean) => void;
+  isLoadingModalOpen: boolean;
+  setIsLoadingModalOpen: (v: boolean) => void;
+  isSuccessModalOpen: boolean;
+  setIsSuccessModalOpen: (v: boolean) => void;
+  // 토스트 알림
+  showAlert: boolean;
+  setShowAlert: (v: boolean) => void;
+  showSaveAlert: boolean;
+  setShowSaveAlert: (v: boolean) => void;
+  showCancelAlert: boolean;
+  setShowCancelAlert: (v: boolean) => void;
+}
+
+export function useWriteModals(): UseWriteModalsResult {
+  const [isPostSaveModalOpen, setIsPostSaveModalOpen] = useState(false);
+  const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
+    useState(false);
+  const [isLoadingModalOpen, setIsLoadingModalOpen] = useState(false);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [showSaveAlert, setShowSaveAlert] = useState(false);
+  const [showCancelAlert, setShowCancelAlert] = useState(false);
+
+  return {
+    isPostSaveModalOpen,
+    setIsPostSaveModalOpen,
+    isTemplateSelectModalOpen,
+    setIsTemplateSelectModalOpen,
+    isLoadingModalOpen,
+    setIsLoadingModalOpen,
+    isSuccessModalOpen,
+    setIsSuccessModalOpen,
+    showAlert,
+    setShowAlert,
+    showSaveAlert,
+    setShowSaveAlert,
+    showCancelAlert,
+    setShowCancelAlert,
+  };
+}

--- a/src/shared/hooks/useWriteSummaryFlow.ts
+++ b/src/shared/hooks/useWriteSummaryFlow.ts
@@ -1,0 +1,138 @@
+import { useCallback } from "react";
+import { editPost, startSummary, cancelSummary } from "@/api/post.api";
+import type { EditPostRequest } from "@/models/post.model";
+import type { SummaryTypeParam, StartLoadingResponse } from "@/models/post.model";
+import type { SummaryStatus } from "@/shared/ui/Modal/PostLoadingModal";
+
+export interface UseWriteSummaryFlowOptions {
+  postId: number | null;
+  summaryTaskId: string | null;
+  summaryProgress: number;
+  setSummaryTaskId: (v: string | null) => void;
+  setSummaryProgress: (v: number) => void;
+  setSummaryStatus: (v: SummaryStatus | null) => void;
+  setStatusMessage: (v: string) => void;
+  setTemplateLabel: (v: string) => void;
+  setIsTemplateSelectModalOpen: (v: boolean) => void;
+  setIsLoadingModalOpen: (v: boolean) => void;
+  setCreatedPostId: (v: number | null) => void;
+  setShowCancelAlert: (v: boolean) => void;
+  /** ms to show cancel toast after closing loading modal. Default 3000. */
+  cancelAlertDuration?: number;
+}
+
+export interface UseWriteSummaryFlowResult {
+  /** 요약 시작: 수정 API 호출 후 startSummary, 모달/상태 업데이트. getEditRequestBody는 페이지에서 buildEditFormFromMeta 등으로 생성한 EditPostRequest 반환 */
+  runConfirmTemplate: (
+    type: SummaryTypeParam,
+    label: string,
+    getEditRequestBody: () => Promise<EditPostRequest>
+  ) => Promise<void>;
+  /** 로딩 모달 닫기(요약 취소). closingRef는 페이지에서 관리해 중복 호출 방지 */
+  closeLoadingModal: (closingRef: { current: boolean }) => Promise<void>;
+}
+
+export function useWriteSummaryFlow(
+  options: UseWriteSummaryFlowOptions
+): UseWriteSummaryFlowResult {
+  const {
+    postId,
+    summaryTaskId,
+    summaryProgress,
+    setSummaryTaskId,
+    setSummaryProgress,
+    setSummaryStatus,
+    setStatusMessage,
+    setTemplateLabel,
+    setIsTemplateSelectModalOpen,
+    setIsLoadingModalOpen,
+    setCreatedPostId,
+    setShowCancelAlert,
+    cancelAlertDuration = 3000,
+  } = options;
+
+  const runConfirmTemplate = useCallback(
+    async (
+      type: SummaryTypeParam,
+      label: string,
+      getEditRequestBody: () => Promise<EditPostRequest>
+    ) => {
+      if (!postId) return;
+      try {
+        const body = await getEditRequestBody();
+        await editPost(postId, body);
+
+        setIsTemplateSelectModalOpen(false);
+        setIsLoadingModalOpen(true);
+        setSummaryProgress(0);
+        setSummaryStatus(null);
+        setStatusMessage("");
+        setTemplateLabel(label);
+
+        const res: StartLoadingResponse = await startSummary(postId, type);
+        const taskId =
+          (res as any).taskId ??
+          (res as any).data?.taskId ??
+          (res as any).content?.taskId;
+
+        if (!taskId) throw new Error("요약 작업 ID(taskId)를 찾을 수 없어요.");
+        setSummaryTaskId(taskId);
+      } catch (e) {
+        console.error(e);
+        setIsLoadingModalOpen(false);
+        setIsTemplateSelectModalOpen(true);
+        setSummaryTaskId(null);
+        setCreatedPostId(null);
+        setSummaryProgress(0);
+        setSummaryStatus(null);
+        setStatusMessage("요약 시작에 실패했어요. 잠시 후 다시 시도해주세요.");
+      }
+    },
+    [
+      postId,
+      setSummaryTaskId,
+      setSummaryProgress,
+      setSummaryStatus,
+      setStatusMessage,
+      setTemplateLabel,
+      setIsTemplateSelectModalOpen,
+      setIsLoadingModalOpen,
+      setCreatedPostId,
+    ]
+  );
+
+  const closeLoadingModal = useCallback(
+    async (closingRef: { current: boolean }) => {
+      if (closingRef.current) return;
+      closingRef.current = true;
+      try {
+        if (summaryProgress < 100 && postId && summaryTaskId) {
+          try {
+            await cancelSummary(postId, summaryTaskId);
+          } catch (e) {
+            console.error("요약 작업 취소 실패:", e);
+          }
+        }
+        setIsLoadingModalOpen(false);
+        setSummaryTaskId(null);
+        setSummaryProgress(0);
+        setShowCancelAlert(true);
+        setTimeout(() => setShowCancelAlert(false), cancelAlertDuration);
+      } finally {
+        closingRef.current = false;
+      }
+    },
+    [
+      postId,
+      summaryTaskId,
+      summaryProgress,
+      setIsLoadingModalOpen,
+      setSummaryTaskId,
+      setSummaryProgress,
+      setShowCancelAlert,
+      cancelAlertDuration,
+    ]
+  );
+
+  return { runConfirmTemplate, closeLoadingModal };
+}

--- a/src/shared/hooks/useWriteSummaryFlow.ts
+++ b/src/shared/hooks/useWriteSummaryFlow.ts
@@ -46,7 +46,6 @@ export function useWriteSummaryFlow(
     setTemplateLabel,
     setIsTemplateSelectModalOpen,
     setIsLoadingModalOpen,
-    setCreatedPostId,
     setShowCancelAlert,
     cancelAlertDuration = 3000,
   } = options;
@@ -82,7 +81,6 @@ export function useWriteSummaryFlow(
         setIsLoadingModalOpen(false);
         setIsTemplateSelectModalOpen(true);
         setSummaryTaskId(null);
-        setCreatedPostId(null);
         setSummaryProgress(0);
         setSummaryStatus(null);
         setStatusMessage("요약 시작에 실패했어요. 잠시 후 다시 시도해주세요.");
@@ -97,7 +95,6 @@ export function useWriteSummaryFlow(
       setTemplateLabel,
       setIsTemplateSelectModalOpen,
       setIsLoadingModalOpen,
-      setCreatedPostId,
     ]
   );
 

--- a/src/shared/ui/WriteToast.tsx
+++ b/src/shared/ui/WriteToast.tsx
@@ -1,0 +1,28 @@
+interface WriteToastProps {
+  show: boolean;
+  message: string;
+  /** default: 보라 배경, success: 흰 배경(저장 완료 등) */
+  variant?: "default" | "success";
+}
+
+const BASE_CLASS =
+  "fixed top-4 left-1/2 -translate-x-1/2 z-[9999] max-w-[92vw] border border-purple-400 text-purple-700 px-4 py-2 rounded-md shadow-lg transition-all duration-300 ease-in-out";
+
+export function WriteToast({
+  show,
+  message,
+  variant = "default",
+}: WriteToastProps) {
+  if (!show) return null;
+
+  const bgClass =
+    variant === "success"
+      ? "bg-white"
+      : "bg-purple-100";
+
+  return (
+    <div className={`${BASE_CLASS} ${bgClass}`}>
+      {message}
+    </div>
+  );
+}

--- a/src/shared/utils/canonicalizeTags.ts
+++ b/src/shared/utils/canonicalizeTags.ts
@@ -1,0 +1,37 @@
+import { getTagsByKeyword } from "@/api/post.api";
+
+/**
+ * 태그 문자열 목록 → API로 정규화된 태그 목록 (TempWrite/FreeFormWrite 공통)
+ * # 접두사 제거, 중복 제거, API 매칭으로 정규화
+ */
+export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of rawTags) {
+    const q = String(raw).replace(/^#\s*/, "").trim();
+    if (!q) continue;
+
+    const res = await getTagsByKeyword({ tagName: q });
+    const resList: unknown = Array.isArray(res)
+      ? res
+      : (res as { data?: unknown })?.data ??
+        (res as { content?: unknown })?.content ??
+        (res as { results?: unknown })?.results;
+    const list: unknown[] = Array.isArray(resList) ? resList : [];
+    const names = list
+      .map((t) =>
+        typeof t === "string" ? t : (t as { name?: string })?.name ?? t
+      )
+      .filter(Boolean) as string[];
+    const exact = names.find((n) => n.toLowerCase() === q.toLowerCase());
+    const pick = (exact ?? names[0]) as string | undefined;
+    const normalized = String(pick ?? q).trim();
+
+    if (!seen.has(normalized.toLowerCase())) {
+      seen.add(normalized.toLowerCase());
+      out.push(normalized);
+    }
+  }
+  return out;
+}

--- a/src/shared/utils/canonicalizeTags.ts
+++ b/src/shared/utils/canonicalizeTags.ts
@@ -13,12 +13,7 @@ export async function canonicalizeTags(rawTags: string[]): Promise<string[]> {
     if (!q) continue;
 
     const res = await getTagsByKeyword({ tagName: q });
-    const resList: unknown = Array.isArray(res)
-      ? res
-      : (res as { data?: unknown })?.data ??
-        (res as { content?: unknown })?.content ??
-        (res as { results?: unknown })?.results;
-    const list: unknown[] = Array.isArray(resList) ? resList : [];
+    const list = Array.isArray(res) ? res : [];
     const names = list
       .map((t) =>
         typeof t === "string" ? t : (t as { name?: string })?.name ?? t

--- a/src/shared/utils/errorCodeLabel.ts
+++ b/src/shared/utils/errorCodeLabel.ts
@@ -1,0 +1,20 @@
+/** 에러 코드 → 표시 라벨 매핑 (TempWrite/FreeFormWrite 공통) */
+export const ERROR_CODE_TO_LABEL: Record<string, string> = {
+  BUILD_COMPILE_ERROR: "Build/Compile Error",
+  RUNTIME_ERROR: "Runtime Error",
+  DEPENDENCY_VERSION_ERROR: "Dependency/Version Error",
+  NETWORK_API_ERROR: "Network/API Error",
+  AUTHENTICATION_AUTHORIZATION_ERROR: "Authentication/Authorization Error",
+  DATABASE_ERROR: "Database Error",
+  UI_RENDERING_ERROR: "UI/Rendering Error",
+  CONFIGURATION_ERROR: "Configuration Error",
+  TIMEOUT_ERROR_HANDLING: "Timeout/Error Handling",
+  THIRD_PARTY_LIBRARY_ERROR: "Third-Party Library Error",
+};
+
+/** 에러 코드 → 표시용 라벨 (없으면 코드 그대로) */
+export const toErrorLabel = (code?: string | null) =>
+  code ? ERROR_CODE_TO_LABEL[code] ?? code : null;
+
+/** 에러 선택 드롭다운용 옵션 목록 */
+export const ERROR_OPTIONS = Object.values(ERROR_CODE_TO_LABEL);

--- a/src/widgets/mypage/TroubleShootingList.tsx
+++ b/src/widgets/mypage/TroubleShootingList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import SortButtonGroup from "@/entities/project/ui/SortButtonGroup";
 import TroubleShootingCard from "@/entities/trouble/ui/TroubleShootingCard";
 import { mapToTroubleShootingCard } from "@/entities/trouble/card-compat.mapper";
@@ -142,6 +142,10 @@ const TroubleShootingList = () => {
     }
   };
 
+  const handleSummaryDeleted = useCallback(() => {
+    reload();
+  }, [reload]);
+
   return (
     <div className="w-full max-w-[948px] mx-auto px-4 sm:px-0 flex flex-col gap-6 sm:gap-10 pb-16 sm:pb-[78px]">
       {/* 정렬 기준 선택 (우측 정렬 유지) */}
@@ -179,9 +183,14 @@ const TroubleShootingList = () => {
             (card as any).summaryType ?? baseVm.summaryType
           );
 
+          // '원본+요약본' 탭에서만 summaryId 유지 → 요약본 삭제 + 삭제 노출. 그 외 탭은 원본만으로 간주 → 삭제(원본 삭제)만 노출
           const vm = {
             ...baseVm,
             summaryType: summaryTypeLabel,
+            summaryId:
+              selectedStatus === "created"
+                ? baseVm.summaryId
+                : undefined,
           };
 
           return (
@@ -189,6 +198,7 @@ const TroubleShootingList = () => {
               key={(card as any).summaryId ?? card.id} // 요약본 탭에서 summaryId 기준으로 유니크 키 주면 더 안전
               {...vm}
               onDeleted={handleDeleted}
+              onSummaryDeleted={handleSummaryDeleted}
               onClick={() => {
                 const ownerIdForState = isMyPage
                   ? viewerId != null
@@ -209,6 +219,18 @@ const TroubleShootingList = () => {
                 }
 
                 const slug = makePostSlug(vm.title, card.id);
+
+                // 0) 내 글 + 작성중: 이어쓰기(가이드/자유형은 진입 후 상세 조회로 분기)
+                if (isMyPage && statusFromList === "inProgress") {
+                  navigate(PATH.TEMP_WRITING, {
+                    state: {
+                      from: "mypage",
+                      postId: card.id,
+                      projectId: (card as any).projectId,
+                    },
+                  });
+                  return;
+                }
 
                 // 1) 내 마이페이지 + '원본+요약본' 탭일 때만 합본 라우팅
                 if (isMyPage && selectedStatus === "created") {


### PR DESCRIPTION
## 🔥 Issues

- closed #188 

## ✅ What to do

- [x] TempWritePage, FreeFormWritePage의 중복 로직을 공통 훅·유틸·컴포넌트로 추출하여 가독성과 유지보수성을 개선

## 📄 Description

### 공통 유틸
- **`shared/utils/errorCodeLabel.ts`** — 에러 코드 → 라벨 매핑 (`ERROR_OPTIONS`, `toErrorLabel`)
- **`shared/utils/canonicalizeTags.ts`** — 태그 정규화 (`canonicalizeTags`)

### 공통 훅
- **`shared/hooks/useSummaryPolling.ts`** — 요약 상태 폴링 (getSummaryStatus, 401 재시도, progress/status 반영)
- **`shared/hooks/useProjectSelection.ts`** — 프로젝트 목록·선택 (useProjectList, selectedProjectId, projectNames, nameToId, projectNameById)
- **`shared/hooks/useWriteModals.ts`** — 저장/요약 모달·토스트 열림 상태 (PostSave, TemplateSelect, Loading, Success 모달 + alert 토스트)
- **`shared/hooks/useWriteSummaryFlow.ts`** — 요약 시작 플로우 (editPost → startSummary, 로딩 모달 열기/닫기·취소)

### 공통 UI
- **`shared/ui/WriteToast.tsx`** — 고정 토스트 (show, message, variant)
- **`shared/components/WritePageMetaSection.tsx`** — 제목 input + 프로젝트/에러 드롭다운 + 태그 (선택적 `actions` 슬롯)

### 반영 페이지
- **TempWritePage** — 위 훅·컴포넌트 사용, 인라인 로직·중복 제거
- **FreeFormWritePage** — 동일 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 통합된 프로젝트 선택 훅과 재사용 가능한 메타 섹션 컴포넌트 추가
  * 요약 실행/취소 흐름 훅과 요약 상태 폴링 훅 추가
  * 일관된 토스트 컴포넌트 및 태그 정규화 유틸리티 추가
  * 요약 삭제 이벤트를 받은 후 리프레시하는 콜백 추가

* **개선 사항**
  * 모달·토스트·경고 상태 통합으로 UX 간결화
  * 오류 라벨 일괄화 및 삭제 액션 문구·표현 개선
  * 요약 폴링·취소 안정성 및 전반적 흐름 구성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->