### PR TITLE
[FEAT] 신고 생성 API 연동

### DIFF
--- a/src/api/report.api.ts
+++ b/src/api/report.api.ts
@@ -1,0 +1,39 @@
+import getAPIResponseData from "@/utils/getAPIResponseData";
+import api from "./axios";
+
+/** 신고 대상 타입 */
+export type ReportTargetType = "POST" | "COMMENT";
+
+/** 신고 사유 (API reportType) */
+export type ReportType =
+  | "SPAM"
+  | "INFO"
+  | "BLAME"
+  | "PRIVACY"
+  | "SUBJECT"
+  | "COPYRIGHT";
+
+export interface CreateReportBody {
+  reportedUserId: number;
+  targetType: ReportTargetType;
+  targetId: number;
+  reportType: ReportType;
+  copyrightImgUrl?: string;
+}
+
+/**
+ * 신고 생성 API
+ * POST /reports
+ */
+export function createReport(body: CreateReportBody): Promise<void> {
+  const payload: Record<string, unknown> = {
+    reportedUserId: body.reportedUserId,
+    targetType: body.targetType,
+    targetId: body.targetId,
+    reportType: body.reportType,
+    copyrightImgUrl: body.copyrightImgUrl ?? "",
+  };
+  return getAPIResponseData<void>(
+    api.post("/reports", payload)
+  ).then(() => undefined);
+}

--- a/src/pages/Community/CommunityPostDetail.tsx
+++ b/src/pages/Community/CommunityPostDetail.tsx
@@ -1,3 +1,4 @@
+import { createReport } from "@/api/report.api";
 import ConfirmDeleteModal from "@/shared/ui/Modal/ConfirmDeleteModal";
 import ReportModal from "@/shared/ui/Modal/ReportModal";
 import { PostDetailContent } from "./components/PostDetailContent";
@@ -29,6 +30,7 @@ export default function CommunityPostDetail() {
     open: false,
     message: "",
   });
