### PR TITLE
FEAT: 포스트 상세 상단 태그 클릭 UI 및 라우팅 로직 개발

### DIFF
--- a/src/entities/trouble/ui/TagList.tsx
+++ b/src/entities/trouble/ui/TagList.tsx
@@ -34,10 +34,10 @@ export default function TagList({
     <div
       className={`flex flex-nowrap items-center overflow-hidden ${wrapperClass}`}
     >
-      {tags.map((tag) =>
+      {tags.map((tag, index) =>
         onTagClick ? (
           <button
-            key={tag}
+            key={`${tag}-${index}`}
             type="button"
             className={getTagClass()}
             title={tag}
@@ -46,7 +46,7 @@ export default function TagList({
             #{tag}
           </button>
         ) : (
-          <div key={tag} className={getTagClass()} title={tag}>
+          <div key={`${tag}-${index}`} className={getTagClass()} title={tag}>
             #{tag}
           </div>
         ),

--- a/src/entities/trouble/ui/TagList.tsx
+++ b/src/entities/trouble/ui/TagList.tsx
@@ -1,15 +1,27 @@
 interface TagListProps {
   tags: string[];
   variant?: "default" | "post" | "mypage";
+  onTagClick?: (tag: string) => void;
 }
 
-export default function TagList({ tags, variant = "default" }: TagListProps) {
+export default function TagList({
+  tags,
+  variant = "default",
+  onTagClick,
+}: TagListProps) {
   const wrapperClass = variant === "post" ? "gap-[16px]" : "gap-[6px]";
 
   const getTagClass = () => {
     switch (variant) {
       case "post":
-        return "py-[6px] px-[10px] bg-subColor2 rounded-[20px] text-body-16-regular text-primary whitespace-nowrap shrink-0";
+        return [
+          "py-[6px] px-[10px] rounded-[20px] text-body-16-regular text-primary whitespace-nowrap shrink-0",
+          "bg-subColor2",
+          onTagClick &&
+            "cursor-pointer transition-colors hover:bg-primary hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+        ]
+          .filter(Boolean)
+          .join(" ");
       case "mypage":
         return "flex py-[6px] px-[10px] justify-center items-center gap-[2px] rounded-[20px] bg-gray1 text-primary text-body-14-regular whitespace-nowrap shrink-0";
       case "default":
@@ -22,11 +34,23 @@ export default function TagList({ tags, variant = "default" }: TagListProps) {
     <div
       className={`flex flex-nowrap items-center overflow-hidden ${wrapperClass}`}
     >
-      {tags.map((tag) => (
-        <div key={tag} className={getTagClass()} title={tag}>
-          #{tag}
-        </div>
-      ))}
+      {tags.map((tag) =>
+        onTagClick ? (
+          <button
+            key={tag}
+            type="button"
+            className={getTagClass()}
+            title={tag}
+            onClick={() => onTagClick(tag)}
+          >
+            #{tag}
+          </button>
+        ) : (
+          <div key={tag} className={getTagClass()} title={tag}>
+            #{tag}
+          </div>
+        ),
+      )}
     </div>
   );
 }

--- a/src/pages/Community/components/PostDetailHeader.tsx
+++ b/src/pages/Community/components/PostDetailHeader.tsx
@@ -1,10 +1,12 @@
 import type { RefObject } from "react";
+import { useNavigate } from "react-router-dom";
 import TagList from "@/entities/trouble/ui/TagList";
 import KebabDropdown from "@/shared/ui/Menu/KebabDropdown";
 import KebabMenuButton from "@/shared/ui/Menu/KebabMenuButton";
 import imageIcon from "@/assets/icons/image.svg";
 import starIcon from "@/assets/icons/star.svg";
 import type { CommunityPostDetailProps } from "@/pages/Community/types";
+import { PATH } from "@/shared/config/paths";
 
 export interface PostDetailHeaderProps {
   post: CommunityPostDetailProps;
@@ -32,6 +34,13 @@ export function PostDetailHeader({
   onReport,
   onAuthorClick,
 }: PostDetailHeaderProps) {
+  const navigate = useNavigate();
+
+  const handleTagClick = (tag: string) => {
+    const searchParams = new URLSearchParams({ query: tag });
+    navigate(`${PATH.SEARCH}?${searchParams.toString()}`);
+  };
+
   return (
     <div className="flex w-full pt-20 sm:pt-[180px] pb-[18px] items-center border-b border-gray1">
       <div className="flex flex-col items-start gap-8 sm:gap-[44px] w-full">
@@ -69,7 +78,7 @@ export function PostDetailHeader({
             <div className="text-head-48 break-words">{post.title}</div>
           </div>
           <div className="flex flex-wrap items-center gap-[12px] sm:gap-[16px]">
-            <TagList tags={post.tags} variant="post" />
+            <TagList tags={post.tags} variant="post" onTagClick={handleTagClick} />
             <div className="text-body-16-regular text-gray3">·</div>
             <div className="text-body-20-regular text-gray3">{post.date}</div>
           </div>

--- a/src/pages/MyPage/CombinedDetailPage.tsx
+++ b/src/pages/MyPage/CombinedDetailPage.tsx
@@ -498,7 +498,14 @@ export default function CombinedDetailPage() {
                   {vm.header.title}
                 </div>
                 <div className="flex flex-wrap items-center gap-3 sm:gap-[16px] min-w-0">
-                  <TagList tags={vm.header.tags} variant="post" />
+                  <TagList
+                    tags={vm.header.tags}
+                    variant="post"
+                    onTagClick={(tag) => {
+                      const searchParams = new URLSearchParams({ query: tag });
+                      navigate(`${PATH.SEARCH}?${searchParams.toString()}`);
+                    }}
+                  />
                   <div className="text-body-16-regular text-gray3">·</div>
                   <div className="text-body-20-regular text-gray3">
                     {vm.header.date}

--- a/src/pages/TempWrite/PostSummaryDetail.tsx
+++ b/src/pages/TempWrite/PostSummaryDetail.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import HeaderWoSearch from "@/layouts/Header/HeaderWoSearch";
 import TagList from "@/entities/trouble/ui/TagList";
+import { PATH } from "@/shared/config/paths";
 import PostGuideMd from "@/entities/trouble/ui/PostGuideMd";
 import { getPostSummary } from "@/api/post.api";
 import type { GetSummaryResponse } from "@/models/post.model";
@@ -23,6 +24,7 @@ function fetchSummaryOnce(id: number) {
 
 export default function PostSummaryDetail() {
   const { summaryId } = useParams<{ summaryId: string }>();
+  const navigate = useNavigate();
 
   const [data, setData] = useState<GetSummaryResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -144,7 +146,14 @@ export default function PostSummaryDetail() {
                   </div>
 
                   <div className="flex flex-wrap items-center gap-[12px] sm:gap-[16px]">
-                    <TagList tags={data.postTags ?? []} variant="post" />
+                    <TagList
+                      tags={data.postTags ?? []}
+                      variant="post"
+                      onTagClick={(tag) => {
+                        const searchParams = new URLSearchParams({ query: tag });
+                        navigate(`${PATH.SEARCH}?${searchParams.toString()}`);
+                      }}
+                    />
                     <div className="text-body-16-regular text-gray3">·</div>
                     <time className="text-body-20-regular text-gray3">
                       {new Date(data.summaryCreatedAt).toLocaleDateString()}


### PR DESCRIPTION
## 🔥 Issues

- closed #208 

## ✅ What to do

- [x] 포스트 상세 상단 태그 클릭 UI 및 라우팅 로직 개발
- [x] 태그 키워드를 이용한 검색 결과 리스트 연동

## 📄 Description

- 포스트 상세 페이지 상단에 노출되는 기술 태그(언어/프레임워크)에 마우스 호버(Hover) 효과 추가.
- 태그 클릭 시 검색 페이지로 이동하도록 클릭 이벤트 및 라우팅 처리.
- 이동 시 선택된 태그의 키워드(또는 ID)를 쿼리 파라미터로 전달.
- 상세 페이지에서 넘어온 태그 키워드를 검색창에 자동 입력 상태로 표시.
- 해당 키워드로 API를 호출하여 필터링된 포스트 리스트를 화면에 렌더링.
- 검색 결과가 없을 경우에 대한 예외 처리 UI(빈 화면) 구현.

## 👀 References

- 검색 결과 서버 500 에러 추후 확인 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **태그 검색 기능 추가**
  - 게시물 상세 페이지, 내 페이지, 임시 저장 페이지의 태그가 이제 클릭 가능합니다. 태그를 클릭하면 해당 태그로 검색된 결과 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->