+  const [reportSubmitting, setReportSubmitting] = useState(false);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showToast = useCallback((message: string) => {
     setToast({ open: true, message });
@@ -392,20 +394,71 @@ export default function CommunityPostDetail() {
       )}
 
       {/* 신고 모달 */}
-      {reportModalOpen && (
+      {reportModalOpen && reportTarget && post && (
         <ReportModal
           onClose={() => {
             setReportModalOpen(false);
             setReportTarget(null);
           }}
-          onSubmit={(reason) => {
-            // TODO: 신고 API 연동
-            void reason;
-            void reportTarget;
+          loading={reportSubmitting}
+          onSubmit={async (reportType, copyrightImgUrl) => {
+            let reportedUserId: number | undefined;
+            const targetType = reportTarget.type === "post" ? "POST" : "COMMENT";
+            const targetId =
+              reportTarget.type === "post"
+                ? reportTarget.postId
+                : Number(reportTarget.commentId);
 
-            showToast("신고가 접수되었습니다.");
-            setReportModalOpen(false);
-            setReportTarget(null);
+            if (reportTarget.type === "post") {
+              reportedUserId = post.authorId;
+            } else {
+              const comment = comments.find((c) => c.id === reportTarget.commentId);
+              reportedUserId = comment?.userId;
+            }
+
+            if (reportedUserId == null || !Number.isFinite(reportedUserId)) {
+              showToast("신고 대상을 찾을 수 없어요.");
+              return;
+            }
+            if (reportTarget.type === "comment" && !Number.isFinite(targetId)) {
+              showToast("잘못된 댓글 정보예요.");
+              return;
+            }
+            const viewerId = detailCtx.viewerId ?? null;
+            if (viewerId != null && reportedUserId === viewerId) {
+              showToast("자기 자신은 신고할 수 없어요.");
+              return;
+            }
+
+            try {
+              setReportSubmitting(true);
+              await createReport({
+                reportedUserId,
+                targetType,
+                targetId,
+                reportType,
+                ...(copyrightImgUrl && { copyrightImgUrl }),
+              });
+              showToast("신고가 접수되었습니다.");
+              setReportModalOpen(false);
+              setReportTarget(null);
+            } catch (err: unknown) {
+              const res = (err as { response?: { status?: number; data?: { error?: { status?: string } } } })
+                ?.response;
+              const httpConflict = res?.status === 409;
+              const bodyConflict = res?.data?.error?.status === "CONFLICT";
+              const serverMsg = (err as { response?: { data?: { error?: { message?: string } } } })
+                ?.response?.data?.error?.message;
+              const msg =
+                httpConflict || bodyConflict
+                  ? "이미 신고했거나 신고할 수 없는 대상이에요."
+                  : serverMsg ?? "신고 접수에 실패했어요. 잠시 후 다시 시도해주세요.";
+              showToast(msg);
+              setReportModalOpen(false);
+              setReportTarget(null);
+            } finally {
+              setReportSubmitting(false);
+            }
           }}
         />
       )}

--- a/src/shared/constants/reportReasons.ts
+++ b/src/shared/constants/reportReasons.ts
@@ -1,0 +1,17 @@
+import type { ReportType } from "@/api/report.api";
+
+/** 신고 사유 옵션 (API reportType + 표시 라벨) */
+export const REPORT_OPTIONS: { reportType: ReportType; label: string }[] = [
+  { reportType: "SPAM", label: "스팸 및 홍보성 게시글" },
+  { reportType: "INFO", label: "기술적 오류 및 잘못된 정보" },
+  { reportType: "BLAME", label: "비방, 욕설 및 혐오 표현" },
+  { reportType: "PRIVACY", label: "개인정보노출" },
+  { reportType: "SUBJECT", label: "주제와 맞지 않는 게시글" },
+  { reportType: "COPYRIGHT", label: "저작권 침해 및 무단 전재" },
+];
+
+/** 하위 호환: 라벨만의 배열 */
+export const REPORT_REASONS = REPORT_OPTIONS.map(
+  (o) => o.label,
+) as unknown as readonly [string, string, string, string, string, string];
+export type ReportReason = (typeof REPORT_REASONS)[number];

--- a/src/shared/ui/Modal/ReportModal.tsx
+++ b/src/shared/ui/Modal/ReportModal.tsx
@@ -1,23 +1,18 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import BaseModal from "./BaseModal";
 import exitIcon from "@/assets/icons/exiticon.svg";
 import unselectedCircle from "@/assets/icons/unselected_circle.svg";
 import selectedCircle from "@/assets/icons/selected_circle.svg";
+import type { ReportType } from "@/api/report.api";
+import { uploadImage } from "@/api/image.api";
+import { REPORT_OPTIONS } from "@/shared/constants/reportReasons";
 
-export const REPORT_REASONS = [
-  "스팸 및 홍보성 게시글",
-  "기술적 오류 및 잘못된 정보",
-  "저작권 침해 및 무단 전재",
-  "비방, 욕설 및 혐오 표현",
-  "주제와 맞지 않는 게시글",
-  "개인정보노출",
-] as const;
-
-export type ReportReason = (typeof REPORT_REASONS)[number];
+const MAX_MB = 8;
 
 interface ReportModalProps {
   onClose: () => void;
-  onSubmit?: (reason: ReportReason) => void;
+  /** reportType, 저작권 시 선택적 copyrightImgUrl */
+  onSubmit?: (reportType: ReportType, copyrightImgUrl?: string) => void;
   /** 권리침해 신고 페이지 URL (미제공 시 링크 비활성화) */
   rightsViolationReportUrl?: string;
   loading?: boolean;
@@ -29,13 +24,74 @@ export default function ReportModal({
   rightsViolationReportUrl,
   loading = false,
 }: ReportModalProps) {
-  const [selectedReason, setSelectedReason] = useState<ReportReason>(
-    REPORT_REASONS[0],
+  const [selectedReportType, setSelectedReportType] = useState<ReportType>(
+    REPORT_OPTIONS[0].reportType,
   );
+  const [copyrightImgUrl, setCopyrightImgUrl] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [tempPreview, setTempPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isCopyright = selectedReportType === "COPYRIGHT";
 
   const handleSubmit = () => {
-    if (!selectedReason) return;
-    onSubmit?.(selectedReason);
+    if (!selectedReportType) return;
+    if (isUploading) {
+      alert("이미지 업로드가 끝난 후 신고할 수 있어요.");
+      return;
+    }
+    onSubmit?.(selectedReportType, copyrightImgUrl ?? undefined);
+  };
+
+  const handleCopyrightImageSelect = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      alert("이미지 파일만 업로드할 수 있어요.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+    if (file.size > MAX_MB * 1024 * 1024) {
+      alert(`파일 용량이 너무 커요. 최대 ${MAX_MB}MB까지 가능합니다.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    if (tempPreview) URL.revokeObjectURL(tempPreview);
+    const localUrl = URL.createObjectURL(file);
+    setTempPreview(localUrl);
+
+    try {
+      setIsUploading(true);
+      setUploadProgress(0);
+      const serverUrl = await uploadImage(file, (p) => setUploadProgress(p));
+      setCopyrightImgUrl(serverUrl);
+      if (localUrl) URL.revokeObjectURL(localUrl);
+      setTempPreview(null);
+    } catch (err: unknown) {
+      console.error(err);
+      alert(
+        (err as { message?: string })?.message ?? "이미지 업로드에 실패했습니다.",
+      );
+      setCopyrightImgUrl(null);
+    } finally {
+      setIsUploading(false);
+      setUploadProgress(0);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleRemoveCopyrightImage = () => {
+    if (tempPreview) {
+      URL.revokeObjectURL(tempPreview);
+      setTempPreview(null);
+    }
+    setCopyrightImgUrl(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   return (
@@ -61,20 +117,20 @@ export default function ReportModal({
 
       {/* 신고 사유 라디오 그룹 (2열) */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-5 sm:gap-x-6 gap-y-7 sm:gap-y-9 w-full mt-5 mb-5 px-8 sm:px-12">
-        {REPORT_REASONS.map((reason) => {
-          const isSelected = selectedReason === reason;
+        {REPORT_OPTIONS.map(({ reportType, label }) => {
+          const isSelected = selectedReportType === reportType;
           return (
             <label
-              key={reason}
+              key={reportType}
               className="flex items-center gap-3 cursor-pointer group"
             >
               <span className="relative shrink-0 w-6 h-6 flex items-center justify-center">
                 <input
                   type="radio"
                   name="reportReason"
-                  value={reason}
+                  value={reportType}
                   checked={isSelected}
-                  onChange={() => setSelectedReason(reason)}
+                  onChange={() => setSelectedReportType(reportType)}
                   className="sr-only"
                 />
                 <img
@@ -85,12 +141,21 @@ export default function ReportModal({
                 />
               </span>
               <span className="text-body-14-regular sm:text-body-16-regular text-black group-hover:text-gray4">
-                {reason}
+                {label}
               </span>
             </label>
           );
         })}
       </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="sr-only"
+        aria-label="서류 이미지 선택"
+        onChange={handleCopyrightImageSelect}
+      />
 
       {/* 안내 텍스트 */}
       <p className="text-body-16-regular text-[#525252] mt-6 mb-2 leading-relaxed px-8 sm:px-12 whitespace-pre-line text-left">
@@ -99,31 +164,62 @@ export default function ReportModal({
 추가 서류가 접수되지 않을 경우, 신고 건이 처리되지 않습니다.`}
       </p>
 
-      {/* 권리침해 신고하기 링크 (URL 제공 시에만 렌더링) */}
-      {rightsViolationReportUrl &&
-      rightsViolationReportUrl !== "#" &&
-      rightsViolationReportUrl.trim() !== "" ? (
-        <a
-          href={rightsViolationReportUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-body-16-regular text-[#525252] hover:opacity-90 mt-3 mb-8 inline-flex items-center gap-0.5 px-8 sm:px-12"
-        >
-          <span className="underline">권리침해 신고하기</span>
-          &gt;
-        </a>
-      ) : (
-        <span className="text-body-16-regular text-gray2 mt-3 mb-8 inline-flex items-center gap-0.5 px-8 sm:px-12 cursor-default">
-          권리침해 신고하기 &gt;
-        </span>
-      )}
+      {/* 권리침해 신고하기: 저작권 선택 시 이미지 업로드, 아니면 외부 링크 또는 비활성 */}
+      <div className="mt-3 mb-8 px-8 sm:px-12 flex flex-wrap items-center gap-2">
+        {isCopyright ? (
+          <>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-body-16-regular text-gray-800 underline underline-offset-2 hover:text-black transition"
+            >
+              권리침해 신고하기 &gt;
+            </button>
+            {isUploading && (
+              <span className="text-body-14-regular text-gray4">
+                업로드 중… {uploadProgress}%
+              </span>
+            )}
+            {!isUploading && copyrightImgUrl && (
+              <>
+                <span className="text-body-14-regular text-gray4">(첨부됨)</span>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemoveCopyrightImage();
+                  }}
+                  className="text-body-14-regular text-gray4 underline underline-offset-1 hover:opacity-80"
+                >
+                  제거
+                </button>
+              </>
+            )}
+          </>
+        ) : rightsViolationReportUrl &&
+          rightsViolationReportUrl !== "#" &&
+          rightsViolationReportUrl.trim() !== "" ? (
+          <a
+            href={rightsViolationReportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-body-16-regular text-gray-800 underline underline-offset-2 hover:text-black transition inline-flex items-center gap-0.5"
+          >
+            권리침해 신고하기 &gt;
+          </a>
+        ) : (
+          <span className="text-body-16-regular text-gray2 cursor-default">
+            권리침해 신고하기 &gt;
+          </span>
+        )}
+      </div>
 
       {/* 신고하기 버튼 */}
       <div className="flex justify-center w-full">
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={!selectedReason || loading}
+          disabled={!selectedReportType || loading}
           className="w-full max-w-[200px] sm:max-w-[160px] py-3 sm:py-[16px] min-h-[44px] sm:min-h-0 rounded-xl bg-primary text-white text-head-16-semibold sm:text-head-18-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition"
         >
           {loading ? "처리 중..." : "신고하기"}


### PR DESCRIPTION
## ✅ What to do

- [x] 신고 생성 API 연동

## 📄 Description

### API
- **`/reports` POST** 연동 (`src/api/report.api.ts`)
  - `reportedUserId`, `targetType`(POST/COMMENT), `targetId`, `reportType`, `copyrightImgUrl`(항상 전송, 미첨부 시 `""`)

### 신고 모달
- 신고 사유를 API `reportType`(SPAM, INFO, BLAME, PRIVACY, SUBJECT, COPYRIGHT)과 매핑
- **저작권 침해 및 무단 전재** 선택 시: **권리침해 신고하기 >** 클릭으로 이미지 업로드 (공통 이미지 API 사용), 첨부/제거·업로드 진행률 표시
- 권리침해 신고하기 버튼 스타일: 진한 글자색 + 밑줄

### 상세 페이지 연동
- 게시글 신고: `reportedUserId` = 글 작성자, `targetType: POST`, `targetId: postId`
- 댓글 신고: `reportedUserId` = 댓글 작성자, `targetType: COMMENT`, `targetId: commentId`
- 자기 자신 신고 시 API 호출 없이 토스트로 안내
- **예외 응답**(409/CONFLICT 등) 시에도 모달 닫고 토스트로 안내 (성공과 동일한 흐름)

## 참고
- 신고 사유 상수: `src/shared/constants/reportReasons.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 커뮤니티 게시물 및 댓글 신고 기능 추가
  * 저작권 침해 신고 시 이미지 첨부 기능 지원
  * 신고 사유 확대: 스팸, 정보성 광고, 명예훼손, 개인정보 침해, 주제 위반, 저작권 침해

<!-- end of auto-generated comment: release notes by coderabbit.ai -->